### PR TITLE
Switch to KubernetesPodOperator

### DIFF
--- a/airflow_variables.txt
+++ b/airflow_variables.txt
@@ -7,6 +7,7 @@
     "gcs_exported_data_bucket_name": "stellar-testing-us",
     "image_name": "stellar/stellar-etl:latest",
     "image_output_path": "/etl/exported_data/",
+    "kube_config_location": "",
     "local_output_path": "/home/airflow/etlData/",
     "namespace": "default",
     "output_file_names": {

--- a/airflow_variables.txt
+++ b/airflow_variables.txt
@@ -1,5 +1,5 @@
 {
-    "affinity": "{}"
+    "affinity": "{}",
     "api_key_path": "/home/airflow/gcs/data/apiKey.json",
     "bq_dataset": "test_dataset",
     "bq_project": "stellar-testing-281223",

--- a/airflow_variables.txt
+++ b/airflow_variables.txt
@@ -1,4 +1,5 @@
 {
+    "affinity": "{}"
     "api_key_path": "/home/airflow/gcs/data/apiKey.json",
     "bq_dataset": "test_dataset",
     "bq_project": "stellar-testing-281223",
@@ -38,5 +39,7 @@
         "trades": "trade_table",
         "transactions": "tx_table",
         "trustlines": "trust_table"
-    }
+    },
+    "volume_claim_name": "etl-data-claim",
+    "volume_name": "etl-data"
 }

--- a/dags/stellar_etl_airflow/build_export_task.py
+++ b/dags/stellar_etl_airflow/build_export_task.py
@@ -4,12 +4,12 @@ This file contains functions for creating Airflow tasks to run stellar-etl expor
 
 import json
 from airflow import AirflowException
-from airflow.models import Variable
-from stellar_etl_airflow.docker_operator import DockerOperator 
+from airflow.models import Variable 
 
 from airflow.contrib.operators.kubernetes_pod_operator import KubernetesPodOperator 
 from airflow.kubernetes.volume import Volume
 from airflow.kubernetes.volume_mount import VolumeMount
+
 def get_path_variables():
     '''
         Returns the image output path, core executable path, and core config path.
@@ -114,17 +114,3 @@ def build_export_task(dag, cmd_type, command, filename):
          volume_mounts=[data_mount],
          volumes=[data_volume]
      ) 
-    '''
-    etl_cmd, output_file = generate_etl_cmd(command, filename, cmd_type)
-    etl_cmd_string = ' '.join(etl_cmd)
-    full_cmd = f'bash -c "{etl_cmd_string} && echo \"{output_file}\""'
-    return DockerOperator(
-        task_id=command + '_task',
-        image=Variable.get('image_name'),
-        command=full_cmd, 
-        volumes=[f'{Variable.get("local_output_path")}:{Variable.get("image_output_path")}'],
-        dag=dag,
-        xcom_push=True,
-        auto_remove=True,
-        force_pull=True,
-    )'''

--- a/dags/stellar_etl_airflow/build_export_task.py
+++ b/dags/stellar_etl_airflow/build_export_task.py
@@ -94,6 +94,10 @@ def build_export_task(dag, cmd_type, command, filename):
     etl_cmd_string = ' '.join(etl_cmd)
     cmd = ['bash']
     args = ['-c', f'{etl_cmd_string} && mkdir -p /airflow/xcom/ && echo \'{{"output_file":"{output_file}"}}\' >> /airflow/xcom/return.json']
+    
+    config_file_location = Variable.get('kube_config_location')
+    in_cluster = False if config_file_location else True
+    
     return KubernetesPodOperator(
          task_id=command + '_task',
          name=command + '_task',
@@ -104,8 +108,8 @@ def build_export_task(dag, cmd_type, command, filename):
          dag=dag,
          do_xcom_push=True,
          is_delete_operator_pod=True,
-         in_cluster=False,
-         config_file="/Users/isaiahturner/.kube/config",
+         in_cluster=in_cluster,
+         config_file=config_file_location,
          volume_mounts=[data_mount],
          volumes=[data_volume],
          affinity=Variable.get('affinity', deserialize_json=True)

--- a/dags/stellar_etl_airflow/build_time_task.py
+++ b/dags/stellar_etl_airflow/build_time_task.py
@@ -33,5 +33,6 @@ def build_time_task(dag, use_next_exec_time=True):
          do_xcom_push=True,
          is_delete_operator_pod=True,
          in_cluster=False,
-         config_file="/Users/isaiahturner/.kube/config"
+         config_file="/Users/isaiahturner/.kube/config",
+         affinity=Variable.get('affinity', deserialize_json=True)
      ) 

--- a/dags/stellar_etl_airflow/build_time_task.py
+++ b/dags/stellar_etl_airflow/build_time_task.py
@@ -2,7 +2,6 @@
 This file contains functions for creating Airflow tasks to convert from a time range to a ledger range.
 '''
 
-from stellar_etl_airflow.docker_operator import DockerOperator 
 from airflow.contrib.operators.kubernetes_pod_operator import KubernetesPodOperator 
 from airflow.models import Variable
 
@@ -19,20 +18,7 @@ def build_time_task(dag, use_next_exec_time=True):
     Returns:
         the newly created task
     '''
-    
-    '''
-    end_time = '{{ next_execution_date.isoformat() }}' if use_next_exec_time else '{{ ts }}'
-    command = "stellar-etl get_ledger_range_from_times -s {{ ts }} --stdout -e " + end_time
-    return DockerOperator(
-        task_id='get_ledger_range_from_times',
-        image=Variable.get('image_name'),
-        command=command, 
-        volumes=[f'{Variable.get("local_output_path")}:{Variable.get("image_output_path")}'],
-        dag=dag,
-        xcom_push=True,
-        auto_remove=True,
-    )
-    '''
+
     end_time = '{{ next_execution_date.isoformat() }}' if use_next_exec_time else '{{ ts }}'
     command = ["stellar-etl"]
     args = [ "get_ledger_range_from_times", "-s", "{{ ts }}", "-o", "/airflow/xcom/return.json", '-e', end_time]

--- a/dags/stellar_etl_airflow/build_time_task.py
+++ b/dags/stellar_etl_airflow/build_time_task.py
@@ -22,6 +22,8 @@ def build_time_task(dag, use_next_exec_time=True):
     end_time = '{{ next_execution_date.isoformat() }}' if use_next_exec_time else '{{ ts }}'
     command = ["stellar-etl"]
     args = [ "get_ledger_range_from_times", "-s", "{{ ts }}", "-o", "/airflow/xcom/return.json", '-e', end_time]
+    config_file_location = Variable.get('kube_config_location')
+    in_cluster = False if config_file_location else True
     return KubernetesPodOperator(
          task_id='get_ledger_range_from_times',
          name='get_ledger_range_from_times',
@@ -32,7 +34,7 @@ def build_time_task(dag, use_next_exec_time=True):
          dag=dag,
          do_xcom_push=True,
          is_delete_operator_pod=True,
-         in_cluster=False,
-         config_file="/Users/isaiahturner/.kube/config",
+         in_cluster=in_cluster,
+         config_file=config_file_location,
          affinity=Variable.get('affinity', deserialize_json=True)
      ) 

--- a/dags/stellar_etl_airflow/build_time_task.py
+++ b/dags/stellar_etl_airflow/build_time_task.py
@@ -2,7 +2,8 @@
 This file contains functions for creating Airflow tasks to convert from a time range to a ledger range.
 '''
 
-from stellar_etl_airflow.docker_operator import DockerOperator  
+from stellar_etl_airflow.docker_operator import DockerOperator 
+from airflow.contrib.operators.kubernetes_pod_operator import KubernetesPodOperator 
 from airflow.models import Variable
 
 def build_time_task(dag, use_next_exec_time=True):
@@ -18,7 +19,8 @@ def build_time_task(dag, use_next_exec_time=True):
     Returns:
         the newly created task
     '''
-
+    
+    '''
     end_time = '{{ next_execution_date.isoformat() }}' if use_next_exec_time else '{{ ts }}'
     command = "stellar-etl get_ledger_range_from_times -s {{ ts }} --stdout -e " + end_time
     return DockerOperator(
@@ -30,3 +32,20 @@ def build_time_task(dag, use_next_exec_time=True):
         xcom_push=True,
         auto_remove=True,
     )
+    '''
+    end_time = '{{ next_execution_date.isoformat() }}' if use_next_exec_time else '{{ ts }}'
+    command = ["stellar-etl"]
+    args = [ "get_ledger_range_from_times", "-s", "{{ ts }}", "-o", "/airflow/xcom/return.json", '-e', end_time]
+    return KubernetesPodOperator(
+         task_id='get_ledger_range_from_times',
+         name='get_ledger_range_from_times',
+         namespace='etl-tasks',
+         image=Variable.get('image_name'),
+         cmds=command,
+         arguments=args,
+         dag=dag,
+         do_xcom_push=True,
+         is_delete_operator_pod=True,
+         in_cluster=False,
+         config_file="/Users/isaiahturner/.kube/config"
+     ) 

--- a/dags/stellar_etl_airflow/default.py
+++ b/dags/stellar_etl_airflow/default.py
@@ -10,20 +10,3 @@ def get_default_dag_args():
     'retries': 5,
     'retry_delay': timedelta(minutes=5),
 }
-
-def get_default_kubernetes_affinity():
-    return {
-                'nodeAffinity': {
-                'requiredDuringSchedulingIgnoredDuringExecution': {
-                    'nodeSelectorTerms': [{
-                        'matchExpressions': [{
-                            'key': 'cloud.google.com/gke-nodepool',
-                            'operator': 'In',
-                            'values': [
-                                Variable.get('pool_name')
-                            ]
-                        }]
-                    }]
-                }
-                }
-            }


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).
</details>

### What
This PR switches the tasks that use the ETL from the DockerOperator to the KubernetesPodOperator. It also introduces new variables that make it possible to customize the Pod and its volumes. Closes #46.

### Why
The DockerOperator had security concerns. We would have to provide root privileges to the container so it could run Docker. This switch prevents those concerns.

### Known limitations
Need to document the newly added variables.