### PR TITLE
Update offer schema

### DIFF
--- a/schemas/offers_schema.json
+++ b/schemas/offers_schema.json
@@ -12,12 +12,12 @@
   {
     "mode": "NULLABLE",
     "name": "selling_asset",
-    "type": "STRING"
+    "type": "FLOAT"
   },
   {
     "mode": "NULLABLE",
     "name": "buying_asset",
-    "type": "STRING"
+    "type": "FLOAT"
   },
   {
     "mode": "NULLABLE",


### PR DESCRIPTION
Now that we have assets, the offer schema should use asset ids to represent the buying and selling assets. These ids are now floats instead of strings.