### PR TITLE
Long running fixes

### DIFF
--- a/dags/process_unbounded_core_orderbooks_dag.py
+++ b/dags/process_unbounded_core_orderbooks_dag.py
@@ -43,7 +43,7 @@ Entries are updated, deleted, or inserted as needed.
 apply_dim_account_changes_task = build_apply_gcs_changes_to_bq_task(dag, 'dimAccounts')
 apply_dim_offer_changes_task = build_apply_gcs_changes_to_bq_task(dag, 'dimOffers')
 apply_dim_markets_changes_task = build_apply_gcs_changes_to_bq_task(dag, 'dimMarkets')
-send_fact_events_to_bq_task = build_gcs_to_bq_task(dag, 'factEvents')
+send_fact_events_to_bq_task = build_apply_gcs_changes_to_bq_task(dag, 'factEvents')
 
 
 '''

--- a/dags/stellar_etl_airflow/build_apply_gcs_changes_to_bq_task.py
+++ b/dags/stellar_etl_airflow/build_apply_gcs_changes_to_bq_task.py
@@ -98,6 +98,7 @@ def generate_equality_comparison(data_type, source_table_alias, dest_table_alias
         'operations': f'{dest_table_alias}.id = {source_table_alias}.id',
         'trades': f'{dest_table_alias}.history_operation_id = {source_table_alias}.history_operation_id AND {dest_table_alias}.order = {source_table_alias}.order',
         'assets': f'{dest_table_alias}.id = {source_table_alias}.id',
+        'factEvents': f'{dest_table_alias}.offer_instance_id = {source_table_alias}.offer_instance_id AND {dest_table_alias}.ledger_id = {source_table_alias}.ledger_id '
     }
 
     equality_comparison = switch.get(data_type, 'No comparison')
@@ -211,7 +212,7 @@ def apply_gcs_changes(data_type, **kwargs):
     if data_type in ['accounts', 'offers', 'trustlines']:
         logging.info('Using merge query...')
         sql_query = create_merge_query(table_id, data_type, schema_dict)
-    elif data_type in ['ledgers', 'transactions', 'operations', 'trades', 'assets', 'dimAccounts', 'dimOffers', 'dimMarkets']:
+    elif data_type in ['ledgers', 'transactions', 'operations', 'trades', 'assets', 'dimAccounts', 'dimOffers', 'dimMarkets', 'factEvents']:
         logging.info('Using insert unique query...')
         sql_query = create_insert_unique_query(table_id, data_type, schema_dict)
     else:

--- a/dags/unbounded_core_changes_dag.py
+++ b/dags/unbounded_core_changes_dag.py
@@ -26,5 +26,6 @@ date_task = build_time_task(dag, use_next_exec_time=False)
 
 file_names = Variable.get('output_file_names', deserialize_json=True)
 changes_task = build_export_task(dag, 'unbounded-core', 'export_ledger_entry_changes', file_names['changes'])
+changes_task.retries = 0
 
 date_task >> changes_task

--- a/dags/unbounded_core_orderbook_dag.py
+++ b/dags/unbounded_core_orderbook_dag.py
@@ -26,5 +26,6 @@ date_task = build_time_task(dag, use_next_exec_time=False)
 
 file_names = Variable.get('output_file_names', deserialize_json=True)
 orderbook_task = build_export_task(dag, 'unbounded-core', 'export_orderbooks', file_names['orderbooks'])
+orderbook_task.retries = 0
 
 date_task >> orderbook_task


### PR DESCRIPTION
### What
This PR switches the factEvent branch in the process orderbook dag to use a unique merge instead of a blind append. It also sets the retries for long running tasks to 0.

### Why
We need to use merges instead of appends to ensure tasks are idempotent. Setting retries to 0 prevents us from reingesting huge amounts of data if a failure occurs in a long running task. It does require some more manual work, which is detailed in the `Long-Running Task Failures` section of the [Handling Failures](https://docs.google.com/document/d/1IIpDW0nrR-RtXx0dZDAViCtgjn78hhczYKoj71I65EA/edit#heading=h.c1mbxnin3mci) document.