### PR TITLE
Split out dev and prod env vars and tag image version

### DIFF
--- a/airflow_variables_dev.txt
+++ b/airflow_variables_dev.txt
@@ -1,9 +1,9 @@
 {
     "affinity": "{}",
     "api_key_path": "/home/airflow/gcs/data/apiKey.json",
-    "bq_dataset": "crypto_stellar_internal_2",
-    "bq_project": "hubble-261722",
-    "gcs_exported_data_bucket_name": "us-central1-bounded-captive-1c4f324d-bucket",
+    "bq_dataset": "test_gcp_airflow_internal",
+    "bq_project": "test-hubble-319619",
+    "gcs_exported_data_bucket_name": "us-central1-internal-airflo-8d08728f-bucket",
     "gcs_exported_object_prefix": "dag-exported",
     "image_name": "stellar/stellar-etl:03f28fd",
     "image_output_path": "/etl/exported_data/",
@@ -52,7 +52,7 @@
         "transactions": "history_transactions",
         "trustlines": "trust_lines"
     },
-    "use_testnet": "False",
+    "use_testnet": "True",
     "volume_config": "{}",
     "volume_name": "etl-data"
 }


### PR DESCRIPTION
Tag images with a unique tag when built, set hubble to reference a pinned image.