### PR TITLE
Added trigger rule for process DAGs

### DIFF
--- a/dags/process_unbounded_core_changes_dag.py
+++ b/dags/process_unbounded_core_changes_dag.py
@@ -44,9 +44,13 @@ apply_trustline_changes_task = build_apply_gcs_changes_to_bq_task(dag, 'trustlin
 
 '''
 This task triggers the next run of this DAG once accounts, offers, and trustlines have been processed.
+Since the trigger_rule is all_done, this task happens even if a processing failure occurs. This means
+that the next process event will always trigger.
 '''
 trigger_next = BashOperator(task_id="trigger_next", 
-           bash_command="airflow trigger_dag 'process_unbounded_core_changes'", dag=dag)
+           bash_command="airflow trigger_dag 'process_unbounded_core_changes'",
+           dag=dag,
+           trigger_rule='all_done')
 
 account_sensor >> load_accounts_task >> apply_account_changes_task >> trigger_next
 offer_sensor >> load_offers_task >> apply_offer_changes_task >> trigger_next

--- a/dags/process_unbounded_core_orderbooks_dag.py
+++ b/dags/process_unbounded_core_orderbooks_dag.py
@@ -48,9 +48,13 @@ send_fact_events_to_bq_task = build_gcs_to_bq_task(dag, 'factEvents')
 
 '''
 This task triggers the next run of this DAG once accounts, offers, and trustlines have been processed.
+Since the trigger_rule is all_done, this task happens even if a processing failure occurs. This means
+that the next process event will always trigger.
 '''
 trigger_next = BashOperator(task_id="trigger_next", 
-           bash_command="airflow trigger_dag 'process_unbounded_core_orderbooks'", dag=dag)
+           bash_command="airflow trigger_dag 'process_unbounded_core_orderbooks'", 
+           dag=dag,
+           trigger_rule='all_done')
 
 dim_account_sensor >> load_dim_accounts_task >> apply_dim_account_changes_task >> trigger_next
 dim_offer_sensor >> load_dim_offers_task >> apply_dim_offer_changes_task >> trigger_next


### PR DESCRIPTION
### What 
This PR changes the `trigger_next` task in the `process_unbounded_core_changes` and `process_unbounded_core_orderbooks` DAGs to always trigger. 

### Why
If a processing run fails and the `trigger_next` task doesn't run, then future batches will not be uploaded. The only way to fix this was to manually trigger another process DAG run. Now, the trigger will happen automatically.