### PR TITLE
Update Kube Settings

### DIFF
--- a/airflow_variables.txt
+++ b/airflow_variables.txt
@@ -34,11 +34,10 @@
     "output_path": "/home/airflow/gcs/data/",
     "owner": "SDF",
     "resources": {
-        "request_memory": "64Mi",
-        "limit_memory": "3Gi",
-        "request_cpu": "50m",
-        "limit_cpu": "0.5",
-        "limit_ephemeral_storage": "2Gi"
+        "request_memory": "5Gi",
+        "limit_memory": "15Gi",
+        "request_cpu": "1.2",
+        "limit_ephemeral_storage": "12Gi"
     },
     "schema_filepath": "/home/airflow/gcs/dags/schemas/",
     "table_ids": {

--- a/airflow_variables_dev.txt
+++ b/airflow_variables_dev.txt
@@ -34,11 +34,10 @@
     "output_path": "/home/airflow/gcs/data/",
     "owner": "SDF",
     "resources": {
-        "request_memory": "64Mi",
-        "limit_memory": "3Gi",
-        "request_cpu": "50m",
-        "limit_cpu": "0.5",
-        "limit_ephemeral_storage": "2Gi"
+        "request_memory": "5Gi",
+        "limit_memory": "15Gi",
+        "request_cpu": "1.2",
+        "limit_ephemeral_storage": "12Gi"
     },
     "schema_filepath": "/home/airflow/gcs/dags/schemas/",
     "table_ids": {

--- a/dags/stellar_etl_airflow/build_export_task.py
+++ b/dags/stellar_etl_airflow/build_export_task.py
@@ -1,6 +1,7 @@
 '''
 This file contains functions for creating Airflow tasks to run stellar-etl export functions.
 '''
+import ast
 import datetime
 import logging
 import os
@@ -120,6 +121,8 @@ def build_export_task(dag, cmd_type, command, filename, use_gcs=False, use_testn
         dag=dag,
         do_xcom_push=True,
         is_delete_operator_pod=True,
+        startup_timeout_seconds=720,
+        resources=ast.literal_eval(Variable.get('resources')),
         in_cluster=in_cluster,
         config_file=config_file_location,
         affinity=Variable.get('affinity', deserialize_json=True),

--- a/dags/stellar_etl_airflow/build_time_task.py
+++ b/dags/stellar_etl_airflow/build_time_task.py
@@ -1,6 +1,7 @@
 '''
 This file contains functions for creating Airflow tasks to convert from a time range to a ledger range.
 '''
+import ast
 
 from airflow.contrib.operators.kubernetes_pod_operator import KubernetesPodOperator 
 from airflow.models import Variable
@@ -38,6 +39,8 @@ def build_time_task(dag, use_testnet=False, use_next_exec_time=True):
          dag=dag,
          do_xcom_push=True,
          is_delete_operator_pod=True,
+         startup_timeout_seconds=720,
+         resources=ast.literal_eval(Variable.get('resources')),
          in_cluster=in_cluster,
          config_file=config_file_location,
          affinity=Variable.get('affinity', deserialize_json=True),


### PR DESCRIPTION
The `KubernetesPodOperator` will now pull the resources for kube pods from the `airflow.txt` resources parameter. Pods should be bigger to accommodate the CaptiveCore size.