### PR TITLE
Update dags to use --gcs_bucket instead of load tasks

### DIFF
--- a/airflow_variables.txt
+++ b/airflow_variables.txt
@@ -4,6 +4,7 @@
     "bq_dataset": "test_gcp_airflow_internal",
     "bq_project": "test-hubble-319619",
     "gcs_exported_data_bucket_name": "us-central1-internal-airflo-8d08728f-bucket",
+    "gcs_exported_object_prefix": "dag-exported",
     "image_name": "stellar/stellar-etl:latest",
     "image_output_path": "/etl/exported_data/",
     "image_pull_policy": "Always",
@@ -20,6 +21,7 @@
         "dimOffers": "dimOffers.txt",
         "factEvents": "factEvents.txt",
         "ledgers": "ledgers.txt",
+        "liquidity_pools": "liquidity_pools.txt",
         "offers": "offers.txt",
         "operations": "operations.txt",
         "orderbooks": "orderbook_folder",
@@ -38,13 +40,14 @@
     },
     "schema_filepath": "/home/airflow/gcs/dags/schemas/",
     "table_ids": {
-        "accounts": "acccounts",
+        "accounts": "accounts",
         "assets": "history_assets",
         "dimAccounts": "dim_accounts",
         "dimMarkets": "dim_markets",
         "dimOffers": "dim_offers",
         "factEvents": "fact_offer_events",
         "ledgers": "history_ledgers",
+        "liquidity_pools": "liquidity_pools",
         "offers": "offers",
         "operations": "history_operations",
         "trades": "history_trades",
@@ -52,6 +55,7 @@
         "trustlines": "trust_lines"
     },
     "use_kubernetes_pod_exporter": "False",
+    "use_testnet": "False",
     "volume_config": "{}",
     "volume_name": "etl-data"
 }

--- a/airflow_variables.txt
+++ b/airflow_variables.txt
@@ -54,7 +54,6 @@
         "transactions": "history_transactions",
         "trustlines": "trust_lines"
     },
-    "use_kubernetes_pod_exporter": "False",
     "use_testnet": "False",
     "volume_config": "{}",
     "volume_name": "etl-data"

--- a/dags/bounded_core_dag.py
+++ b/dags/bounded_core_dag.py
@@ -1,22 +1,17 @@
 '''
-The bounded_core_export DAG exports ledger entry changes (accounts, offers, and trustlines) within a bounded range using stellar-core. 
-This DAG should be triggered manually if it is required to export entry changes within a specified time range. For consistent updates, use
-the unbounded version.
+The state_table_export DAG exports ledger entry changes (accounts, offers, and trustlines) within a bounded range using stellar-core. 
+This DAG should be triggered manually if it is required to export entry changes within a specified time range. 
 '''
+import ast
+import datetime
 import json
-from time import time
+import logging
 
 from stellar_etl_airflow.build_export_task import build_export_task
 from stellar_etl_airflow.build_time_task import build_time_task
 from stellar_etl_airflow.default import get_default_dag_args
 from stellar_etl_airflow.build_batch_stats import build_batch_stats
 from stellar_etl_airflow.build_gcs_to_bq_task import build_gcs_to_bq_task
-
-import datetime
-import distutils
-import distutils.util
-import logging
-import time
 
 from airflow import DAG
 from airflow.models import Variable
@@ -26,15 +21,15 @@ logger = logging.getLogger('airflow.task')
 logger.setLevel(logging.INFO)
 
 dag = DAG(
-    'bounded_core_export',
+    'state_table_export',
     default_args=get_default_dag_args(),
-    start_date=datetime.datetime(2021, 10, 14),
+    start_date=datetime.datetime(2021, 11, 22, 3),#datetime.datetime(2021, 11, 29, 20),
     description='This DAG runs a bounded stellar-core instance, which allows it to export accounts, offers, liquidity pools, and trustlines to BigQuery.',
     schedule_interval='*/30 * * * *',
     user_defined_filters={'fromjson': lambda s: json.loads(s)},
 )
 
-use_testnet = bool(distutils.util.strtobool(Variable.get("use_testnet")))
+use_testnet = ast.literal_eval(Variable.get("use_testnet"))
 file_names = Variable.get('output_file_names', deserialize_json=True)
 
 date_task = build_time_task(dag)

--- a/dags/bounded_core_dag.py
+++ b/dags/bounded_core_dag.py
@@ -12,26 +12,34 @@ from stellar_etl_airflow.default import get_default_dag_args
 from stellar_etl_airflow.build_batch_stats import build_batch_stats
 from stellar_etl_airflow.build_load_task import build_load_task
 from stellar_etl_airflow.build_gcs_to_bq_task import build_gcs_to_bq_task
+
 import datetime
+import distutils
+import distutils.util
+import logging
 import time
 
 from airflow import DAG
 from airflow.models import Variable
+
+logging.basicConfig(format='%(message)s')
+logger = logging.getLogger('airflow.task')
+logger.setLevel(logging.INFO)
 
 dag = DAG(
     'bounded_core_export',
     default_args=get_default_dag_args(),
     start_date=datetime.datetime(2021, 10, 14),
     description='This DAG runs a bounded stellar-core instance, which allows it to export accounts, offers, liquidity pools, and trustlines to BigQuery.',
-    schedule_interval='*/15 * * * *',
+    schedule_interval='*/30 * * * *',
     user_defined_filters={'fromjson': lambda s: json.loads(s)},
 )
 
-date_task = build_time_task(dag)
-
+use_testnet = bool(distutils.util.strtobool(Variable.get("use_testnet")))
 file_names = Variable.get('output_file_names', deserialize_json=True)
-changes_task = build_export_task(dag, 'bounded-core', 'export_ledger_entry_changes', file_names['changes'])
-changes_task.post_execute = lambda **x: time.sleep(60)
+
+date_task = build_time_task(dag)
+changes_task = build_export_task(dag, 'bounded-core', 'export_ledger_entry_changes', file_names['changes'], use_testnet=use_testnet, use_gcs=True)
 
 '''
 The write batch stats task will take a snapshot of the DAG run_id, execution date, 
@@ -44,30 +52,16 @@ write_pool_stats = build_batch_stats(dag, 'liquidity_pools')
 write_trust_stats = build_batch_stats(dag, 'trust_lines')
 
 '''
-The load tasks receive the location of the exported file through Airflow's XCOM system.
-Then, the task loads the file into Google Cloud Storage. Finally, the file is deleted
-from local storage.
-'''
-load_acc_task = build_load_task(dag, 'accounts', 'get_ledger_range_from_times', True)
-load_acc_task.pre_execute = lambda **x: time.sleep(30)
-load_off_task = build_load_task(dag, 'offers', 'get_ledger_range_from_times', True)
-load_off_task.pre_execute = lambda **x: time.sleep(30)
-load_pool_task = build_load_task(dag, 'liquidity_pools', 'get_ledger_range_from_times', True)
-load_pool_task.pre_execute = lambda **x: time.sleep(30)
-load_trust_task = build_load_task(dag, 'trustlines', 'get_ledger_range_from_times', True)
-load_trust_task.pre_execute = lambda **x: time.sleep(30)
-
-'''
 The apply tasks receive the location of the file in Google Cloud storage through Airflow's XCOM system.
 Then, the task merges the entries in the file with the entries in the corresponding table in BigQuery. 
 Entries are updated, deleted, or inserted as needed.
 '''
-send_acc_to_bq_task = build_gcs_to_bq_task(dag, 'accounts', partition=False)
-send_off_to_bq_task = build_gcs_to_bq_task(dag, 'offers', partition=False)
-send_pool_to_bq_task = build_gcs_to_bq_task(dag, 'liquidity_pools', partition=False)
-send_trust_to_bq_task = build_gcs_to_bq_task(dag, 'trustlines', partition=False)
+send_acc_to_bq_task = build_gcs_to_bq_task(dag, changes_task.task_id, 'accounts', '/*-accounts.txt', partition=False)
+send_off_to_bq_task = build_gcs_to_bq_task(dag, changes_task.task_id, 'offers', '/*-offers.txt', partition=False)
+send_pool_to_bq_task = build_gcs_to_bq_task(dag, changes_task.task_id,'liquidity_pools', '/*-liquidity_pools.txt', partition=False)
+send_trust_to_bq_task = build_gcs_to_bq_task(dag, changes_task.task_id, 'trustlines', '/*-trustlines.txt', partition=False)
 
-date_task >> changes_task >> write_acc_stats >> load_acc_task >> send_acc_to_bq_task
-date_task >> changes_task >> write_off_stats >> load_off_task >> send_off_to_bq_task
-date_task >> changes_task >> write_pool_stats >> load_pool_task >> send_pool_to_bq_task
-date_task >> changes_task >> write_trust_stats >> load_trust_task >> send_trust_to_bq_task
+date_task >> changes_task >> write_acc_stats >> send_acc_to_bq_task
+date_task >> changes_task >> write_off_stats >> send_off_to_bq_task
+date_task >> changes_task >> write_pool_stats >> send_pool_to_bq_task
+date_task >> changes_task >> write_trust_stats >> send_trust_to_bq_task

--- a/dags/bounded_core_dag.py
+++ b/dags/bounded_core_dag.py
@@ -10,7 +10,6 @@ from stellar_etl_airflow.build_export_task import build_export_task
 from stellar_etl_airflow.build_time_task import build_time_task
 from stellar_etl_airflow.default import get_default_dag_args
 from stellar_etl_airflow.build_batch_stats import build_batch_stats
-from stellar_etl_airflow.build_load_task import build_load_task
 from stellar_etl_airflow.build_gcs_to_bq_task import build_gcs_to_bq_task
 
 import datetime

--- a/dags/bucket_list_dag.py
+++ b/dags/bucket_list_dag.py
@@ -7,7 +7,6 @@ when initializing the tables in order to catch up to the current state in the ne
 import json
 from stellar_etl_airflow.build_export_task import build_export_task
 from stellar_etl_airflow.build_time_task import build_time_task
-from stellar_etl_airflow.build_load_task import build_load_task
 from stellar_etl_airflow.build_batch_stats import build_batch_stats
 from stellar_etl_airflow.default import get_default_dag_args
 from stellar_etl_airflow.build_gcs_to_bq_task import build_gcs_to_bq_task

--- a/dags/bucket_list_dag.py
+++ b/dags/bucket_list_dag.py
@@ -11,8 +11,10 @@ from stellar_etl_airflow.build_load_task import build_load_task
 from stellar_etl_airflow.build_batch_stats import build_batch_stats
 from stellar_etl_airflow.default import get_default_dag_args
 from stellar_etl_airflow.build_gcs_to_bq_task import build_gcs_to_bq_task
-import time
 import datetime
+import distutils
+import distutils.util
+import time
 
 from airflow import DAG
 from airflow.models import Variable
@@ -21,13 +23,13 @@ dag = DAG(
     'bucket_list_export',
     default_args=get_default_dag_args(),
     start_date=datetime.datetime(2021, 10, 15),
-    end_date=datetime.datetime(2021, 10, 15),
     description='This DAG loads a point forward view of state tables. Caution: Does not capture historical changes!',
-    schedule_interval="@daily",
+    schedule_interval='@daily',
     user_defined_filters={'fromjson': lambda s: json.loads(s)},
 )
 
 file_names = Variable.get('output_file_names', deserialize_json=True)
+use_testnet = bool(distutils.util.strtobool(Variable.get("use_testnet")))
 
 '''
 The time task reads in the execution time of the current run, as well as the next
@@ -47,43 +49,24 @@ write_trust_stats = build_batch_stats(dag, 'trustlines')
 
 '''
 The export tasks call export commands on the Stellar ETL using the ledger range from the time task.
-The results of the comand are stored in a file. There is one task for each of the data types that 
-can be exported from the history archives.
-
-The DAG sleeps for 30 seconds after the export_task writes to the file to give the poststart.sh
-script time to copy the file over to the correct directory. If there is no sleep, the load task 
-starts prematurely and will not load data.
+The results of the comand are uploaded to GCS. The location is returned through XCOM.
 '''
-export_acc_task = build_export_task(dag, 'bucket', 'export_accounts', file_names['accounts'])
-export_acc_task.post_execute = lambda **x: time.sleep(60)
-export_off_task = build_export_task(dag, 'bucket', 'export_offers', file_names['offers'])
-export_off_task.post_execute = lambda **x: time.sleep(60)
-export_pool_task = build_export_task(dag, 'bucket', 'export_pools', file_names['liquidity_pools'])
-export_pool_task.post_execute = lambda **x: time.sleep(60)
-export_trust_task = build_export_task(dag, 'bucket', 'export_trustlines', file_names['trustlines'])
-export_trust_task.post_execute = lambda **x: time.sleep(60)
-
-'''
-The load tasks receive the location of the exported file through Airflow's XCOM system.
-Then, the task loads the file into Google Cloud Storage. Finally, the file is deleted
-from local storage.
-'''
-load_acc_task = build_load_task(dag, 'accounts', 'export_accounts_task', True)
-load_off_task = build_load_task(dag, 'offers', 'export_offers_task', True)
-load_pool_task = build_load_task(dag, 'liqudity_pools', 'export_pools_task', True)
-load_trust_task = build_load_task(dag, 'trustlines', 'export_trustlines_task', True)
+export_acc_task = build_export_task(dag, 'bucket', 'export_accounts', file_names['accounts'], use_testnet=use_testnet, use_gcs=True)
+export_off_task = build_export_task(dag, 'bucket', 'export_offers', file_names['offers'], use_testnet=use_testnet, use_gcs=True)
+export_pool_task = build_export_task(dag, 'bucket', 'export_pools', file_names['liquidity_pools'], use_testnet=use_testnet, use_gcs=True)
+export_trust_task = build_export_task(dag, 'bucket', 'export_trustlines', file_names['trustlines'], use_testnet=use_testnet, use_gcs=True)
 
 '''
 The apply tasks receive the location of the file in Google Cloud storage through Airflow's XCOM system.
 Then, the task merges the entries in the file with the entries in the corresponding table in BigQuery. 
 Entries are updated, deleted, or inserted as needed.
 '''
-send_acc_to_bq_task = build_gcs_to_bq_task(dag, 'accounts', partition=False)
-send_off_to_bq_task = build_gcs_to_bq_task(dag, 'offers', partition=False)
-send_pool_to_bq_task = build_gcs_to_bq_task(dag, 'liquidity_pools', partition=False)
-send_trust_to_bq_task = build_gcs_to_bq_task(dag, 'trustlines', partition=False)
+send_acc_to_bq_task = build_gcs_to_bq_task(dag, export_acc_task.task_id, 'accounts', '', partition=False)
+send_off_to_bq_task = build_gcs_to_bq_task(dag, export_off_task.task_id, 'offers', '', partition=False)
+send_pool_to_bq_task = build_gcs_to_bq_task(dag, export_pool_task.task_id, 'liquidity_pools', '', partition=False)
+send_trust_to_bq_task = build_gcs_to_bq_task(dag, export_trust_task.task_id, 'trustlines', '',  partition=False)
 
-time_task >> write_acc_stats >> export_acc_task >> load_acc_task >> send_acc_to_bq_task
-time_task >> write_off_stats >> export_off_task >> load_off_task >> send_off_to_bq_task
-time_task >> write_pool_stats >> export_pool_task >> load_pool_task >> send_pool_to_bq_task
-time_task >> write_trust_stats >> export_trust_task >> load_trust_task >> send_trust_to_bq_task
+time_task >> write_acc_stats >> export_acc_task >> send_acc_to_bq_task
+time_task >> write_off_stats >> export_off_task >> send_off_to_bq_task
+time_task >> write_pool_stats >> export_pool_task >> send_pool_to_bq_task
+time_task >> write_trust_stats >> export_trust_task >> send_trust_to_bq_task

--- a/dags/bucket_list_dag.py
+++ b/dags/bucket_list_dag.py
@@ -4,16 +4,16 @@ bucket list. As a result, it is faster than stellar-core. Bucket list commands r
 to stop exporting. This end ledger  is determined by when the Airflow DAG is run. This DAG should be triggered manually 
 when initializing the tables in order to catch up to the current state in the network, but should not be scheduled to run constantly.
 '''
+import ast
+import datetime
 import json
+import time
+
 from stellar_etl_airflow.build_export_task import build_export_task
 from stellar_etl_airflow.build_time_task import build_time_task
 from stellar_etl_airflow.build_batch_stats import build_batch_stats
 from stellar_etl_airflow.default import get_default_dag_args
 from stellar_etl_airflow.build_gcs_to_bq_task import build_gcs_to_bq_task
-import datetime
-import distutils
-import distutils.util
-import time
 
 from airflow import DAG
 from airflow.models import Variable
@@ -22,13 +22,14 @@ dag = DAG(
     'bucket_list_export',
     default_args=get_default_dag_args(),
     start_date=datetime.datetime(2021, 10, 15),
+    end_date=datetime.datetime(2021, 10, 15),
     description='This DAG loads a point forward view of state tables. Caution: Does not capture historical changes!',
     schedule_interval='@daily',
     user_defined_filters={'fromjson': lambda s: json.loads(s)},
 )
 
 file_names = Variable.get('output_file_names', deserialize_json=True)
-use_testnet = bool(distutils.util.strtobool(Variable.get("use_testnet")))
+use_testnet = ast.literal_eval(Variable.get("use_testnet"))
 
 '''
 The time task reads in the execution time of the current run, as well as the next

--- a/dags/history_archive_dag.py
+++ b/dags/history_archive_dag.py
@@ -3,6 +3,8 @@ The history_archive_export DAG exports ledgers, transactions, operations, and tr
 It is scheduled to export information to BigQuery every 5 minutes. 
 '''
 import datetime
+import distutils
+import distutils.util
 import json
 import time
 from stellar_etl_airflow.build_export_task import build_export_task
@@ -20,12 +22,14 @@ from airflow.models import Variable
 dag = DAG(
     'history_archive_export',
     default_args=get_default_dag_args(),
+    start_date=datetime.datetime(2021, 11, 18),
     description='This DAG exports ledgers, transactions, operations, and trades from the history archive to BigQuery.',
-    schedule_interval="0 */3 * * *",
+    schedule_interval='*/6 * * * *',
     user_defined_filters={'fromjson': lambda s: json.loads(s)},
 )
 
 file_names = Variable.get('output_file_names', deserialize_json=True)
+use_testnet = bool(distutils.util.strtobool(Variable.get("use_testnet")))
 
 '''
 The time task reads in the execution time of the current run, as well as the next
@@ -53,27 +57,11 @@ The DAG sleeps for 30 seconds after the export_task writes to the file to give t
 script time to copy the file over to the correct directory. If there is no sleep, the load task 
 starts prematurely and will not load data.
 '''
-ledger_export_task = build_export_task(dag, 'archive', 'export_ledgers', file_names['ledgers'])
-ledger_export_task.post_execute = lambda **x: time.sleep(30)
-tx_export_task = build_export_task(dag, 'archive', 'export_transactions', file_names['transactions'])
-tx_export_task.post_execute = lambda **x: time.sleep(30)
-op_export_task = build_export_task(dag, 'archive', 'export_operations', file_names['operations'])
-op_export_task.post_execute = lambda **x: time.sleep(30)
-trade_export_task = build_export_task(dag, 'archive', 'export_trades', file_names['trades'])
-trade_export_task.post_execute = lambda **x: time.sleep(30)
-asset_export_task = build_export_task(dag, 'archive', 'export_assets', file_names['assets'])
-asset_export_task.post_execute = lambda **x: time.sleep(30)
-
-'''
-The load tasks receive the location of the exported file through Airflow's XCOM system.
-Then, the task loads the file into Google Cloud Storage. Finally, the file is deleted
-from local storage.
-'''
-load_ledger_task = build_load_task(dag, 'ledgers', 'export_ledgers_task', True)
-load_tx_task = build_load_task(dag, 'transactions', 'export_transactions_task', True)
-load_op_task = build_load_task(dag, 'operations', 'export_operations_task', True)
-load_trade_task = build_load_task(dag, 'trades', 'export_trades_task', True)
-load_asset_task = build_load_task(dag, 'assets', 'export_assets_task', True)
+ledger_export_task = build_export_task(dag, 'archive', 'export_ledgers', file_names['ledgers'], use_testnet=use_testnet, use_gcs=True)
+tx_export_task = build_export_task(dag, 'archive', 'export_transactions', file_names['transactions'], use_testnet=use_testnet, use_gcs=True)
+op_export_task = build_export_task(dag, 'archive', 'export_operations', file_names['operations'], use_testnet=use_testnet, use_gcs=True)
+trade_export_task = build_export_task(dag, 'archive', 'export_trades', file_names['trades'], use_testnet=use_testnet, use_gcs=True)
+asset_export_task = build_export_task(dag, 'archive', 'export_assets', file_names['assets'], use_testnet=use_testnet, use_gcs=True)
 
 '''
 The delete partition task checks to see if the given partition/batch id exists in 
@@ -89,14 +77,14 @@ delete_old_asset_task = build_delete_data_task(dag, 'history_assets')
 The send tasks receive the location of the file in Google Cloud storage through Airflow's XCOM system.
 Then, the task merges the unique entries in the file into the corresponding table in BigQuery. 
 '''
-send_ledgers_to_bq_task = build_gcs_to_bq_task(dag, 'ledgers', partition=True)
-send_txs_to_bq_task = build_gcs_to_bq_task(dag, 'transactions', partition=True)
-send_ops_to_bq_task = build_gcs_to_bq_task(dag, 'operations', partition=True)
-send_trades_to_bq_task = build_gcs_to_bq_task(dag, 'trades', partition=False)
-send_assets_to_bq_task = build_gcs_to_bq_task(dag, 'assets', partition=False)
-
-time_task >> write_ledger_stats >> ledger_export_task >> load_ledger_task >> delete_old_ledger_task >> send_ledgers_to_bq_task
-time_task >> write_tx_stats >> tx_export_task >> load_tx_task  >> delete_old_tx_task >>send_txs_to_bq_task
-time_task >> write_op_stats >> op_export_task >> load_op_task  >> delete_old_op_task >>send_ops_to_bq_task
-time_task >> write_trade_stats >> trade_export_task >> load_trade_task  >> delete_old_trade_task >>send_trades_to_bq_task
-time_task >> write_asset_stats >> asset_export_task >> load_asset_task  >> delete_old_asset_task >>send_assets_to_bq_task
+send_ledgers_to_bq_task = build_gcs_to_bq_task(dag, ledger_export_task.task_id, 'ledgers', '', partition=True)
+send_txs_to_bq_task = build_gcs_to_bq_task(dag, tx_export_task.task_id, 'transactions', '', partition=True)
+send_ops_to_bq_task = build_gcs_to_bq_task(dag, op_export_task.task_id, 'operations', '', partition=True)
+send_trades_to_bq_task = build_gcs_to_bq_task(dag, trade_export_task.task_id, 'trades', '', partition=False)
+send_assets_to_bq_task = build_gcs_to_bq_task(dag, asset_export_task.task_id, 'assets', '', partition=False)
+ 
+time_task >> write_ledger_stats >> ledger_export_task >> delete_old_ledger_task >> send_ledgers_to_bq_task
+time_task >> write_tx_stats >> tx_export_task >> delete_old_tx_task >> send_txs_to_bq_task
+time_task >> write_op_stats >> op_export_task >> delete_old_op_task >> send_ops_to_bq_task
+time_task >> write_trade_stats >> trade_export_task  >> delete_old_trade_task >> send_trades_to_bq_task
+time_task >> write_asset_stats >> asset_export_task  >> delete_old_asset_task >> send_assets_to_bq_task

--- a/dags/history_archive_dag.py
+++ b/dags/history_archive_dag.py
@@ -1,12 +1,11 @@
 '''
-The history_archive_export DAG exports ledgers, transactions, operations, and trades from the history archives. 
-It is scheduled to export information to BigQuery every 5 minutes. 
+The history_archive_export DAG exports ledgers and transactions from the history archives. 
+It is scheduled to export information to BigQuery at regular intervals.
 '''
+import ast
 import datetime
-import distutils
-import distutils.util
 import json
-import time
+
 from stellar_etl_airflow.build_export_task import build_export_task
 from stellar_etl_airflow.build_time_task import build_time_task
 from stellar_etl_airflow.default import get_default_dag_args
@@ -19,16 +18,16 @@ from airflow.models import Variable
 
 
 dag = DAG(
-    'history_archive_export',
+    'history_archive_without_captive_core',
     default_args=get_default_dag_args(),
-    start_date=datetime.datetime(2021, 11, 18),
+    start_date=datetime.datetime(2021, 11, 29, 21),
     description='This DAG exports ledgers, transactions, and assets from the history archive to BigQuery. Incremental Loads',
     schedule_interval='*/6 * * * *',
     user_defined_filters={'fromjson': lambda s: json.loads(s)},
 )
 
 file_names = Variable.get('output_file_names', deserialize_json=True)
-use_testnet = bool(distutils.util.strtobool(Variable.get("use_testnet")))
+use_testnet = ast.literal_eval(Variable.get("use_testnet"))
 
 '''
 The time task reads in the execution time of the current run, as well as the next

--- a/dags/history_archive_with_captive_core_dag.py
+++ b/dags/history_archive_with_captive_core_dag.py
@@ -20,7 +20,7 @@ from airflow.models import Variable
 dag = DAG(
     'history_archive_with_captive_core',
     default_args=get_default_dag_args(),
-    start_date=datetime.datetime(2021, 11, 29, 21),
+    start_date=datetime.datetime(2021, 11, 29, 22),
     description='This DAG exports trades and operations from the history archive using CaptiveCore. This supports parsing sponsorship and AMMs.',
     schedule_interval='*/30 * * * *',
     user_defined_filters={'fromjson': lambda s: json.loads(s)},

--- a/dags/history_archive_with_captive_core_dag.py
+++ b/dags/history_archive_with_captive_core_dag.py
@@ -19,11 +19,11 @@ from airflow.models import Variable
 
 
 dag = DAG(
-    'history_archive_export',
+    'history_archive_export_with_captive_core',
     default_args=get_default_dag_args(),
-    start_date=datetime.datetime(2021, 11, 18),
-    description='This DAG exports ledgers, transactions, and assets from the history archive to BigQuery. Incremental Loads',
-    schedule_interval='*/6 * * * *',
+    start_date=datetime.datetime(2021, 10, 14),
+    description='This DAG exports trades and operations from the history archive using CaptiveCore. This supports parsing sponsorship and AMMs.',
+    schedule_interval='*/30 * * * *',
     user_defined_filters={'fromjson': lambda s: json.loads(s)},
 )
 
@@ -41,9 +41,8 @@ The write batch stats task will take a snapshot of the DAG run_id, execution dat
 start and end ledgers so that reconciliation and data validation are easier. The 
 record is written to an internal dataset for data eng use only.
 '''
-write_ledger_stats = build_batch_stats(dag, 'history_ledgers')
-write_tx_stats = build_batch_stats(dag, 'history_transactions')
-write_asset_stats = build_batch_stats(dag, 'history_assets')
+write_op_stats = build_batch_stats(dag, 'history_operations')
+write_trade_stats = build_batch_stats(dag, 'history_trades')
 
 '''
 The export tasks call export commands on the Stellar ETL using the ledger range from the time task.
@@ -54,26 +53,22 @@ The DAG sleeps for 30 seconds after the export_task writes to the file to give t
 script time to copy the file over to the correct directory. If there is no sleep, the load task 
 starts prematurely and will not load data.
 '''
-ledger_export_task = build_export_task(dag, 'archive', 'export_ledgers', file_names['ledgers'], use_testnet=use_testnet, use_gcs=True)
-tx_export_task = build_export_task(dag, 'archive', 'export_transactions', file_names['transactions'], use_testnet=use_testnet, use_gcs=True)
-asset_export_task = build_export_task(dag, 'archive', 'export_assets', file_names['assets'], use_testnet=use_testnet, use_gcs=True)
+op_export_task = build_export_task(dag, 'archive', 'export_operations', file_names['operations'], use_testnet=use_testnet, use_gcs=True)
+trade_export_task = build_export_task(dag, 'archive', 'export_trades', file_names['trades'], use_testnet=use_testnet, use_gcs=True)
 
 '''
 The delete partition task checks to see if the given partition/batch id exists in 
 Bigquery. If it does, the records are deleted prior to reinserting the batch.
 '''
-delete_old_ledger_task = build_delete_data_task(dag, 'history_ledgers')
-delete_old_tx_task = build_delete_data_task(dag, 'history_transactions')
-delete_old_asset_task = build_delete_data_task(dag, 'history_assets')
+delete_old_op_task = build_delete_data_task(dag, 'history_operations')
+delete_old_trade_task = build_delete_data_task(dag, 'history_trades')
 
 '''
 The send tasks receive the location of the file in Google Cloud storage through Airflow's XCOM system.
 Then, the task merges the unique entries in the file into the corresponding table in BigQuery. 
 '''
-send_ledgers_to_bq_task = build_gcs_to_bq_task(dag, ledger_export_task.task_id, 'ledgers', '', partition=True)
-send_txs_to_bq_task = build_gcs_to_bq_task(dag, tx_export_task.task_id, 'transactions', '', partition=True)
-send_assets_to_bq_task = build_gcs_to_bq_task(dag, asset_export_task.task_id, 'assets', '', partition=False)
+send_ops_to_bq_task = build_gcs_to_bq_task(dag, op_export_task.task_id, 'operations', '', partition=True)
+send_trades_to_bq_task = build_gcs_to_bq_task(dag, trade_export_task.task_id, 'trades', '', partition=False)
  
-time_task >> write_ledger_stats >> ledger_export_task >> delete_old_ledger_task >> send_ledgers_to_bq_task
-time_task >> write_tx_stats >> tx_export_task >> delete_old_tx_task >> send_txs_to_bq_task
-time_task >> write_asset_stats >> asset_export_task  >> delete_old_asset_task >> send_assets_to_bq_task
+time_task >> write_op_stats >> op_export_task >> delete_old_op_task >> send_ops_to_bq_task
+time_task >> write_trade_stats >> trade_export_task  >> delete_old_trade_task >> send_trades_to_bq_task

--- a/dags/history_archive_with_captive_core_dag.py
+++ b/dags/history_archive_with_captive_core_dag.py
@@ -1,12 +1,11 @@
 '''
-The history_archive_export DAG exports ledgers, transactions, operations, and trades from the history archives. 
-It is scheduled to export information to BigQuery every 5 minutes. 
+The history_archive_export DAG exports operations and trades from the history archives. 
+It is scheduled to export information to BigQuery at regular intervals.
 '''
+import ast
 import datetime
-import distutils
-import distutils.util
 import json
-import time
+
 from stellar_etl_airflow.build_export_task import build_export_task
 from stellar_etl_airflow.build_time_task import build_time_task
 from stellar_etl_airflow.default import get_default_dag_args
@@ -19,16 +18,16 @@ from airflow.models import Variable
 
 
 dag = DAG(
-    'history_archive_export_with_captive_core',
+    'history_archive_with_captive_core',
     default_args=get_default_dag_args(),
-    start_date=datetime.datetime(2021, 10, 14),
+    start_date=datetime.datetime(2021, 11, 29, 21),
     description='This DAG exports trades and operations from the history archive using CaptiveCore. This supports parsing sponsorship and AMMs.',
     schedule_interval='*/30 * * * *',
     user_defined_filters={'fromjson': lambda s: json.loads(s)},
 )
 
 file_names = Variable.get('output_file_names', deserialize_json=True)
-use_testnet = bool(distutils.util.strtobool(Variable.get("use_testnet")))
+use_testnet = ast.literal_eval(Variable.get("use_testnet"))
 
 '''
 The time task reads in the execution time of the current run, as well as the next

--- a/dags/history_archive_without_captive_core_dag.py
+++ b/dags/history_archive_without_captive_core_dag.py
@@ -20,7 +20,7 @@ from airflow.models import Variable
 dag = DAG(
     'history_archive_without_captive_core',
     default_args=get_default_dag_args(),
-    start_date=datetime.datetime(2021, 11, 29, 21),
+    start_date=datetime.datetime(2021, 11, 29, 22, 30),
     description='This DAG exports ledgers, transactions, and assets from the history archive to BigQuery. Incremental Loads',
     schedule_interval='*/6 * * * *',
     user_defined_filters={'fromjson': lambda s: json.loads(s)},

--- a/dags/state_table_dag.py
+++ b/dags/state_table_dag.py
@@ -23,7 +23,7 @@ logger.setLevel(logging.INFO)
 dag = DAG(
     'state_table_export',
     default_args=get_default_dag_args(),
-    start_date=datetime.datetime(2021, 11, 22, 3),#datetime.datetime(2021, 11, 29, 20),
+    start_date=datetime.datetime(2021, 11, 29, 22, 30),
     description='This DAG runs a bounded stellar-core instance, which allows it to export accounts, offers, liquidity pools, and trustlines to BigQuery.',
     schedule_interval='*/30 * * * *',
     user_defined_filters={'fromjson': lambda s: json.loads(s)},

--- a/dags/stellar_etl_airflow/build_export_task.py
+++ b/dags/stellar_etl_airflow/build_export_task.py
@@ -84,7 +84,7 @@ def generate_etl_cmd(command, base_filename, cmd_type, use_gcs=False, use_testne
         cmd.extend(['--gcs-bucket', Variable.get('gcs_exported_data_bucket_name')])
         batch_date = '{{ prev_execution_date.to_datetime_string() }}'
         batch_insert_ts = datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%SZ")
-        metadata = f'batch_id={run_id},batch_run_date={batch_date},batch_insert_ts={batch_insert_ts}'
+        metadata = f"'batch_id={run_id},batch_run_date={batch_date},batch_insert_ts={batch_insert_ts}'"
         cmd.extend(['-u', metadata])
     if use_testnet:
         cmd.append('--testnet')


### PR DESCRIPTION
This PR considers 4 DAGS:

* `history_archives` (without CaptiveCore)
* `history_archives_with_captive_core`: `history_trades` and `history_operations` split into its own DAG
* `bounded_captive_core` for state tables 
* `bucket_list` -- @sydneynotthecity: how is this used? is this different from `bounded_captive_core`?

This change requires giving GCS permissions to `471979297599-compute@developer.gserviceaccount.com` for the GCS destination. I won't do this now so as not to disturb prod, but this will need to happen when it's rolled out.
