### PR TITLE
Add affinity for kube operators

### DIFF
--- a/airflow_variables.txt
+++ b/airflow_variables.txt
@@ -1,5 +1,17 @@
 {
-    "affinity": "{}",
+    "affinity": {
+        "nodeAffinity": { 
+            "requiredDuringSchedulingIgnoredDuringExecution": { 
+                "nodeSelectorTerms": [{ 
+                    "matchExpressions": [{ 
+                        "key": "cloud.google.com/gke-nodepool", 
+                        "operator": "In", 
+                        "values": ["hubble-etl"] 
+                        }] 
+                    }] 
+                } 
+            } 
+        },
     "api_key_path": "/home/airflow/gcs/data/apiKey.json",
     "bq_dataset": "crypto_stellar_internal_2",
     "bq_project": "hubble-261722",

--- a/airflow_variables_dev.txt
+++ b/airflow_variables_dev.txt
@@ -1,5 +1,17 @@
 {
-    "affinity": "{}",
+    "affinity": {
+        "nodeAffinity": { 
+            "requiredDuringSchedulingIgnoredDuringExecution": { 
+                "nodeSelectorTerms": [{ 
+                    "matchExpressions": [{ 
+                        "key": "cloud.google.com/gke-nodepool", 
+                        "operator": "In", 
+                        "values": ["hubble-etl-dev"] 
+                        }] 
+                    }] 
+                } 
+            } 
+        },
     "api_key_path": "/home/airflow/gcs/data/apiKey.json",
     "bq_dataset": "test_gcp_airflow_internal",
     "bq_project": "test-hubble-319619",


### PR DESCRIPTION
The airflow scheduler was experiencing resource starvation because CaptiveCore tasks were executing on the same pods that the scheduler was. The PR adds node pools so that process intensive tasks execute separate from Airflow infrastructure.