### PR TITLE
poststart.sh: check if file has size before moving

### DIFF
--- a/dags/stellar_etl_airflow/build_load_task.py
+++ b/dags/stellar_etl_airflow/build_load_task.py
@@ -46,6 +46,7 @@ def attempt_upload(local_filepath, gcs_filepath, bucket_name, mime_type='text/pl
     '''
 
     storage_service = build_storage_service()
+    logging.info('File size is: %s kb' % str(os.path.getsize(local_filepath) / 1000))
     if os.path.getsize(local_filepath) > 10 * 2 ** 20:
         media = MediaFileUpload(local_filepath, mime_type, resumable=True)
         logging.info('File is large, uploading to GCS in chunks')

--- a/dags/stellar_etl_airflow/build_load_task.py
+++ b/dags/stellar_etl_airflow/build_load_task.py
@@ -96,11 +96,20 @@ def upload_to_gcs(data_type, prev_task_id, **kwargs):
     bucket_name = Variable.get('gcs_exported_data_bucket_name')
 
     logging.info(f'Attempting to upload local file at {local_filepath} to Google Cloud Storage path {gcs_filepath} in bucket {bucket_name}')
-    success = attempt_upload(local_filepath, gcs_filepath, bucket_name)
+    # TODO: consider adding a sanity check to make sure the filename shouldn't exist (ie no data to upload)
+    if os.path.exists(local_filepath):
+        success = attempt_upload(local_filepath, gcs_filepath, bucket_name)
+        fileExists = True
+    else:
+        logging.info('File does no exist, no data to upload')
+        success = True
+        fileExists = False
+    
     if success:
         #TODO: consider adding backups or integrity checking before uploading/deleting
-        logging.info(f'Upload successful, removing file at {local_filepath}')
-        os.remove(local_filepath)
+        if fileExists:
+            logging.info(f'Upload successful, removing file at {local_filepath}')
+            os.remove(local_filepath)
     else: 
         raise AirflowException('Upload was not successful')
 

--- a/poststart.sh
+++ b/poststart.sh
@@ -1,13 +1,11 @@
 #!/bin/bash
 
 move_file_if_closed() {
+    fileSize=$(wc -c < "$1")
     lsof "$1";
-    # if lsof returns an error code of 1, it means the file is not opened by any other processes
-    if [ $? == 1 ]; then
-        fileSize=$(wc -c < "$1")
-        if [ $fileSize -gt 0 ]; then
-            mv "$1" /home/airflow/gcs/data/;
-        fi
+    # if lsof returns an error code of 1, it means the file is not opened by any other processes, allowing us to move it safely
+    if [[ $? == 1 && $fileSize -gt 0 ]]; then
+        mv "$1" /home/airflow/gcs/data/;
     fi
 }
 

--- a/poststart.sh
+++ b/poststart.sh
@@ -1,11 +1,21 @@
 #!/bin/bash
 
 move_file_if_closed() {
-    fileSize=$(wc -c < "$1")
     lsof "$1";
-    # if lsof returns an error code of 1, it means the file is not opened by any other processes, allowing us to move it safely
-    if [[ $? == 1 && $fileSize -gt 0 ]]; then
-        mv "$1" /home/airflow/gcs/data/;
+    # if lsof returns an error code of 1, it means the file is not opened by any other processes
+    if [ $? == 1 ]; then
+        fileSize=$(wc -c < "$1")
+        if [ $fileSize -gt 0 ]; then
+            mv "$1" /home/airflow/gcs/data/;
+        # if empty double check not waiting to be written to
+        else
+            sleep 1
+            lsof "$1";
+            if [ $? == 1 ]; then
+                mv "$1" /home/airflow/gcs/data/;
+            fi
+            return
+        fi
     fi
 }
 

--- a/poststart.sh
+++ b/poststart.sh
@@ -7,14 +7,6 @@ move_file_if_closed() {
         fileSize=$(wc -c < "$1")
         if [ $fileSize -gt 0 ]; then
             mv "$1" /home/airflow/gcs/data/;
-        # if empty double check not waiting to be written to
-        else
-            sleep 1
-            lsof "$1";
-            if [ $? == 1 ]; then
-                mv "$1" /home/airflow/gcs/data/;
-            fi
-            return
         fi
     fi
 }

--- a/poststart.sh
+++ b/poststart.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 
 move_file_if_closed() {
+    fileSize=$(wc -c < "$1")
     lsof "$1";
     # if lsof returns an error code of 1, it means the file is not opened by any other processes, allowing us to move it safely
-    if (($? == 1)); then
+    if [[ $? == 1 && $fileSize -gt 0 ]]; then
         mv "$1" /home/airflow/gcs/data/;
     fi
 }


### PR DESCRIPTION
**WHAT**

adding a check to see if the file on the local pod has size before moving it to the google cloud shared folder

**WHY**

The way DockerOperator in `build_export_task` works when outputting to a file is it creates the file first, then writes to it. The current poststart script is constantly checking for the presence of a file, and if found and unopened, it moves it. It seems it was moving it before the file was written to but after created, because it shows up in gcs empty, even though it originally had data.

This only shows up when the ledger range is larger. I believe because gathering the data takes longer, so it widens the window the poststart script has to move the file preemptively.

This solution is essentially:
- move the .txt file to gcs if it has data
- for the load task if there is no .txt file, then no data to upload so end successfully (if for whatever reason the export task fails, then the load task wouldn't start anyways bc it's downstream)