### PR TITLE
dags: added logging to  tasks

### DIFF
--- a/dags/bucket_list_dag.py
+++ b/dags/bucket_list_dag.py
@@ -5,7 +5,6 @@ to stop exporting. This end ledger  is determined by when the Airflow DAG is run
 when initializing the tables in order to catch up to the current state in the network, but should not be scheduled to run constantly.
 '''
 import json
-import logging
 from stellar_etl_airflow.build_export_task import build_export_task
 from stellar_etl_airflow.build_time_task import build_time_task
 from stellar_etl_airflow.build_load_task import build_load_task

--- a/dags/bucket_list_dag.py
+++ b/dags/bucket_list_dag.py
@@ -24,7 +24,6 @@ dag = DAG(
 )
 
 file_names = Variable.get('output_file_names', deserialize_json=True)
-logger = logging.getLogger("airflow.task")
 
 time_task = build_time_task(dag, use_next_exec_time=False)
 
@@ -37,18 +36,18 @@ The load tasks receive the location of the exported file through Airflow's XCOM 
 Then, the task loads the file into Google Cloud Storage. Finally, the file is deleted
 from local storage.
 '''
-load_acc_task = build_load_task(dag, logging, 'ledgers', 'export_ledgers_task')
-load_off_task = build_load_task(dag, logging, 'transactions', 'export_transactions_task')
-load_trust_task = build_load_task(dag, logging, 'operations', 'export_operations_task')
+load_acc_task = build_load_task(dag, 'ledgers', 'export_ledgers_task')
+load_off_task = build_load_task(dag, 'transactions', 'export_transactions_task')
+load_trust_task = build_load_task(dag, 'operations', 'export_operations_task')
 
 '''
 The apply tasks receive the location of the file in Google Cloud storage through Airflow's XCOM system.
 Then, the task merges the entries in the file with the entries in the corresponding table in BigQuery. 
 Entries are updated, deleted, or inserted as needed.
 '''
-apply_account_changes_task = build_apply_gcs_changes_to_bq_task(dag, logging, 'accounts')
-apply_offer_changes_task = build_apply_gcs_changes_to_bq_task(dag, logging, 'offers')
-apply_trustline_changes_task = build_apply_gcs_changes_to_bq_task(dag, logging, 'trustlines')
+apply_account_changes_task = build_apply_gcs_changes_to_bq_task(dag, 'accounts')
+apply_offer_changes_task = build_apply_gcs_changes_to_bq_task(dag, 'offers')
+apply_trustline_changes_task = build_apply_gcs_changes_to_bq_task(dag, 'trustlines')
 
 time_task >> export_acc_task >> load_acc_task >> apply_account_changes_task
 time_task >> export_off_task >> load_off_task >> apply_offer_changes_task

--- a/dags/history_archive_dag.py
+++ b/dags/history_archive_dag.py
@@ -21,7 +21,6 @@ dag = DAG(
     user_defined_filters={'fromjson': lambda s: json.loads(s)},
 )
 
-logger = logging.getLogger("airflow.task")
 file_names = Variable.get('output_file_names', deserialize_json=True)
 
 '''
@@ -45,10 +44,10 @@ The load tasks receive the location of the exported file through Airflow's XCOM 
 Then, the task loads the file into Google Cloud Storage. Finally, the file is deleted
 from local storage.
 '''
-load_ledger_task = build_load_task(dag, logger, 'ledgers', 'export_ledgers_task')
-load_tx_task = build_load_task(dag, logger, 'transactions', 'export_transactions_task')
-load_op_task = build_load_task(dag, logger, 'operations', 'export_operations_task')
-load_trade_task = build_load_task(dag, logger, 'trades', 'export_trades_task')
+load_ledger_task = build_load_task(dag, 'ledgers', 'export_ledgers_task')
+load_tx_task = build_load_task(dag, 'transactions', 'export_transactions_task')
+load_op_task = build_load_task(dag, 'operations', 'export_operations_task')
+load_trade_task = build_load_task(dag, 'trades', 'export_trades_task')
 
 '''
 The send tasks receive the location of the file in Google Cloud storage through Airflow's XCOM system.

--- a/dags/history_archive_dag.py
+++ b/dags/history_archive_dag.py
@@ -3,7 +3,6 @@ The history_archive_export DAG exports ledgers, transactions, operations, and tr
 It is scheduled to export information to BigQuery every 5 minutes. 
 '''
 import json
-import logging
 from stellar_etl_airflow.build_export_task import build_export_task
 from stellar_etl_airflow.build_time_task import build_time_task
 from stellar_etl_airflow.default import get_default_dag_args

--- a/dags/history_archive_dag.py
+++ b/dags/history_archive_dag.py
@@ -3,7 +3,7 @@ The history_archive_export DAG exports ledgers, transactions, operations, and tr
 It is scheduled to export information to BigQuery every 5 minutes. 
 '''
 import json
-
+import logging
 from stellar_etl_airflow.build_export_task import build_export_task
 from stellar_etl_airflow.build_time_task import build_time_task
 from stellar_etl_airflow.default import get_default_dag_args
@@ -21,6 +21,7 @@ dag = DAG(
     user_defined_filters={'fromjson': lambda s: json.loads(s)},
 )
 
+logger = logging.getLogger("airflow.task")
 file_names = Variable.get('output_file_names', deserialize_json=True)
 
 '''
@@ -44,10 +45,10 @@ The load tasks receive the location of the exported file through Airflow's XCOM 
 Then, the task loads the file into Google Cloud Storage. Finally, the file is deleted
 from local storage.
 '''
-load_ledger_task = build_load_task(dag, 'ledgers', 'export_ledgers_task')
-load_tx_task = build_load_task(dag, 'transactions', 'export_transactions_task')
-load_op_task = build_load_task(dag, 'operations', 'export_operations_task')
-load_trade_task = build_load_task(dag, 'trades', 'export_trades_task')
+load_ledger_task = build_load_task(dag, logger, 'ledgers', 'export_ledgers_task')
+load_tx_task = build_load_task(dag, logger, 'transactions', 'export_transactions_task')
+load_op_task = build_load_task(dag, logger, 'operations', 'export_operations_task')
+load_trade_task = build_load_task(dag, logger, 'trades', 'export_trades_task')
 
 '''
 The send tasks receive the location of the file in Google Cloud storage through Airflow's XCOM system.

--- a/dags/process_unbounded_core_dag.py
+++ b/dags/process_unbounded_core_dag.py
@@ -20,7 +20,6 @@ dag = DAG(
     schedule_interval='@once',
 )
 
-logger = logging.getLogger("airflow.task")
 
 account_sensor = build_file_sensor_task(dag, 'accounts')
 offer_sensor = build_file_sensor_task(dag, 'offers')
@@ -31,18 +30,18 @@ The load tasks receive the location of the exported file through Airflow's XCOM 
 Then, the task loads the file into Google Cloud Storage. Finally, the file is deleted
 from local storage.
 '''
-load_accounts_task = build_load_task(dag, logger, 'accounts', 'accounts_file_sensor')
-load_offers_task = build_load_task(dag, logger, 'offers', 'offers_file_sensor')
-load_trustlines_task = build_load_task(dag, logger, 'trustlines', 'trustlines_file_sensor')
+load_accounts_task = build_load_task(dag, 'accounts', 'accounts_file_sensor')
+load_offers_task = build_load_task(dag, 'offers', 'offers_file_sensor')
+load_trustlines_task = build_load_task(dag, 'trustlines', 'trustlines_file_sensor')
 
 '''
 The apply tasks receive the location of the file in Google Cloud storage through Airflow's XCOM system.
 Then, the task merges the entries in the file with the entries in the corresponding table in BigQuery. 
 Entries are updated, deleted, or inserted as needed.
 '''
-apply_account_changes_task = build_apply_gcs_changes_to_bq_task(dag, logger, 'accounts')
-apply_offer_changes_task = build_apply_gcs_changes_to_bq_task(dag, logger, 'offers')
-apply_trustline_changes_task = build_apply_gcs_changes_to_bq_task(dag, logger, 'trustlines')
+apply_account_changes_task = build_apply_gcs_changes_to_bq_task(dag, 'accounts')
+apply_offer_changes_task = build_apply_gcs_changes_to_bq_task(dag, 'offers')
+apply_trustline_changes_task = build_apply_gcs_changes_to_bq_task(dag, 'trustlines')
 
 
 '''

--- a/dags/process_unbounded_core_dag.py
+++ b/dags/process_unbounded_core_dag.py
@@ -4,7 +4,6 @@ data in batches to a folder as the network progresses. The process_unbounded_cor
 batches as they are written. Once a batch is read, it is loaded into Google Cloud Storage and loaded into BigQuery.
 This DAG is scheduled to run once, and it triggers a new run with the trigger_next every time a batch is processed.
 '''
-import logging
 from stellar_etl_airflow.build_file_sensor_task import build_file_sensor_task
 from stellar_etl_airflow.build_load_task import build_load_task
 from stellar_etl_airflow.default import get_default_dag_args
@@ -19,7 +18,6 @@ dag = DAG(
     description='This DAG reads data from the unbounded stellar-core instance. The exported accounts, offers, and trustlines are uploaded BigQuery.',
     schedule_interval='@once',
 )
-
 
 account_sensor = build_file_sensor_task(dag, 'accounts')
 offer_sensor = build_file_sensor_task(dag, 'offers')

--- a/dags/process_unbounded_core_dag.py
+++ b/dags/process_unbounded_core_dag.py
@@ -4,7 +4,7 @@ data in batches to a folder as the network progresses. The process_unbounded_cor
 batches as they are written. Once a batch is read, it is loaded into Google Cloud Storage and loaded into BigQuery.
 This DAG is scheduled to run once, and it triggers a new run with the trigger_next every time a batch is processed.
 '''
-
+import logging
 from stellar_etl_airflow.build_file_sensor_task import build_file_sensor_task
 from stellar_etl_airflow.build_load_task import build_load_task
 from stellar_etl_airflow.default import get_default_dag_args
@@ -20,6 +20,8 @@ dag = DAG(
     schedule_interval='@once',
 )
 
+logger = logging.getLogger("airflow.task")
+
 account_sensor = build_file_sensor_task(dag, 'accounts')
 offer_sensor = build_file_sensor_task(dag, 'offers')
 trustline_sensor = build_file_sensor_task(dag, 'trustlines') 
@@ -29,18 +31,18 @@ The load tasks receive the location of the exported file through Airflow's XCOM 
 Then, the task loads the file into Google Cloud Storage. Finally, the file is deleted
 from local storage.
 '''
-load_accounts_task = build_load_task(dag, 'accounts', 'accounts_file_sensor')
-load_offers_task = build_load_task(dag, 'offers', 'offers_file_sensor')
-load_trustlines_task = build_load_task(dag, 'trustlines', 'trustlines_file_sensor')
+load_accounts_task = build_load_task(dag, logger, 'accounts', 'accounts_file_sensor')
+load_offers_task = build_load_task(dag, logger, 'offers', 'offers_file_sensor')
+load_trustlines_task = build_load_task(dag, logger, 'trustlines', 'trustlines_file_sensor')
 
 '''
 The apply tasks receive the location of the file in Google Cloud storage through Airflow's XCOM system.
 Then, the task merges the entries in the file with the entries in the corresponding table in BigQuery. 
 Entries are updated, deleted, or inserted as needed.
 '''
-apply_account_changes_task = build_apply_gcs_changes_to_bq_task(dag, 'accounts')
-apply_offer_changes_task = build_apply_gcs_changes_to_bq_task(dag, 'offers')
-apply_trustline_changes_task = build_apply_gcs_changes_to_bq_task(dag, 'trustlines')
+apply_account_changes_task = build_apply_gcs_changes_to_bq_task(dag, logger, 'accounts')
+apply_offer_changes_task = build_apply_gcs_changes_to_bq_task(dag, logger, 'offers')
+apply_trustline_changes_task = build_apply_gcs_changes_to_bq_task(dag, logger, 'trustlines')
 
 
 '''

--- a/dags/stellar_etl_airflow/build_apply_gcs_changes_to_bq_task.py
+++ b/dags/stellar_etl_airflow/build_apply_gcs_changes_to_bq_task.py
@@ -128,7 +128,7 @@ def apply_gcs_changes(data_type, **kwargs):
     Data types should be: 'accounts', 'offers', or 'trustlines'.
 
     Parameters:
-        data_type - type of the data being uploaded; should be string  
+        data_type - type of the data being uploaded; should be string
     Returns:
         N/A
     '''

--- a/dags/stellar_etl_airflow/build_export_task.py
+++ b/dags/stellar_etl_airflow/build_export_task.py
@@ -3,8 +3,6 @@ This file contains functions for creating Airflow tasks to run stellar-etl expor
 '''
 
 import json
-import logging
-
 from airflow import AirflowException
 from airflow.models import Variable
 from airflow.providers.docker.operators.docker import DockerOperator
@@ -42,7 +40,6 @@ def generate_etl_cmd(command, base_filename, cmd_type):
     batch_filename = '-'.join([start_ledger, end_ledger, base_filename])
     batched_path = image_output_path + batch_filename
     base_path = image_output_path + base_filename
-    full_cmd = f'stellar-etl {command} '
 
     switch = {
         'archive': (f'stellar-etl {command} -s {start_ledger} -e {end_ledger} -o {batched_path}', batch_filename),
@@ -73,7 +70,7 @@ def build_export_task(dag, cmd_type, command, filename):
 
     # echo the output file so it can be captured by xcom; have to run bash to combine commands
     full_cmd = f'bash -c "{etl_cmd} && echo {output_file}"'
-
+    
     return DockerOperator(
             task_id=command + '_task',
             image=Variable.get('image_name'),

--- a/dags/stellar_etl_airflow/build_load_task.py
+++ b/dags/stellar_etl_airflow/build_load_task.py
@@ -29,7 +29,7 @@ def build_storage_service():
     credentials = service_account.Credentials.from_service_account_file(key_path)
     return build('storage', 'v1', credentials=credentials, cache_discovery=False)
 
-def attempt_upload(local_filepath, gcs_filepath, bucket_name, mime_type='text/plain'):
+def attempt_upload(local_filepath, gcs_filepath, bucket_name, logger, mime_type='text/plain'):
     '''
     Tries to upload the file into Google Cloud Storage. Files above 10 megabytes are uploaded incrementally
     as described here: https://github.com/googleapis/google-api-python-client/blob/master/docs/media.md#resumable-media-chunked-upload
@@ -39,6 +39,7 @@ def attempt_upload(local_filepath, gcs_filepath, bucket_name, mime_type='text/pl
         local_filepath - path to the local file to be uploaded 
         gcs_filepath - path for the file in gcs
         bucket_name - name of the bucket to upload to
+        logger - Airflow logger
         mime_type - type of media to upload; other values are defined https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types
     Returns:
         True if the upload is successful. Raises an Airflow error otherwise
@@ -47,33 +48,34 @@ def attempt_upload(local_filepath, gcs_filepath, bucket_name, mime_type='text/pl
     storage_service = build_storage_service()
     if os.path.getsize(local_filepath) > 10 * 2 ** 20:
         media = MediaFileUpload(local_filepath, mime_type, resumable=True)
-
+        logger.info('File is large, uploading to GCS in chunks')
         try:
             request = storage_service.objects().insert(bucket=bucket_name, name=gcs_filepath, media_body=media)
             response = None
             while response is None:
                 status, response = request.next_chunk()
                 if status:
-                    logging.info("Uploaded %d%%." % int(status.progress() * 100))
+                    logger.info("Uploaded %d%%." % int(status.progress() * 100))
             return True
         except errors.HttpError as e:
             raise AirflowException("Unable to upload large file to gcs", e)
     else:
         media = MediaFileUpload(local_filepath, mime_type)
-
+        logger.info('File is small, uploading to GCS all at once')
         try:
             storage_service.objects().insert(bucket=bucket_name, name=gcs_filepath, media_body=media).execute()
             return True
         except errors.HttpError as e:
             raise AirflowException("Unable to upload file to gcs", e)
 
-def upload_to_gcs(data_type, prev_task_id, **kwargs):
+def upload_to_gcs(data_type, prev_task_id, logger, **kwargs):
     '''
     Uploads a local file to Google Cloud Storage and deletes the local file if the upload is successful.
-
+    Data types should be: accounts, ledgers, offers, operations, trades, transactions, or trustlines.
     
     Parameters:
-        data_type - type of the data being uploaded (transaction, ledger, etc)
+        data_type - type of the data being uploade; should be string
+        logger - Airflow logger
         prev_task_id - the task id to get the filename from
     Returns:
         the full filepath in Google Cloud Storage of the uploaded file
@@ -89,21 +91,24 @@ def upload_to_gcs(data_type, prev_task_id, **kwargs):
     local_filepath = Variable.get('output_path') + filename
     bucket_name = Variable.get('gcs_bucket_name')
 
-    success = attempt_upload(local_filepath, gcs_filepath, bucket_name)
+    logger.info(f'Attempting to upload local file at {local_filepath} to Google Cloud Storage path {gcs_filepath} in bucket {bucket_name}')
+    success = attempt_upload(local_filepath, gcs_filepath, bucket_name, logger)
     if success:
         #TODO: consider adding backups or integrity checking before uploading/deleting
+        logger.info(f'Upload successful, removing file at {local_filepath}')
         os.remove(local_filepath)
 
     return gcs_filepath
 
-def build_load_task(dag, data_type, prev_task_id):
+def build_load_task(dag, logger, data_type, prev_task_id):
     '''
     Creates a task that loads a local file into Google Cloud Storage.
     Data types should be: accounts, ledgers, offers, operations, trades, transactions, or trustlines.
     
     Parameters:
         dag - the parent dag
-        data_type - type of the data being uploaded (transaction, ledger, etc)
+        logger - Airflow logger
+        data_type - type of the data being uploaded; should be string
         prev_task_id - the task id to get the filename from 
     Returns:
         the newly created task
@@ -112,7 +117,7 @@ def build_load_task(dag, data_type, prev_task_id):
     return PythonOperator(
             task_id='load_' + data_type + '_to_gcs',
             python_callable=upload_to_gcs,
-            op_kwargs={'data_type': data_type, 'prev_task_id': prev_task_id},
+            op_kwargs={'data_type': data_type, 'prev_task_id': prev_task_id, 'logger': logger},
             dag=dag,
             provide_context=True,
         )

--- a/dags/stellar_etl_airflow/build_load_task.py
+++ b/dags/stellar_etl_airflow/build_load_task.py
@@ -29,7 +29,7 @@ def build_storage_service():
     credentials = service_account.Credentials.from_service_account_file(key_path)
     return build('storage', 'v1', credentials=credentials, cache_discovery=False)
 
-def attempt_upload(local_filepath, gcs_filepath, bucket_name, logger, mime_type='text/plain'):
+def attempt_upload(local_filepath, gcs_filepath, bucket_name, mime_type='text/plain'):
     '''
     Tries to upload the file into Google Cloud Storage. Files above 10 megabytes are uploaded incrementally
     as described here: https://github.com/googleapis/google-api-python-client/blob/master/docs/media.md#resumable-media-chunked-upload
@@ -39,7 +39,6 @@ def attempt_upload(local_filepath, gcs_filepath, bucket_name, logger, mime_type=
         local_filepath - path to the local file to be uploaded 
         gcs_filepath - path for the file in gcs
         bucket_name - name of the bucket to upload to
-        logger - Airflow logger
         mime_type - type of media to upload; other values are defined https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types
     Returns:
         True if the upload is successful. Raises an Airflow error otherwise
@@ -48,34 +47,33 @@ def attempt_upload(local_filepath, gcs_filepath, bucket_name, logger, mime_type=
     storage_service = build_storage_service()
     if os.path.getsize(local_filepath) > 10 * 2 ** 20:
         media = MediaFileUpload(local_filepath, mime_type, resumable=True)
-        logger.info('File is large, uploading to GCS in chunks')
+        logging.info('File is large, uploading to GCS in chunks')
         try:
             request = storage_service.objects().insert(bucket=bucket_name, name=gcs_filepath, media_body=media)
             response = None
             while response is None:
                 status, response = request.next_chunk()
                 if status:
-                    logger.info("Uploaded %d%%." % int(status.progress() * 100))
+                    logging.info("Uploaded %d%%." % int(status.progress() * 100))
             return True
         except errors.HttpError as e:
             raise AirflowException("Unable to upload large file to gcs", e)
     else:
         media = MediaFileUpload(local_filepath, mime_type)
-        logger.info('File is small, uploading to GCS all at once')
+        logging.info('File is small, uploading to GCS all at once')
         try:
             storage_service.objects().insert(bucket=bucket_name, name=gcs_filepath, media_body=media).execute()
             return True
         except errors.HttpError as e:
             raise AirflowException("Unable to upload file to gcs", e)
 
-def upload_to_gcs(data_type, prev_task_id, logger, **kwargs):
+def upload_to_gcs(data_type, prev_task_id, **kwargs):
     '''
     Uploads a local file to Google Cloud Storage and deletes the local file if the upload is successful.
     Data types should be: accounts, ledgers, offers, operations, trades, transactions, or trustlines.
     
     Parameters:
         data_type - type of the data being uploade; should be string
-        logger - Airflow logger
         prev_task_id - the task id to get the filename from
     Returns:
         the full filepath in Google Cloud Storage of the uploaded file
@@ -91,23 +89,22 @@ def upload_to_gcs(data_type, prev_task_id, logger, **kwargs):
     local_filepath = Variable.get('output_path') + filename
     bucket_name = Variable.get('gcs_bucket_name')
 
-    logger.info(f'Attempting to upload local file at {local_filepath} to Google Cloud Storage path {gcs_filepath} in bucket {bucket_name}')
-    success = attempt_upload(local_filepath, gcs_filepath, bucket_name, logger)
+    logging.info(f'Attempting to upload local file at {local_filepath} to Google Cloud Storage path {gcs_filepath} in bucket {bucket_name}')
+    success = attempt_upload(local_filepath, gcs_filepath, bucket_name)
     if success:
         #TODO: consider adding backups or integrity checking before uploading/deleting
-        logger.info(f'Upload successful, removing file at {local_filepath}')
+        logging.info(f'Upload successful, removing file at {local_filepath}')
         os.remove(local_filepath)
 
     return gcs_filepath
 
-def build_load_task(dag, logger, data_type, prev_task_id):
+def build_load_task(dag, data_type, prev_task_id):
     '''
     Creates a task that loads a local file into Google Cloud Storage.
     Data types should be: accounts, ledgers, offers, operations, trades, transactions, or trustlines.
     
     Parameters:
         dag - the parent dag
-        logger - Airflow logger
         data_type - type of the data being uploaded; should be string
         prev_task_id - the task id to get the filename from 
     Returns:
@@ -117,7 +114,7 @@ def build_load_task(dag, logger, data_type, prev_task_id):
     return PythonOperator(
             task_id='load_' + data_type + '_to_gcs',
             python_callable=upload_to_gcs,
-            op_kwargs={'data_type': data_type, 'prev_task_id': prev_task_id, 'logger': logger},
+            op_kwargs={'data_type': data_type, 'prev_task_id': prev_task_id},
             dag=dag,
             provide_context=True,
         )


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).
</details>

### What
This PR adds more logging to Airflow tasks. This logging details things like where tasks are in their process, what files they interact with, and BigQuery job results. Closes #4 .

### Why
We want more detailed logging in order to make future debugging easier. It also lets us see what is being modified and see more in-depth information on the results of tasks.

### Known limitations
From what I can tell, logging to the log files instead of the command line only works for functions called by PythonOperators. This means this PR doesn't add any additional logging to other operators. Fortunately, other operators tend to have their own logging or perform simple tasks that don't require detailed logs. If we need more logging for these other operators, we could extend the operators ourselves and add logging where desired.