### PR TITLE
dags: make exported filenames unique

### DIFF
--- a/dags/history_archive_dag.py
+++ b/dags/history_archive_dag.py
@@ -33,11 +33,11 @@ date_task >> ledger_export_task
 date_task >> tx_export_task
 date_task >> op_export_task
 
-load_ledger_task = build_load_task(dag, 'ledgers', file_names['ledgers'])
+load_ledger_task = build_load_task(dag, 'ledgers')
 ledger_export_task >> load_ledger_task
 
-load_tx_task = build_load_task(dag, 'transactions', file_names['transactions'])
+load_tx_task = build_load_task(dag, 'transactions')
 tx_export_task >> load_tx_task
 
-load_op_task = build_load_task(dag, 'operations', file_names['operations'])
+load_op_task = build_load_task(dag, 'operations')
 op_export_task >> load_op_task

--- a/dags/stellar_etl_airflow/build_export_task.py
+++ b/dags/stellar_etl_airflow/build_export_task.py
@@ -5,6 +5,7 @@ to be added to the PATH env variable.
 '''
 
 import json
+import logging
 
 from subprocess import Popen, PIPE
 
@@ -44,12 +45,12 @@ def execute_cmd(args):
     stdout, stderr = process.communicate()
     if process.returncode:
         raise AirflowException("Bash command failed", process.returncode, stderr)
-    return stdout, stderr
+    #return stdout, stderr
 
 def get_path_variables():
     return Variable.get('output_path'), Variable.get('core_exec_path'), Variable.get('core_cfg_path')
 
-def run_etl_cmd(command, filename, cmd_type, **kwargs):
+def run_etl_cmd(command, base_filename, cmd_type, **kwargs):
     '''
     Runs the provided stellar-etl command with arguments that are appropriate for the command type.
     The supported command types are: 
@@ -62,28 +63,32 @@ def run_etl_cmd(command, filename, cmd_type, **kwargs):
     
     Parameters:
         command - stellar-etl command (ex. export_ledgers, export_accounts)
-        filename - filename for the output file or folder
+        base_filename - base filename for the output file or folder; the ledger range is appended to this filename
         cmd_type - the type of the command, which is determined by the information source
     Returns:
-        output of the command, error
+        name of the file that contains the exported data
     '''
 
     start_ledger, end_ledger = parse_ledger_range(kwargs)
     output_path, core_exec, core_cfg = get_path_variables()
-    cmd_args = ['stellar-etl', command, '-o', output_path + filename]
+
+    batch_filename = '-'.join([start_ledger, end_ledger, base_filename])
+    cmd_args = ['stellar-etl', command, '-o', output_path + batch_filename]
 
     if cmd_type == 'archive':
         cmd_args.extend(['-s', start_ledger, '-e', end_ledger])
     elif cmd_type == 'bucket':
         cmd_args.extend(['-e', end_ledger])
     elif cmd_type == 'bounded-core':
-        cmd_args.extend(['-s', start_ledger, '-e', end_ledger, '-x', core_exec, '-c', core_cfg,])
+        cmd_args.extend(['-s', start_ledger, '-e', end_ledger, '-x', core_exec, '-c', core_cfg])
     elif cmd_type == 'unbounded-core':
-        cmd_args.extend(['-s', start_ledger, '-x', core_exec, '-c', core_cfg, ])
+        cmd_args.extend(['-s', start_ledger, '-x', core_exec, '-c', core_cfg])
     else:
         raise AirflowException("Command type is not supported: ", cmd_type)
-
-    return execute_cmd(cmd_args)
+    execute_cmd(cmd_args)
+    #output, _ = execute_cmd(cmd_args)
+    #logging.info('Comand output: ' + str(output))
+    return batch_filename
 
 def build_export_task(dag, cmd_type, command, filename):
     '''
@@ -101,7 +106,7 @@ def build_export_task(dag, cmd_type, command, filename):
     return PythonOperator(
             task_id=command + '_task',
             python_callable=run_etl_cmd,
-            op_kwargs={'command': command, 'filename': filename, 'cmd_type': cmd_type},
+            op_kwargs={'command': command, 'base_filename': filename, 'cmd_type': cmd_type},
             provide_context=True,
             dag=dag,
         )

--- a/dags/stellar_etl_airflow/build_export_task.py
+++ b/dags/stellar_etl_airflow/build_export_task.py
@@ -62,7 +62,7 @@ def run_etl_cmd(command, base_filename, cmd_type, **kwargs):
     
     Parameters:
         command - stellar-etl command (ex. export_ledgers, export_accounts)
-        base_filename - base filename for the output file or folder; the ledger range is appended to this filename
+        base_filename - base filename for the output file or folder; the ledger range is pre-pended to this filename
         cmd_type - the type of the command, which is determined by the information source
     Returns:
         name of the file that contains the exported data

--- a/dags/stellar_etl_airflow/build_export_task.py
+++ b/dags/stellar_etl_airflow/build_export_task.py
@@ -27,7 +27,7 @@ def parse_ledger_range(context):
     range_string = context['task_instance'].xcom_pull(task_ids='get_ledger_range_from_times')
     range_parsed = json.loads(range_string)
     start = range_parsed['start']
-    end = range_parsed['end']
+    end = max(range_parsed['end'] - 1, start)
     return str(start), str(end)
 
 def execute_cmd(args):    

--- a/dags/stellar_etl_airflow/build_export_task.py
+++ b/dags/stellar_etl_airflow/build_export_task.py
@@ -45,7 +45,6 @@ def execute_cmd(args):
     stdout, stderr = process.communicate()
     if process.returncode:
         raise AirflowException("Bash command failed", process.returncode, stderr)
-    #return stdout, stderr
 
 def get_path_variables():
     return Variable.get('output_path'), Variable.get('core_exec_path'), Variable.get('core_cfg_path')
@@ -86,8 +85,6 @@ def run_etl_cmd(command, base_filename, cmd_type, **kwargs):
     else:
         raise AirflowException("Command type is not supported: ", cmd_type)
     execute_cmd(cmd_args)
-    #output, _ = execute_cmd(cmd_args)
-    #logging.info('Comand output: ' + str(output))
     return batch_filename
 
 def build_export_task(dag, cmd_type, command, filename):

--- a/dags/stellar_etl_airflow/build_load_task.py
+++ b/dags/stellar_etl_airflow/build_load_task.py
@@ -81,7 +81,7 @@ def upload_to_gcs(data_type, **kwargs):
     '''
 
     filename = kwargs['task_instance'].xcom_pull(task_ids='export_' + data_type + '_task')
-    gcs_filepath = 'exported/' + data_type + '/' + filename
+    gcs_filepath = f'exported/{data_type}/{filename}'
 
     local_filepath = Variable.get('output_path') + filename
     bucket_name = Variable.get('gcs_bucket_name')

--- a/dags/stellar_etl_airflow/default.py
+++ b/dags/stellar_etl_airflow/default.py
@@ -8,5 +8,5 @@ def get_default_dag_args():
     'depends_on_past': False,
     'start_date': "2015-09-30T16:41:54+00:00",
     'retries': 5,
-    'retry_delay': timedelta(seconds=30),
+    'retry_delay': timedelta(minutes=5),
 }

--- a/dags/stellar_etl_airflow/default.py
+++ b/dags/stellar_etl_airflow/default.py
@@ -6,7 +6,7 @@ def get_default_dag_args():
     return {
     'owner': owner_name,
     'depends_on_past': False,
-    'start_date': "2015-09-30T16:46:54+00:00",
+    'start_date': "2015-09-30T16:41:54+00:00",
     'retries': 5,
     'retry_delay': timedelta(seconds=30),
 }

--- a/dags/stellar_etl_airflow/default.py
+++ b/dags/stellar_etl_airflow/default.py
@@ -8,5 +8,5 @@ def get_default_dag_args():
     'depends_on_past': False,
     'start_date': "2015-09-30T16:46:54+00:00",
     'retries': 5,
-    'retry_delay': timedelta(minutes=5),
+    'retry_delay': timedelta(seconds=30),
 }


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).
</details>

### What
This PR changes the filenames of exported tasks. Now each one includes the start and end ledger. Additionally, there is no longer overlap between batches. Closes #13. Closes #14.

### Why
When tasks exported to files with the same name, information was overwritten or deleted prematurely. By ensuring each task creates and cleans up its own unique file, we don't have to worry about multiple DAG runs interfering with each other.

### Known limitations