### PR TITLE
Add liquidity pools to DAGs

### DIFF
--- a/dags/bounded_core_dag.py
+++ b/dags/bounded_core_dag.py
@@ -4,10 +4,16 @@ This DAG should be triggered manually if it is required to export entry changes 
 the unbounded version.
 '''
 import json
+from time import time
 
 from stellar_etl_airflow.build_export_task import build_export_task
 from stellar_etl_airflow.build_time_task import build_time_task
 from stellar_etl_airflow.default import get_default_dag_args
+from stellar_etl_airflow.build_batch_stats import build_batch_stats
+from stellar_etl_airflow.build_load_task import build_load_task
+from stellar_etl_airflow.build_gcs_to_bq_task import build_gcs_to_bq_task
+import datetime
+import time
 
 from airflow import DAG
 from airflow.models import Variable
@@ -15,14 +21,53 @@ from airflow.models import Variable
 dag = DAG(
     'bounded_core_export',
     default_args=get_default_dag_args(),
-    description='This DAG runs a bounded stellar-core instance, which allows it to export accounts, offers, and trustlines to BigQuery.',
-    schedule_interval=None,
+    start_date=datetime.datetime(2021, 10, 14),
+    description='This DAG runs a bounded stellar-core instance, which allows it to export accounts, offers, liquidity pools, and trustlines to BigQuery.',
+    schedule_interval='*/15 * * * *',
     user_defined_filters={'fromjson': lambda s: json.loads(s)},
 )
 
-date_task = build_time_task(dag, use_next_exec_time=False)
+date_task = build_time_task(dag)
 
 file_names = Variable.get('output_file_names', deserialize_json=True)
 changes_task = build_export_task(dag, 'bounded-core', 'export_ledger_entry_changes', file_names['changes'])
+changes_task.post_execute = lambda **x: time.sleep(60)
 
-date_task >> changes_task
+'''
+The write batch stats task will take a snapshot of the DAG run_id, execution date, 
+start and end ledgers so that reconciliation and data validation are easier. The 
+record is written to an internal dataset for data eng use only.
+'''
+write_acc_stats = build_batch_stats(dag, 'accounts')
+write_off_stats = build_batch_stats(dag, 'offers')
+write_pool_stats = build_batch_stats(dag, 'liquidity_pools')
+write_trust_stats = build_batch_stats(dag, 'trust_lines')
+
+'''
+The load tasks receive the location of the exported file through Airflow's XCOM system.
+Then, the task loads the file into Google Cloud Storage. Finally, the file is deleted
+from local storage.
+'''
+load_acc_task = build_load_task(dag, 'accounts', 'get_ledger_range_from_times', True)
+load_acc_task.pre_execute = lambda **x: time.sleep(30)
+load_off_task = build_load_task(dag, 'offers', 'get_ledger_range_from_times', True)
+load_off_task.pre_execute = lambda **x: time.sleep(30)
+load_pool_task = build_load_task(dag, 'liquidity_pools', 'get_ledger_range_from_times', True)
+load_pool_task.pre_execute = lambda **x: time.sleep(30)
+load_trust_task = build_load_task(dag, 'trustlines', 'get_ledger_range_from_times', True)
+load_trust_task.pre_execute = lambda **x: time.sleep(30)
+
+'''
+The apply tasks receive the location of the file in Google Cloud storage through Airflow's XCOM system.
+Then, the task merges the entries in the file with the entries in the corresponding table in BigQuery. 
+Entries are updated, deleted, or inserted as needed.
+'''
+send_acc_to_bq_task = build_gcs_to_bq_task(dag, 'accounts', partition=False)
+send_off_to_bq_task = build_gcs_to_bq_task(dag, 'offers', partition=False)
+send_pool_to_bq_task = build_gcs_to_bq_task(dag, 'liquidity_pools', partition=False)
+send_trust_to_bq_task = build_gcs_to_bq_task(dag, 'trustlines', partition=False)
+
+date_task >> changes_task >> write_acc_stats >> load_acc_task >> send_acc_to_bq_task
+date_task >> changes_task >> write_off_stats >> load_off_task >> send_off_to_bq_task
+date_task >> changes_task >> write_pool_stats >> load_pool_task >> send_pool_to_bq_task
+date_task >> changes_task >> write_trust_stats >> load_trust_task >> send_trust_to_bq_task

--- a/dags/bucket_list_dag.py
+++ b/dags/bucket_list_dag.py
@@ -8,8 +8,11 @@ import json
 from stellar_etl_airflow.build_export_task import build_export_task
 from stellar_etl_airflow.build_time_task import build_time_task
 from stellar_etl_airflow.build_load_task import build_load_task
+from stellar_etl_airflow.build_batch_stats import build_batch_stats
 from stellar_etl_airflow.default import get_default_dag_args
-from stellar_etl_airflow.build_apply_gcs_changes_to_bq_task import build_apply_gcs_changes_to_bq_task
+from stellar_etl_airflow.build_gcs_to_bq_task import build_gcs_to_bq_task
+import time
+import datetime
 
 from airflow import DAG
 from airflow.models import Variable
@@ -17,37 +20,70 @@ from airflow.models import Variable
 dag = DAG(
     'bucket_list_export',
     default_args=get_default_dag_args(),
-    description='This DAG exports ledgers, transactions, and operations from the history archive to BigQuery.',
-    schedule_interval=None,
+    start_date=datetime.datetime(2021, 10, 15),
+    end_date=datetime.datetime(2021, 10, 15),
+    description='This DAG loads a point forward view of state tables. Caution: Does not capture historical changes!',
+    schedule_interval="@daily",
     user_defined_filters={'fromjson': lambda s: json.loads(s)},
 )
 
 file_names = Variable.get('output_file_names', deserialize_json=True)
 
+'''
+The time task reads in the execution time of the current run, as well as the next
+execution time. It converts these two times into ledger ranges.
+'''
 time_task = build_time_task(dag, use_next_exec_time=False)
 
+'''
+The write batch stats task will take a snapshot of the DAG run_id, execution date, 
+start and end ledgers so that reconciliation and data validation are easier. The 
+record is written to an internal dataset for data eng use only.
+'''
+write_acc_stats = build_batch_stats(dag, 'accounts')
+write_off_stats = build_batch_stats(dag, 'offers')
+write_pool_stats = build_batch_stats(dag, 'liquidity_pools')
+write_trust_stats = build_batch_stats(dag, 'trustlines')
+
+'''
+The export tasks call export commands on the Stellar ETL using the ledger range from the time task.
+The results of the comand are stored in a file. There is one task for each of the data types that 
+can be exported from the history archives.
+
+The DAG sleeps for 30 seconds after the export_task writes to the file to give the poststart.sh
+script time to copy the file over to the correct directory. If there is no sleep, the load task 
+starts prematurely and will not load data.
+'''
 export_acc_task = build_export_task(dag, 'bucket', 'export_accounts', file_names['accounts'])
+export_acc_task.post_execute = lambda **x: time.sleep(60)
 export_off_task = build_export_task(dag, 'bucket', 'export_offers', file_names['offers'])
+export_off_task.post_execute = lambda **x: time.sleep(60)
+export_pool_task = build_export_task(dag, 'bucket', 'export_pools', file_names['liquidity_pools'])
+export_pool_task.post_execute = lambda **x: time.sleep(60)
 export_trust_task = build_export_task(dag, 'bucket', 'export_trustlines', file_names['trustlines'])
+export_trust_task.post_execute = lambda **x: time.sleep(60)
 
 '''
 The load tasks receive the location of the exported file through Airflow's XCOM system.
 Then, the task loads the file into Google Cloud Storage. Finally, the file is deleted
 from local storage.
 '''
-load_acc_task = build_load_task(dag, 'accounts', 'export_accounts_task')
-load_off_task = build_load_task(dag, 'offers', 'export_offers_task')
-load_trust_task = build_load_task(dag, 'trustlines', 'export_trustlines_task')
+load_acc_task = build_load_task(dag, 'accounts', 'export_accounts_task', True)
+load_off_task = build_load_task(dag, 'offers', 'export_offers_task', True)
+load_pool_task = build_load_task(dag, 'liqudity_pools', 'export_pools_task', True)
+load_trust_task = build_load_task(dag, 'trustlines', 'export_trustlines_task', True)
 
 '''
 The apply tasks receive the location of the file in Google Cloud storage through Airflow's XCOM system.
 Then, the task merges the entries in the file with the entries in the corresponding table in BigQuery. 
 Entries are updated, deleted, or inserted as needed.
 '''
-apply_account_changes_task = build_apply_gcs_changes_to_bq_task(dag, 'accounts')
-apply_offer_changes_task = build_apply_gcs_changes_to_bq_task(dag, 'offers')
-apply_trustline_changes_task = build_apply_gcs_changes_to_bq_task(dag, 'trustlines')
+send_acc_to_bq_task = build_gcs_to_bq_task(dag, 'accounts', partition=False)
+send_off_to_bq_task = build_gcs_to_bq_task(dag, 'offers', partition=False)
+send_pool_to_bq_task = build_gcs_to_bq_task(dag, 'liquidity_pools', partition=False)
+send_trust_to_bq_task = build_gcs_to_bq_task(dag, 'trustlines', partition=False)
 
-time_task >> export_acc_task >> load_acc_task >> apply_account_changes_task
-time_task >> export_off_task >> load_off_task >> apply_offer_changes_task
-time_task >> export_trust_task >> load_trust_task >> apply_trustline_changes_task
+time_task >> write_acc_stats >> export_acc_task >> load_acc_task >> send_acc_to_bq_task
+time_task >> write_off_stats >> export_off_task >> load_off_task >> send_off_to_bq_task
+time_task >> write_pool_stats >> export_pool_task >> load_pool_task >> send_pool_to_bq_task
+time_task >> write_trust_stats >> export_trust_task >> load_trust_task >> send_trust_to_bq_task

--- a/dags/stellar_etl_airflow/build_delete_data_task.py
+++ b/dags/stellar_etl_airflow/build_delete_data_task.py
@@ -5,7 +5,7 @@ from airflow.providers.google.cloud.operators.bigquery import BigQueryInsertJobO
 
 def build_delete_data_task(dag, table):
     PROJECT_ID = Variable.get('bq_project')
-    DATASET_ID = 'test_gcp_airflow_internal_partitioned'
+    DATASET_ID = Variable.get('bq_dataset')
     batch_id = '{{ run_id }}'
     batch_date = '{{ prev_execution_date.to_datetime_string() }}'
 

--- a/dags/stellar_etl_airflow/build_export_task.py
+++ b/dags/stellar_etl_airflow/build_export_task.py
@@ -10,7 +10,7 @@ def get_path_variables():
     '''
         Returns the image output path, core executable path, and core config path.
     '''
-    return Variable.get('image_output_path'), '/usr/bin/stellar-core', '/etl/stellar-core.cfg'
+    return Variable.get('image_output_path'), '/usr/bin/stellar-core', '/etl/docker/stellar-core.cfg'
 
 def select_correct_filename(cmd_type, base_name, batched_name):
     switch = {

--- a/dags/stellar_etl_airflow/build_gcs_to_bq_task.py
+++ b/dags/stellar_etl_airflow/build_gcs_to_bq_task.py
@@ -25,11 +25,16 @@ def build_gcs_to_bq_task(dag, data_type, partition):
     dataset_name = Variable.get('bq_dataset')
     table_ids = Variable.get('table_ids', deserialize_json=True)
     prev_task_id = f'load_{data_type}_to_gcs'
-    schema_fields = read_local_schema(f'history_{data_type}')
     time_partition = {}
     if partition: 
         time_partition['type'] = 'MONTH'
         time_partition['field'] = 'batch_run_date'
+
+    if data_type in ['ledgers', 'assets', 'transactions', 'operations', 'trades']:
+        schema_fields = read_local_schema(f'history_{data_type}')
+    else:
+        schema_fields = read_local_schema(f'{data_type}')
+
 
     return GoogleCloudStorageToBigQueryOperator(
         task_id=f'send_{data_type}_to_bq',

--- a/dags/stellar_etl_airflow/build_load_task.py
+++ b/dags/stellar_etl_airflow/build_load_task.py
@@ -111,7 +111,10 @@ def upload_to_gcs(data_type, prev_task_id, batch_stats, **kwargs):
     filename = kwargs['task_instance'].xcom_pull(task_ids=prev_task_id)
     logging.info(type(filename))
     if isinstance(filename, dict):
-        filename = filename["output_file"]
+        if 'start' in filename.keys():
+            filename = f'{filename["start"]}-{filename["start"]+63}-{data_type}.txt'
+        else:
+            filename = filename["output_file"]
     elif isinstance(filename, bytes):
         filename = filename.decode('utf-8')
     logging.info(f'Pulling filename from task {prev_task_id}; result is {filename}')
@@ -173,6 +176,7 @@ def build_load_task(dag, data_type, prev_task_id, batch_stats=False):
             python_callable=upload_to_gcs,
             op_kwargs={'data_type': data_type, 'prev_task_id': prev_task_id, 'batch_stats': batch_stats},
             dag=dag,
+            retries=1,
             provide_context=True,
         )
         

--- a/dags/stellar_etl_airflow/build_load_task.py
+++ b/dags/stellar_etl_airflow/build_load_task.py
@@ -40,6 +40,29 @@ def append_batch_stats(filename, batch_id, batch_date):
             line['batch_insert_ts'] = datetime.now().strftime("%Y-%m-%dT%H:%M:%SZ")
             writer.write(line)
 
+def create_filename(data_type, prev_task_id, **kwargs):
+    '''
+    Creates the filename of the object that will be written to GCS. 
+    Parameters:
+        data_type - type of data to upload; string
+        prev_task_id - the task id of the upstream DAG processing job
+    Returns:
+        string instance of filename
+    '''
+    filename = kwargs['task_instance'].xcom_pull(task_ids=prev_task_id)
+    if isinstance(filename, dict):
+        if 'start' in filename.keys():
+            filename = f'{filename["start"]}-{filename["start"]+63}-{data_type}.txt'
+        else:
+            filename = filename["output_file"]
+    elif isinstance(filename, bytes):
+        filename = filename.decode('utf-8')
+    logging.info(f'Pulling filename from task {prev_task_id}; result is {filename}')
+
+    return filename
+
+
+
 def build_storage_service():
     '''
     Creates a storage service object that uses the credentials specified by the Airflow api_key_path variable.
@@ -108,16 +131,7 @@ def upload_to_gcs(data_type, prev_task_id, batch_stats, **kwargs):
     '''
 
     # when getting the filename from the file sensor tasks, we get a string filename
-    filename = kwargs['task_instance'].xcom_pull(task_ids=prev_task_id)
-    logging.info(type(filename))
-    if isinstance(filename, dict):
-        if 'start' in filename.keys():
-            filename = f'{filename["start"]}-{filename["start"]+63}-{data_type}.txt'
-        else:
-            filename = filename["output_file"]
-    elif isinstance(filename, bytes):
-        filename = filename.decode('utf-8')
-    logging.info(f'Pulling filename from task {prev_task_id}; result is {filename}')
+    filename = create_filename(data_type, prev_task_id, **kwargs)
 
     gcs_filepath = f'exported/{data_type}/{os.path.basename(filename)}'
 


### PR DESCRIPTION
The `liquidity_pools` tables can be populated through either the use of the `bounded_core` DAG or the `bucket_list` DAG (used for initial table hydration). 

