### PR TITLE
dags: add load tasks

### DIFF
--- a/dags/bounded_core_dag.py
+++ b/dags/bounded_core_dag.py
@@ -1,5 +1,3 @@
-import json
-
 from stellar_etl_airflow.build_export_task import build_export_task
 from stellar_etl_airflow.build_date_task import build_date_task
 from stellar_etl_airflow.default import get_default_dag_args

--- a/dags/bucket_list_dag.py
+++ b/dags/bucket_list_dag.py
@@ -3,6 +3,7 @@ from stellar_etl_airflow.build_date_task import build_date_task
 from stellar_etl_airflow.default import get_default_dag_args
 
 from airflow import DAG
+from airflow.models import Variable
 
 dag = DAG(
     'bucket_list_export',
@@ -11,13 +12,15 @@ dag = DAG(
     schedule_interval="*/5 * * * *",
 )
 
+file_names = Variable.get('output_file_names', deserialize_json=True)
+
 date_task = build_date_task(dag)
 
-acc_task = build_export_task(dag, 'bucket', 'export_accounts', 'accounts.txt')
+acc_task = build_export_task(dag, 'bucket', 'export_accounts', file_names['accounts'])
 
-off_task = build_export_task(dag, 'bucket', 'export_offers', 'offers.txt')
+off_task = build_export_task(dag, 'bucket', 'export_offers', file_names['offers'])
 
-trust_task = build_export_task(dag, 'bucket', 'export_trustlines', 'trustlines.txt')
+trust_task = build_export_task(dag, 'bucket', 'export_trustlines', file_names['trustlines'])
 
 date_task >> acc_task
 date_task >> off_task

--- a/dags/bucket_list_dag.py
+++ b/dags/bucket_list_dag.py
@@ -1,5 +1,3 @@
-import json
-
 from stellar_etl_airflow.build_export_task import build_export_task
 from stellar_etl_airflow.build_date_task import build_date_task
 from stellar_etl_airflow.default import get_default_dag_args

--- a/dags/history_archive_dag.py
+++ b/dags/history_archive_dag.py
@@ -1,8 +1,10 @@
 from stellar_etl_airflow.build_export_task import build_export_task
 from stellar_etl_airflow.build_date_task import build_date_task
 from stellar_etl_airflow.default import get_default_dag_args
+from stellar_etl_airflow.build_load_task import build_load_task
 
 from airflow import DAG
+from airflow.models import Variable
 
 dag = DAG(
     'history_archive_export',
@@ -11,14 +13,26 @@ dag = DAG(
     schedule_interval="*/5 * * * *",
 )
 
+file_names = Variable.get('output_file_names', deserialize_json=True)
+table_ids = Variable.get('table_ids', deserialize_json=True)
+
 date_task = build_date_task(dag)
 
-ledger_task = build_export_task(dag, 'archive', 'export_ledgers', 'ledgers.txt')
+ledger_export_task = build_export_task(dag, 'archive', 'export_ledgers', file_names['ledgers'])
 
-tx_task = build_export_task(dag, 'archive', 'export_transactions', 'transactions.txt')
+tx_export_task = build_export_task(dag, 'archive', 'export_transactions', file_names['transactions'])
 
-op_task = build_export_task(dag, 'archive', 'export_operations', 'operations.txt')
+op_export_task = build_export_task(dag, 'archive', 'export_operations', file_names['operations'])
 
-date_task >> ledger_task
-date_task >> tx_task
-date_task >> op_task
+date_task >> ledger_export_task
+date_task >> tx_export_task
+date_task >> op_export_task
+
+load_ledger_task = build_load_task(dag, file_names['ledgers'], table_ids['ledgers'])
+ledger_export_task >> load_ledger_task
+
+load_tx_task = build_load_task(dag, file_names['transactions'], table_ids['transactions'])
+tx_export_task >> load_tx_task
+
+load_op_task = build_load_task(dag, file_names['operations'], table_ids['operations'])
+op_export_task >> load_op_task

--- a/dags/history_archive_dag.py
+++ b/dags/history_archive_dag.py
@@ -28,11 +28,11 @@ date_task >> ledger_export_task
 date_task >> tx_export_task
 date_task >> op_export_task
 
-load_ledger_task = build_load_task(dag, file_names['ledgers'], table_ids['ledgers'])
+load_ledger_task = build_load_task(dag, 'ledgers', file_names['ledgers'])
 ledger_export_task >> load_ledger_task
 
-load_tx_task = build_load_task(dag, file_names['transactions'], table_ids['transactions'])
+load_tx_task = build_load_task(dag, 'transactions', file_names['transactions'])
 tx_export_task >> load_tx_task
 
-load_op_task = build_load_task(dag, file_names['operations'], table_ids['operations'])
+load_op_task = build_load_task(dag, 'operations', file_names['operations'])
 op_export_task >> load_op_task

--- a/dags/history_archive_dag.py
+++ b/dags/history_archive_dag.py
@@ -1,5 +1,3 @@
-import json
-
 from stellar_etl_airflow.build_export_task import build_export_task
 from stellar_etl_airflow.build_date_task import build_date_task
 from stellar_etl_airflow.default import get_default_dag_args

--- a/dags/stellar_etl_airflow/build_date_task.py
+++ b/dags/stellar_etl_airflow/build_date_task.py
@@ -1,13 +1,4 @@
-import json
-
-from datetime import timedelta
-from subprocess import Popen
-
-from airflow import DAG, AirflowException
 from airflow.operators.bash_operator import BashOperator
-from airflow.operators.python_operator import PythonOperator
-from airflow.utils.dates import days_ago
-from airflow.models import Variable
 
 
 def build_date_task(dag):

--- a/dags/stellar_etl_airflow/build_export_task.py
+++ b/dags/stellar_etl_airflow/build_export_task.py
@@ -1,12 +1,9 @@
 import json
 
-from datetime import timedelta
 from subprocess import Popen, PIPE
 
-from airflow import DAG, AirflowException
-from airflow.operators.bash_operator import BashOperator
+from airflow import AirflowException
 from airflow.operators.python_operator import PythonOperator
-from airflow.utils.dates import days_ago
 from airflow.models import Variable
 
 def parse_ledger_range(context):
@@ -17,7 +14,7 @@ def parse_ledger_range(context):
     return str(start), str(end)
 
 def execute_cmd(args):
-    process = Popen(args)#, stdout=PIPE, stderr=PIPE)
+    process = Popen(args, stdout=PIPE, stderr=PIPE)
     if process.returncode:
         raise AirflowException("Bash command failed")
     stdout, stderr = process.communicate()

--- a/dags/stellar_etl_airflow/build_load_task.py
+++ b/dags/stellar_etl_airflow/build_load_task.py
@@ -1,13 +1,19 @@
-from airflow.operators.python_operator import PythonOperator
 from google.cloud import bigquery
-from airflow.models import Variable
-from airflow import AirflowException
+from google.oauth2 import service_account
 
-def append_to_bigquery(file_path, table_id):
-    client = bigquery.Client()
-    table_id = Variable.get('project_name') + Variable.get('database_name') + table_id
+from airflow import AirflowException
+from airflow.models import Variable
+from airflow.operators.python_operator import PythonOperator
+
+def append_to_bigquery(filename, table_id, **kwargs):
+    key_path = Variable.get('api_key_path')
+    credentials = service_account.Credentials.from_service_account_file(key_path, scopes=['https://www.googleapis.com/auth/bigquery'])
+
+    client = bigquery.Client(credentials=credentials, project=Variable.get('project_name'))
+    table_id = '.'.join([Variable.get('project_name'), Variable.get('database_name'), table_id])
     job_config = bigquery.LoadJobConfig(source_format=bigquery.SourceFormat.NEWLINE_DELIMITED_JSON, autodetect=True)   
 
+    file_path = Variable.get('output_path') + filename
     with open(file_path, "rb") as source_file:
         job = client.load_table_from_file(source_file, table_id, job_config=job_config)
     job.result()
@@ -16,11 +22,10 @@ def append_to_bigquery(file_path, table_id):
     if errors: 
         raise AirflowException("Loading command failed", errors) 
 
-def build_load_task(dag, exported_file, table_id):
+def build_load_task(dag, exported_filename, table_id):
     return PythonOperator(
             task_id='load_' + table_id + '_task',
             python_callable=append_to_bigquery,
-            op_kwargs={'file_path': exported_file, 'table_id': table_id},
-            provide_context=True,
+            op_kwargs={'filename': exported_filename, 'table_id': table_id},
             dag=dag,
         )

--- a/dags/stellar_etl_airflow/build_load_task.py
+++ b/dags/stellar_etl_airflow/build_load_task.py
@@ -1,0 +1,26 @@
+from airflow.operators.python_operator import PythonOperator
+from google.cloud import bigquery
+from airflow.models import Variable
+from airflow import AirflowException
+
+def append_to_bigquery(file_path, table_id):
+    client = bigquery.Client()
+    table_id = Variable.get('project_name') + Variable.get('database_name') + table_id
+    job_config = bigquery.LoadJobConfig(source_format=bigquery.SourceFormat.NEWLINE_DELIMITED_JSON, autodetect=True)   
+
+    with open(file_path, "rb") as source_file:
+        job = client.load_table_from_file(source_file, table_id, job_config=job_config)
+    job.result()
+
+    errors = job.errors
+    if errors: 
+        raise AirflowException("Loading command failed", errors) 
+
+def build_load_task(dag, exported_file, table_id):
+    return PythonOperator(
+            task_id='load_' + table_id + '_task',
+            python_callable=append_to_bigquery,
+            op_kwargs={'file_path': exported_file, 'table_id': table_id},
+            provide_context=True,
+            dag=dag,
+        )

--- a/dags/stellar_etl_airflow/build_load_task.py
+++ b/dags/stellar_etl_airflow/build_load_task.py
@@ -1,31 +1,85 @@
-from google.cloud import bigquery
+import os
+import logging
 from google.oauth2 import service_account
 
 from airflow import AirflowException
 from airflow.models import Variable
 from airflow.operators.python_operator import PythonOperator
 
-def append_to_bigquery(filename, table_id, **kwargs):
+from apiclient.http import MediaFileUpload
+from googleapiclient import errors
+from googleapiclient.discovery import build
+from stellar_etl_airflow.build_export_task import parse_ledger_range
+
+MEGABYTE = 1024 * 1024
+
+def build_storage_credentials():
     key_path = Variable.get('api_key_path')
-    credentials = service_account.Credentials.from_service_account_file(key_path, scopes=['https://www.googleapis.com/auth/bigquery'])
+    credentials = service_account.Credentials.from_service_account_file(key_path)
+    return build('storage', 'v1', credentials=credentials, cache_discovery=False)
 
-    client = bigquery.Client(credentials=credentials, project=Variable.get('project_name'))
-    table_id = '.'.join([Variable.get('project_name'), Variable.get('database_name'), table_id])
-    job_config = bigquery.LoadJobConfig(source_format=bigquery.SourceFormat.NEWLINE_DELIMITED_JSON, autodetect=True)   
+def attempt_upload(local_filepath, gcs_filepath, bucket_name, mime_type='text/plain'):
+    '''
+    Tries to upload the file into Google Cloud Storage. Files above 10 megabytes are uploaded incrementally
+    as described here: https://github.com/googleapis/google-api-python-client/blob/master/docs/media.md#resumable-media-chunked-upload.
 
-    file_path = Variable.get('output_path') + filename
-    with open(file_path, "rb") as source_file:
-        job = client.load_table_from_file(source_file, table_id, job_config=job_config)
-    job.result()
+    
+    Parameter:
+        local_filepath - path to the local file to be uploaded 
+        gcs_filepath - path for the file in gcs
+        bucket_name - name of the bucket to upload to
+        mime_type - type of media to upload
+    Returns:
+        True if the upload is successful. Raises an Airflow error otherwise
+    '''
+    storage_service = build_storage_credentials()
+    if os.path.getsize(local_filepath) > 10 * MEGABYTE:
+        media = MediaFileUpload(local_filepath, mime_type, resumable=True)
 
-    errors = job.errors
-    if errors: 
-        raise AirflowException("Loading command failed", errors) 
+        try:
+            request = storage_service.objects().insert(bucket=bucket_name, name=gcs_filepath, media_body=media)
+            response = None
+            while response is None:
+                status, response = request.next_chunk()
+                if status:
+                    logging.info("Uploaded %d%%." % int(status.progress() * 100))
+            return True
+        except errors.HttpError as e:
+            raise AirflowException("Unable to upload large file to gcs", e)
+    else:
+        media = MediaFileUpload(local_filepath, mime_type)
 
-def build_load_task(dag, exported_filename, table_id):
+        try:
+            storage_service.objects().insert(bucket=bucket_name, name=gcs_filepath, media_body=media).execute()
+            return True
+        except errors.HttpError as e:
+            raise AirflowException("Unable to upload file to gcs", e)
+
+def upload_to_gcs(filename, data_type, **kwargs):
+    '''
+    Uploads a local file to Google Cloud Storage and deletes the local file if the upload is sucessful.
+
+    
+    Parameter:
+        filename - name of the file to be uploaded 
+        data_type - type of the data being uploaded (transaction, ledger, etc)
+    Returns:
+        N/A
+    '''
+    start_ledger, end_ledger = parse_ledger_range(kwargs)
+    gcs_filepath = 'exported/' + data_type + '/' + '-'.join([start_ledger, end_ledger, filename])
+    local_filepath = Variable.get('output_path') + filename
+    bucket_name = Variable.get('gcs_bucket_name')
+
+    success = attempt_upload(local_filepath, gcs_filepath, bucket_name)
+    if success:
+        os.remove(local_filepath)
+
+def build_load_task(dag, data_type, exported_filename):
     return PythonOperator(
-            task_id='load_' + table_id + '_task',
-            python_callable=append_to_bigquery,
-            op_kwargs={'filename': exported_filename, 'table_id': table_id},
+            task_id='load_' + data_type + '_to_gcs',
+            python_callable=upload_to_gcs,
+            op_kwargs={'filename': exported_filename, 'data_type': data_type},
             dag=dag,
+            provide_context=True,
         )

--- a/dags/stellar_etl_airflow/build_load_task.py
+++ b/dags/stellar_etl_airflow/build_load_task.py
@@ -74,6 +74,7 @@ def upload_to_gcs(filename, data_type, **kwargs):
     success = attempt_upload(local_filepath, gcs_filepath, bucket_name)
     if success:
         os.remove(local_filepath)
+    return gcs_filepath
 
 def build_load_task(dag, data_type, exported_filename):
     return PythonOperator(

--- a/dags/unbounded_core_dag.py
+++ b/dags/unbounded_core_dag.py
@@ -1,5 +1,3 @@
-import json
-
 from stellar_etl_airflow.build_export_task import build_export_task
 from stellar_etl_airflow.build_date_task import build_date_task
 from stellar_etl_airflow.default import get_default_dag_args


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).
</details>

### What
This PR adds the tasks to load a local file into Google Cloud Storage.

### Why
We want to load files into Google Cloud Storage so that they can be moved into BigQuery more easily. This intermediate task handles the loading into GCS.

### Known limitations
Right now, only the history archives dag has the load tasks. This is because we will need to separate ledger entries changes  that are outputted by the ETL. Until then, the data should not be loaded into GCS.