### PR TITLE
Update schemas to add sponsorship

### DIFF
--- a/schemas/accounts_schema.json
+++ b/schemas/accounts_schema.json
@@ -93,5 +93,20 @@
     "mode": "NULLABLE",
     "name": "batch_insert_ts",
     "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "sponsor",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "num_sponsored",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "num_sponsoring",
+    "type": "INTEGER"
   }
 ]

--- a/schemas/offers_schema.json
+++ b/schemas/offers_schema.json
@@ -11,13 +11,33 @@
   },
   {
     "mode": "NULLABLE",
-    "name": "selling_asset",
-    "type": "FLOAT"
+    "name": "selling_asset_type",
+    "type": "STRING"
   },
   {
     "mode": "NULLABLE",
-    "name": "buying_asset",
-    "type": "FLOAT"
+    "name": "selling_asset_code",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "selling_asset_issuer",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "buying_asset_type",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "buying_asset_code",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "buying_asset_issuer",
+    "type": "STRING"
   },
   {
     "mode": "NULLABLE",
@@ -58,6 +78,11 @@
     "mode": "NULLABLE",
     "name": "deleted",
     "type": "BOOLEAN"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "sponsor",
+    "type": "STRING"
   },
   {
     "mode": "NULLABLE",


### PR DESCRIPTION
Both the `accounts` and `offers` tables were missing sponsorship fields. 

Columns were added in stellar-etl repo via [PR#154](https://github.com/stellar/stellar-etl/pull/154)

**Changes:**

**`accounts`**
* Add `sponsor` string field
* Add `num_sponsored` int field
* Add `num_sponsoring` int field

Note - the fields will need to be appended to the end of the table to preserve current schema and not break load jobs.


**`offers`**
* Add `sponsor` string field
* UPDATE `buying_asset_id` to `type`, `code`, `issuer`
* UPDATE `selling_asset_id` to `type`, `code`, `issuer`

Note - the `offers` table will be dropped and reloaded because of the breaking updates to the schema.