### PR TITLE
Increase max bad records allowed in BQ

### DIFF
--- a/dags/stellar_etl_airflow/build_gcs_to_bq_task.py
+++ b/dags/stellar_etl_airflow/build_gcs_to_bq_task.py
@@ -47,6 +47,7 @@ def build_gcs_to_bq_task(dag, export_task_id, data_type, source_object_suffix, p
         destination_project_dataset_table=f'{project_name}.{dataset_name}.{table_ids[data_type]}',
         write_disposition='WRITE_APPEND',
         create_disposition='CREATE_IF_NEEDED',
+        max_bad_records=10,
         time_partitioning=time_partition,
         dag=dag,
     )


### PR DESCRIPTION
There is a [bug](https://github.com/stellar/hubble/issues/230) in the current `history_operations` table that will need to be fixed. Currently, any `*_muxed_id` field is defined as an `INTEGER`, but the id can be longer than the max integer. 

As a workaround, we are increasing the `MAX_BAD_RECORDS` to 10 records per batch. It is better to ignore the bad record and insert the remaining records in the batch than to reject the entire batch of records. 