### PR TITLE
Update table schemas

### DIFF
--- a/schemas/accounts_schema.json
+++ b/schemas/accounts_schema.json
@@ -7,17 +7,17 @@
   {
     "mode": "NULLABLE",
     "name": "balance",
-    "type": "INTEGER"
+    "type": "FLOAT"
   },
   {
     "mode": "NULLABLE",
     "name": "buying_liabilities",
-    "type": "INTEGER"
+    "type": "FLOAT"
   },
   {
     "mode": "NULLABLE",
     "name": "selling_liabilities",
-    "type": "INTEGER"
+    "type": "FLOAT"
   },
   {
     "mode": "NULLABLE",
@@ -71,7 +71,27 @@
   },
   {
     "mode": "NULLABLE",
+    "name": "ledger_entry_change",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
     "name": "deleted",
     "type": "BOOLEAN"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "batch_id",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "batch_run_date",
+    "type": "DATETIME"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "batch_insert_ts",
+    "type": "TIMESTAMP"
   }
 ]

--- a/schemas/dimOffers_schema.json
+++ b/schemas/dimOffers_schema.json
@@ -22,7 +22,7 @@
   {
     "mode": "NULLABLE",
     "name": "base_amount",
-    "type": "INTEGER"
+    "type": "FLOAT"
   },
   {
     "mode": "NULLABLE",

--- a/schemas/history_operations_schema.json
+++ b/schemas/history_operations_schema.json
@@ -268,6 +268,28 @@
                   "mode": "REPEATED",
                   "name": "or",
                   "type": "RECORD"
+                  },
+                  {
+                    "fields": [
+                    {
+                      "mode": "NULLABLE",
+                      "name": "abs_before",
+                      "type": "STRING" 
+                    },
+                    {
+                      "mode": "NULLABLE",
+                      "name": "rel_before",
+                      "type": "INTEGER"
+                    },
+                    {
+                      "mode": "NULLABLE",
+                      "name": "unconditional",
+                      "type": "BOOLEAN"
+                    }
+                  ],
+                  "mode": "REPEATED",
+                  "name": "not",
+                  "type": "RECORD"
                   }
                 ],
                 "mode": "REPEATED",
@@ -351,6 +373,28 @@
                         "mode": "NULLABLE",
                         "name": "unconditional",
                         "type": "BOOLEAN"
+                      },
+                      {
+                        "fields": [
+                          {
+                            "mode": "NULLABLE",
+                            "name": "abs_before",
+                            "type": "STRING"
+                          },
+                          {
+                            "mode": "NULLABLE",
+                            "name": "rel_before",
+                            "type": "INTEGER"
+                          },
+                          {
+                            "mode": "NULLABLE",
+                            "name": "unconditional",
+                            "type": "BOOLEAN"
+                          } 
+                        ],
+                        "mode": "REPEATED",
+                        "name": "not",
+                        "type": "RECORD"
                       }
                     ],
                     "mode": "REPEATED",
@@ -700,6 +744,135 @@
         "mode": "NULLABLE",
         "name": "begin_sponsor_muxed_id",
         "type": "INTEGER"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "liquidity_pool_id",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "reserve_a_asset_type",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "reserve_a_asset_code",
+        "type": "STRING"
+      }, 
+      {
+        "mode": "NULLABLE",
+        "name": "reserve_a_asset_issuer",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "reserve_a_max_amount",
+        "type": "FLOAT"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "reserve_a_deposit_amount",
+        "type": "FLOAT"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "reserve_b_asset_type",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "reserve_b_asset_code",
+        "type": "STRING"
+      }, 
+      {
+        "mode": "NULLABLE",
+        "name": "reserve_b_asset_issuer",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "reserve_b_max_amount",
+        "type": "FLOAT"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "reserve_b_deposit_amount",
+        "type": "FLOAT"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "min_price",
+        "type": "FLOAT"
+      },
+      { "fields": [
+        {
+          "mode": "NULLABLE",
+          "name": "d",
+          "type": "INTEGER"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "n",
+          "type": "INTEGER"
+        }
+
+      ],
+        "mode": "REPEATED",
+        "name": "min_price_r",
+        "type": "RECORD"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "max_price",
+        "type": "FLOAT"
+      },
+      { "fields": [
+        {
+          "mode": "NULLABLE",
+          "name": "d",
+          "type": "INTEGER"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "n",
+          "type": "INTEGER"
+        }
+
+      ],
+        "mode": "REPEATED",
+        "name": "max_price_r",
+        "type": "RECORD"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "shares_received",
+        "type": "FLOAT" 
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "reserve_a_min_amount",
+        "type": "FLOAT"  
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "reserve_a_withdraw_amount",
+        "type": "FLOAT"  
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "reserve_b_min_amount",
+        "type": "FLOAT"  
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "reserve_b_withdraw_amount",
+        "type": "FLOAT"  
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "shares",
+        "type": "FLOAT"  
       }
     ],
     "mode": "NULLABLE",

--- a/schemas/history_trades_schema.json
+++ b/schemas/history_trades_schema.json
@@ -16,63 +16,53 @@
   },
   {
     "mode": "NULLABLE",
-    "name": "offer_id",
-    "type": "INTEGER"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "base_account_address",
+    "name": "selling_account_address",
     "type": "STRING"
   },
   {
     "mode": "NULLABLE",
-    "name": "base_asset_code",
+    "name": "selling_asset_code",
     "type": "STRING"
   },
   {
      "mode": "NULLABLE",
-     "name": "base_asset_issuer",
+     "name": "selling_asset_issuer",
      "type": "STRING"
   },
   {
      "mode": "NULLABLE",
-     "name": "base_asset_type",
+     "name": "selling_asset_type",
      "type": "STRING"
   },
   {
     "mode": "NULLABLE",
-    "name": "base_amount",
-    "type": "INTEGER"
+    "name": "selling_amount",
+    "type": "FLOAT"
   },
   {
     "mode": "NULLABLE",
-    "name": "counter_account_address",
+    "name": "buying_account_address",
     "type": "STRING"
   },
   {
     "mode": "NULLABLE",
-    "name": "counter_asset_code",
+    "name": "buying_asset_code",
     "type": "STRING"
   },
   {
      "mode": "NULLABLE",
-     "name": "counter_asset_issuer",
+     "name": "buying_asset_issuer",
      "type": "STRING"
   },
   {
      "mode": "NULLABLE",
-     "name": "counter_asset_type",
+     "name": "buying_asset_type",
      "type": "STRING"
   },
   {
     "mode": "NULLABLE",
-    "name": "counter_amount",
-    "type": "INTEGER"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "base_is_seller",
-    "type": "BOOLEAN"
+    "name": "buying_amount",
+    "type": "FLOAT"
   },
   {
     "mode": "NULLABLE",
@@ -86,12 +76,12 @@
   },
   {
     "mode": "NULLABLE",
-    "name": "base_offer_id",
+    "name": "selling_offer_id",
     "type": "INTEGER"
   },
   {
     "mode": "NULLABLE",
-    "name": "counter_offer_id",
+    "name": "buying_offer_id",
     "type": "INTEGER"
   },
   {
@@ -108,5 +98,15 @@
     "mode": "NULLABLE",
     "name": "batch_insert_ts",
     "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "selling_liquidity_pool_id",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "liquidity_pool_fee",
+    "type": "INTEGER"
   }
 ]

--- a/schemas/liquidity_pools_schema.json
+++ b/schemas/liquidity_pools_schema.json
@@ -1,0 +1,97 @@
+[
+    {
+        "mode": "NULLABLE",
+        "name": "liquidity_pool_id",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "type",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "fee",
+        "type": "INTEGER"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "trustline_count",
+        "type": "INTEGER"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "pool_share_count",
+        "type": "FLOAT"
+    },
+    {   
+        "mode": "NULLABLE",
+        "name": "asset_a_type",
+        "type": "STRING"
+    },
+    {   
+        "mode": "NULLABLE",
+        "name": "asset_a_code",
+        "type": "STRING"
+    },
+    {   
+        "mode": "NULLABLE",
+        "name": "asset_a_issuer",
+        "type": "STRING"
+    },
+    {   
+        "mode": "NULLABLE",
+        "name": "asset_a_amount",
+        "type": "FLOAT"
+    },
+    {   
+        "mode": "NULLABLE",
+        "name": "asset_b_type",
+        "type": "STRING"
+    },
+    {   
+        "mode": "NULLABLE",
+        "name": "asset_b_code",
+        "type": "STRING"
+    },
+    {   
+        "mode": "NULLABLE",
+        "name": "asset_b_issuer",
+        "type": "STRING"
+    },
+    {   
+        "mode": "NULLABLE",
+        "name": "asset_b_amount",
+        "type": "FLOAT"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "last_modified_ledger",
+        "type": "INTEGER"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "ledger_entry_change",
+        "type": "INTEGER"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "deleted",
+        "type": "BOOLEAN"   
+    },
+    {
+      "mode": "NULLABLE",
+      "name": "batch_id",
+      "type": "STRING"
+    },
+    {
+      "mode": "NULLABLE",
+      "name": "batch_run_date",
+      "type": "DATETIME"
+    },
+    {
+      "mode": "NULLABLE",
+      "name": "batch_insert_ts",
+      "type": "TIMESTAMP"
+    }
+]

--- a/schemas/offers_schema.json
+++ b/schemas/offers_schema.json
@@ -22,7 +22,7 @@
   {
     "mode": "NULLABLE",
     "name": "amount",
-    "type": "INTEGER"
+    "type": "FLOAT"
   },
   {
     "mode": "NULLABLE",
@@ -51,7 +51,27 @@
   },
   {
     "mode": "NULLABLE",
+    "name": "ledger_entry_change",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
     "name": "deleted",
     "type": "BOOLEAN"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "batch_id",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "batch_run_date",
+    "type": "DATETIME"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "batch_insert_ts",
+    "type": "TIMESTAMP"
   }
 ]

--- a/schemas/trustlines_schema.json
+++ b/schemas/trustlines_schema.json
@@ -26,8 +26,13 @@
   },
   {
     "mode": "NULLABLE",
+    "name": "liquidity_pool_id",
+    "type": "STRING"  
+  },
+  {
+    "mode": "NULLABLE",
     "name": "balance",
-    "type": "INTEGER"
+    "type": "FLOAT"
   },
   {
     "mode": "NULLABLE",
@@ -37,12 +42,12 @@
   {
     "mode": "NULLABLE",
     "name": "buying_liabilities",
-    "type": "INTEGER"
+    "type": "FLOAT"
   },
   {
     "mode": "NULLABLE",
     "name": "selling_liabilities",
-    "type": "INTEGER"
+    "type": "FLOAT"
   },
   {
     "mode": "NULLABLE",
@@ -56,7 +61,32 @@
   },
   {
     "mode": "NULLABLE",
+    "name": "ledger_entry_change",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
     "name": "deleted",
     "type": "BOOLEAN"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "batch_id",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "batch_run_date",
+    "type": "DATETIME"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "batch_insert_ts",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "sponsor",
+    "type": "STRING"
   }
 ]


### PR DESCRIPTION
In the `stellar-etl` repo, some [breaking changes](https://github.com/stellar/stellar-etl/pull/137) were made to outputted, transformed fields so that data transformations matched the Horizon API. Because of this, the downstream Airflow schemas needed to be updated so that the DAGs could still load tables. The changes are intended to make the data more usable to downstream consumers.

#### Changes

**Accounts**
* `amount` fields in the accounts table were updated from `INTEGER` to `FLOAT`
* batch run fields were appended to the table to help with maintenance and support

**History_Operations**
* New fields are added to `details` JSON blob for operation types 22 and 23 (Deposit and Withdraw liquidity) 
* Missing fields added to `details.claimants` so that claimable balances parse correctly

**History_Trades**
* all `base` and `counter` fields are updated to `buying` and `selling` prefixes to decouple from Horizon 
* liquidity pool fields added

**Trustlines**
* `amount` fields are updated from `INTEGER` to `FLOAT` (values were originally in stroops) 
* all batch run fields added
* liquidity pool fields added

**Offers**
* all batch run fields added
* `amount` fields are updated from `INTEGER` to `FLOAT` (values were originally in stroops)

**Liquidity_Pools**
Brand new table for liquidity pool data. The schema matches Horizon db with additional information for assets.