### PR TITLE
Add dust trades to history_trades

### DIFF
--- a/airflow_variables.txt
+++ b/airflow_variables.txt
@@ -37,7 +37,7 @@
     "bq_project": "hubble-261722",
     "gcs_exported_data_bucket_name": "us-central1-hubble-2-d948d67b-bucket",
     "gcs_exported_object_prefix": "dag-exported",
-    "image_name": "stellar/stellar-etl:2426e93",
+    "image_name": "stellar/stellar-etl:e4935a4",
     "image_output_path": "/etl/exported_data/",
     "image_pull_policy": "IfNotPresent",
     "kube_config_location": "",

--- a/schemas/history_trades_schema.json
+++ b/schemas/history_trades_schema.json
@@ -108,5 +108,20 @@
     "mode": "NULLABLE",
     "name": "liquidity_pool_fee",
     "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "trade_type",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "rounding_slippage",
+    "type": "INTEGER" 
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "seller_is_exact",
+    "type": "BOOLEAN"
   }
 ]


### PR DESCRIPTION
PR in conjunction with stellar-etl [PR#155](https://github.com/stellar/stellar-etl/pull/155/files) to update Hubble 2.0 to accommodate dust trading/rounding slippage in liquidity pools

Closes [GH#258](https://github.com/stellar/hubble/issues/258)