### PR TITLE
Create Bigquery Views

### DIFF
--- a/dags/ddls/create_view.sh
+++ b/dags/ddls/create_view.sh
@@ -1,0 +1,50 @@
+# /bin/bash -e 
+#
+#
+###############################################################################
+# Creates views based on sql files
+#
+# Author: Sydney Wiseman
+# Date: 28 October 2021
+#
+# Will create a view in specified project/dataset location based on a query.
+# All production views should be created through script so that we have 
+# version control and history of the view.
+###############################################################################
+
+WORKDIR="$(pwd)"
+echo "Current working directory: $WORKDIR"
+
+PROJECT_ID=hubble-261722
+DATASET_ID=crypto_stellar_internal_2
+QUERY_DIR=$WORKDIR/queries/
+
+# create view
+view=${1}
+
+if [ -z "${view}" ]; then
+    echo "$0 is a script that creates Views in Bigquery. Missing a parameter!"
+    echo "Please pass a view name that corresponds to a .sql file in /dags/ddls/queries"
+    exit 1
+fi
+
+# read view sql 
+# query=$(<$QUERY_DIR$view.sql)
+query=`cat $QUERY_DIR$view.sql`
+if [ ${#query} <= 0 ]; then
+    echo "$QUERY_DIR$view.sql is empty. Please provide a valid .sql file."
+    exit 1
+fi
+
+# replace the project id and dataset id
+query=${query//"PROJECT"/$PROJECT_ID}
+query=${query//"DATASET"/$DATASET_ID}
+
+echo "Creating view $view in $DATASET_ID"
+bq mk \
+    --use_legacy_sql=false  \
+    --view "$query" \
+    --project_id $PROJECT_ID \
+    $DATASET_ID.$view 
+
+

--- a/dags/ddls/queries/v_liquidity_pool_trade_volume.sql
+++ b/dags/ddls/queries/v_liquidity_pool_trade_volume.sql
@@ -1,3 +1,7 @@
+-- Finds the trade volume of liquidity pools only (No DEX trades)
+-- Prices are stated in base and quote price to make price tracking
+-- easy. Fees are also subtracted from the trade amount and stated as its
+-- own column so that fees and APR can be evaluated.
 WITH trade_volume AS (
     SELECT T.ledger_closed_at, 
         T.selling_liquidity_pool_id, 

--- a/dags/ddls/queries/v_liquidity_pool_trade_volume.sql
+++ b/dags/ddls/queries/v_liquidity_pool_trade_volume.sql
@@ -1,0 +1,38 @@
+WITH trade_volume AS (
+    SELECT T.ledger_closed_at, 
+        T.selling_liquidity_pool_id, 
+        T.selling_asset_code, 
+        T.selling_amount, 
+        T.buying_account_address, 
+        T.buying_asset_code, 
+        T.buying_amount,
+        C.asset_a_code, 
+        C.asset_a_issuer, 
+        C.asset_b_code, 
+        C.asset_b_issuer,
+        C.asset_pair,
+        T.price_n, T.price_d,
+        CASE WHEN T.selling_asset_code = C.asset_b_code THEN T.selling_amount ELSE T.buying_amount END AS trade_amount,
+        1 + (T.liquidity_pool_fee / 10000) AS fee_multiplier
+    FROM `PROJECT.DATASET.history_trades` T
+    JOIN `PROJECT.DATASET.v_liquidity_pools_current` C
+    ON T.selling_liquidity_pool_id = C.liquidity_pool_id
+    )
+SELECT ledger_closed_at, 
+    selling_liquidity_pool_id, 
+    asset_a_code, 
+    asset_a_issuer, 
+    asset_b_code, 
+    asset_b_issuer,
+    asset_pair,
+    selling_asset_code, 
+    selling_amount, 
+    buying_asset_code, 
+    buying_amount,
+    trade_amount - (trade_amount / fee_multiplier) AS fee_earned,
+    trade_amount / fee_multiplier AS trade_amount, 
+    price_n, 
+    price_d,    
+    CASE WHEN selling_asset_code = asset_b_code THEN price_d / price_n ELSE price_n / price_d END AS quote_price,
+    CASE WHEN selling_asset_code = asset_b_code THEN price_n / price_d ELSE price_d / price_n END AS base_price
+FROM trade_volume

--- a/dags/ddls/queries/v_liquidity_pools_current.sql
+++ b/dags/ddls/queries/v_liquidity_pools_current.sql
@@ -1,0 +1,39 @@
+WITH current_lps AS 
+(
+    SELECT LP.liquidity_pool_id, 
+        LP.fee,
+        LP.trustline_count,
+        LP.pool_share_count,
+        CASE WHEN LP.asset_a_type = 'native' THEN CONCAT('XLM:',LP.asset_b_code)  
+            ELSE CONCAT(LP.asset_a_code,':',LP.asset_b_code) END AS asset_pair,
+        LP.asset_a_code, 
+        LP.asset_a_issuer,
+        LP.asset_b_code, 
+        LP.asset_b_issuer,
+        LP.asset_a_amount, 
+        LP.asset_b_amount,
+        LP.last_modified_ledger,
+        L.closed_at,
+        LP.deleted,
+        DENSE_RANK() OVER(PARTITION BY liquidity_pool_id ORDER BY LP.last_modified_ledger DESC) AS rank_number
+    FROM `PROJECT.DATASET.liquidity_pools` LP
+    JOIN `PROJECT.DATASET.history_ledgers` L
+        ON LP.last_modified_ledger = L.sequence
+    )
+SELECT liquidity_pool_id, 
+    fee, 
+    trustline_count, 
+    pool_share_count,
+    asset_pair, 
+    asset_a_code,
+    asset_a_issuer,
+    asset_b_code, 
+    asset_b_issuer, 
+    asset_a_amount, 
+    asset_b_amount,
+    last_modified_ledger, 
+    closed_at,
+    deleted
+FROM current_lps 
+WHERE rank_number = 1
+    

--- a/dags/ddls/queries/v_liquidity_pools_current.sql
+++ b/dags/ddls/queries/v_liquidity_pools_current.sql
@@ -1,9 +1,14 @@
+-- Finds the latest state of each pool in the `liquidity_pool` table.
+-- Ranks each record (grain: pool id) using last modified ledger sequence 
+-- number. View includes all liquidity pools. (Deleted and Existing)
+-- View matches the Horizon snapshotted state tables.
 WITH current_lps AS 
 (
     SELECT LP.liquidity_pool_id, 
         LP.fee,
         LP.trustline_count,
         LP.pool_share_count,
+        -- XLM asset codes are null. Transform to XLM for readibility
         CASE WHEN LP.asset_a_type = 'native' THEN CONCAT('XLM:',LP.asset_b_code)  
             ELSE CONCAT(LP.asset_a_code,':',LP.asset_b_code) END AS asset_pair,
         LP.asset_a_code, 

--- a/dags/ddls/queries/v_liquidity_providers.sql
+++ b/dags/ddls/queries/v_liquidity_providers.sql
@@ -1,3 +1,4 @@
+-- Create a liquidity provider view to track provider positions
 WITH total_providers AS 
 (
     SELECT op.source_account, 
@@ -8,6 +9,7 @@ WITH total_providers AS
     FROM `PROJECT.DATASET.history_operations` op
     JOIN `PROJECT.DATASET.history_transactions` txn
         ON op.transaction_id = txn.id
+    -- Protocol 18 ops are 22 (deposit) and 23 (withdraw)
     WHERE (op.type=22 OR op.type=23)
         AND (txn.successful = true OR txn.successful IS NULL)
     GROUP BY liquidity_pool_id, 
@@ -23,6 +25,7 @@ SELECT A.liquidity_pool_id,
 FROM total_providers A
 JOIN `PROJECT.DATASET.v_liquidity_pools_current` B 
     ON A.liquidity_pool_id = B.liquidity_pool_id
+-- Filter for active pool providers
 WHERE total_shares > 0
 GROUP BY A.liquidity_pool_id, 
     B.asset_pair, 

--- a/dags/ddls/queries/v_liquidity_providers.sql
+++ b/dags/ddls/queries/v_liquidity_providers.sql
@@ -1,0 +1,32 @@
+WITH total_providers AS 
+(
+    SELECT op.source_account, 
+        op.details.liquidity_pool_id AS liquidity_pool_id, 
+        SUM(COALESCE(op.details.shares_received, 0)) AS shares_deposited,
+        SUM(COALESCE(op.details.shares, 0)) AS shares_withdrawn,
+        SUM(COALESCE(op.details.shares_received, 0)) - SUM(COALESCE(op.details.shares, 0)) AS total_shares
+    FROM `PROJECT.DATASET.history_operations` op
+    JOIN `PROJECT.DATASET.history_transactions` txn
+        ON op.transaction_id = txn.id
+    WHERE (op.type=22 OR op.type=23)
+        AND (txn.successful = true OR txn.successful IS NULL)
+    GROUP BY liquidity_pool_id, 
+        op.source_account
+    )
+SELECT A.liquidity_pool_id, 
+    B.asset_pair, 
+    A.source_account AS provider_account,
+    shares_deposited,
+    shares_withdrawn,
+    total_shares, 
+    COUNT(*) count_pool_providers
+FROM total_providers A
+JOIN `PROJECT.DATASET.v_liquidity_pools_current` B 
+    ON A.liquidity_pool_id = B.liquidity_pool_id
+WHERE total_shares > 0
+GROUP BY A.liquidity_pool_id, 
+    B.asset_pair, 
+    A.source_account,
+    shares_deposited,
+    shares_withdrawn,
+    total_shares

--- a/dags/ddls/queries/v_relevant_asset_trades.sql
+++ b/dags/ddls/queries/v_relevant_asset_trades.sql
@@ -1,3 +1,7 @@
+-- View reports trading for relevant assets only
+-- Both AMM and DEX trades are found in the view
+-- and both the buy and sell side of the trade must
+-- be considered relevant to appear 
 WITH find_relevant_sales AS 
 (
     SELECT *

--- a/dags/ddls/queries/v_relevant_asset_trades.sql
+++ b/dags/ddls/queries/v_relevant_asset_trades.sql
@@ -1,0 +1,40 @@
+WITH find_relevant_sales AS 
+(
+    SELECT *
+    FROM `PROJECT.DATASET.history_trades` t
+    LEFT OUTER JOIN `PROJECT.crypto_stellar_internal.meaningful_assets` a
+        ON t.selling_asset_code = a.code
+        AND t.selling_asset_issuer = a.issuer
+        WHERE a.code IS NOT NULL
+            OR t.selling_asset_type = 'native'
+    ),
+find_relevant_buys AS 
+(
+    SELECT history_operation_id, `order`
+    FROM `PROJECT.DATASET.history_trades` t
+    LEFT OUTER JOIN `PROJECT.crypto_stellar_internal.meaningful_assets` a
+    ON t.buying_asset_code = a.code
+    AND t.buying_asset_issuer = a.issuer
+    WHERE a.code IS NOT NULL 
+        OR t.buying_asset_type = 'native'
+    )
+SELECT S.ledger_closed_at, 
+    S.selling_account_address, 
+    S.selling_asset_code, 
+    S.selling_asset_issuer, 
+    S.selling_asset_type,
+    S.selling_amount, 
+    S.buying_account_address, 
+    S.buying_asset_code, 
+    S.buying_asset_issuer, 
+    S.buying_asset_type,
+    S.buying_amount, 
+    S.price_n, 
+    S.price_d, 
+    S.selling_liquidity_pool_id, 
+    S.liquidity_pool_fee,
+CASE WHEN selling_liquidity_pool_id IS NOT NULL THEN 'AMM' ELSE 'DEX' END AS trade_type
+FROM find_relevant_sales S 
+JOIN find_relevant_buys B
+    ON S.history_operation_id = B.history_operation_id
+    AND S.order = B.order

--- a/dags/ddls/queries/v_trust_lines_current.sql
+++ b/dags/ddls/queries/v_trust_lines_current.sql
@@ -1,3 +1,7 @@
+-- Finds the latest state of each trustline in the `trust_lines` table.
+-- Ranks each record (grain: trust line per account per asset) using 
+-- last modified ledger sequence number. View includes all trust lines.
+-- (Deleted and Existing). View matches the Horizon snapshotted state tables.
 WITH current_tls AS 
 (
     SELECT TL.account_id,

--- a/dags/ddls/queries/v_trust_lines_current.sql
+++ b/dags/ddls/queries/v_trust_lines_current.sql
@@ -1,0 +1,51 @@
+WITH current_tls AS 
+(
+    SELECT TL.account_id,
+        TL.asset_code, 
+        TL.asset_issuer, 
+        TL.asset_type,
+        TL.liquidity_pool_id, 
+        TL.balance, 
+        TL.buying_liabilities,
+        TL.selling_liabilities, 
+        TL.flags, 
+        TL.sponsor,
+        TL.trust_line_limit,
+        TL.last_modified_ledger,
+        L.closed_at,
+        TL.deleted,
+        DENSE_RANK() OVER(PARTITION BY TL.account_id, TL.asset_code, TL.asset_issuer, TL.liquidity_pool_id ORDER BY TL.last_modified_ledger DESC) AS rank_number
+    FROM `PROJECT.DATASET.trust_lines` TL
+    JOIN `PROJECT.DATASET.history_ledgers` L
+        ON TL.last_modified_ledger = L.sequence
+    GROUP BY account_id, 
+        asset_code, 
+        asset_issuer, 
+        asset_type,
+        liquidity_pool_id, 
+        balance, 
+        buying_liabilities,
+        selling_liabilities, 
+        flags, 
+        sponsor, 
+        trust_line_limit,
+        last_modified_ledger, 
+        closed_at, 
+        deleted
+    )
+SELECT account_id, 
+    asset_code, 
+    asset_issuer, 
+    asset_type,
+    liquidity_pool_id, 
+    balance, 
+    buying_liabilities, 
+    selling_liabilities,
+    flags, 
+    sponsor, 
+    trust_line_limit, 
+    last_modified_ledger, 
+    closed_at,
+    deleted
+FROM current_tls  
+WHERE rank_number = 1


### PR DESCRIPTION
There are some views defined in Bigquery to make the AMM data easier to use. While there is no release mechanism for views in Bigquery today, the logic should be preserved in version control. When creating and updating a view that should be adopted in `Hubble 2.0`, the view should be:

1. Peer Reviewed by another contributor via PR,
2. Created using the `create_view.sh` script,
3. Documented with SQL logic in the `ddls/queries` folders

With time, we can have the ability to write a Jenkins pipeline to automatically create views in Bigquery and/or migrate views if we select another data platform for `Hubble`