### PR TITLE
dags/stellar-etl-airflow: silence stellar-etl print output

### DIFF
--- a/dags/stellar_etl_airflow/build_export_task.py
+++ b/dags/stellar_etl_airflow/build_export_task.py
@@ -133,7 +133,7 @@ def build_docker_exporter(dag, command, etl_cmd_string, output_file):
     '''
     from stellar_etl_airflow.docker_operator import DockerOperator 
 
-    full_cmd = f'bash -c "{etl_cmd_string} && echo \"{output_file}\""'
+    full_cmd = f'bash -c "{etl_cmd_string} >> /dev/null && echo \"{output_file}\""'
     force_pull = True if Variable.get('image_pull_policy')=='Always' else False
     return DockerOperator(
         task_id=command + '_task',


### PR DESCRIPTION
When running the `stellar-etl` command with DockerOperator, on random occasions the print output from the command botches the echo command we're passing to it.

looks like this (should be two different outputs)
```
{"attempted_transforms":0,"failed_transforms":0,"successful_transforms":0
235651-252108-trades.txt
```

So silence the `stellar-etl` command (we don't need it) and echo the output_file, which is what we want to save to xcom in airflow