### PR TITLE
Protocol 19 Changes

### DIFF
--- a/airflow_variables.txt
+++ b/airflow_variables.txt
@@ -50,7 +50,7 @@
     },
     "gcs_exported_data_bucket_name": "us-central1-hubble-2-d948d67b-bucket",
     "gcs_exported_object_prefix": "dag-exported",
-    "image_name": "stellar/stellar-etl:e4935a4",
+    "image_name": "stellar/stellar-etl:0a9e995",
     "image_output_path": "/etl/exported_data/",
     "image_pull_policy": "IfNotPresent",
     "kube_config_location": "",

--- a/airflow_variables_dev.txt
+++ b/airflow_variables_dev.txt
@@ -50,7 +50,7 @@
     },
     "gcs_exported_data_bucket_name": "us-central1-hubble-1pt5-dev-7db0e004-bucket",
     "gcs_exported_object_prefix": "dag-exported",
-    "image_name": "stellar/stellar-etl:2426e93",
+    "image_name": "stellar/stellar-etl:0a9e995",
     "image_output_path": "/etl/exported_data/",
     "image_pull_policy": "IfNotPresent",
     "kube_config_location": "",
@@ -120,7 +120,7 @@
         "transactions": "history_transactions",
         "trustlines": "trust_lines"
     },
-    "use_testnet": "False",
+    "use_testnet": "True",
     "volume_config": {},
     "volume_name": "etl-data"
 }

--- a/dags/ddls/queries/v_account_signers_current.sql
+++ b/dags/ddls/queries/v_account_signers_current.sql
@@ -1,0 +1,37 @@
+-- Finds the latest state of each account signer in the `account_signers` table.
+-- Ranks each record (grain: one row per account) using 
+-- last modified ledger sequence number. View includes all account signers.
+-- (Deleted and Existing). View matches the Horizon snapshotted state tables.
+WITH current_signers AS 
+(
+    SELECT S.account_id,
+        S.signer,
+        S.weight,
+        S.sponsor,
+        S.last_modified_ledger,
+        L.closed_at,
+        S.ledger_entry_change,
+        S.deleted,
+        DENSE_RANK() OVER(PARTITION BY S.account_id, S.signer ORDER BY S.last_modified_ledger DESC) AS rank_number
+    FROM `hubble-261722.crypto_stellar_internal_2.account_signers` S
+    JOIN `hubble-261722.crypto_stellar_internal_2.history_ledgers` L
+        ON S.last_modified_ledger = L.sequence
+    GROUP BY account_id,
+        signer,
+        weight,
+        sponsor,
+        last_modified_ledger, 
+        ledger_entry_change,
+        closed_at,
+        deleted
+    )
+SELECT account_id, 
+    signer,
+    weight,
+    sponsor
+    last_modified_ledger, 
+    ledger_entry_change,
+    closed_at,
+    deleted
+FROM current_signers   
+WHERE rank_number = 1

--- a/dags/ddls/queries/v_accounts_current.sql
+++ b/dags/ddls/queries/v_accounts_current.sql
@@ -9,6 +9,8 @@ WITH current_accts AS
         A.buying_liabilities,
         A.selling_liabilities,
         A.sequence_number,
+        A.sequence_ledger,
+        A.sequence_time,
         A.num_subentries,
         A.inflation_destination,
         A.flags,
@@ -21,6 +23,7 @@ WITH current_accts AS
         A.ledger_entry_change,
         L.closed_at,
         A.deleted,
+        sponsor,
         DENSE_RANK() OVER(PARTITION BY A.account_id ORDER BY A.last_modified_ledger DESC) AS rank_number
     FROM `hubble-261722.crypto_stellar_internal_2.accounts` A
     JOIN `hubble-261722.crypto_stellar_internal_2.history_ledgers` L
@@ -30,6 +33,8 @@ WITH current_accts AS
         buying_liabilities, 
         selling_liabilities, 
         sequence_number,
+        sequence_ledger,
+        sequence_time,
         num_subentries, 
         inflation_destination, 
         flags, 
@@ -43,13 +48,16 @@ WITH current_accts AS
         last_modified_ledger, 
         ledger_entry_change,
         closed_at,
-        deleted
+        deleted,
+        sponsor
     )
 SELECT account_id, 
     balance,
     buying_liabilities, 
     selling_liabilities, 
     sequence_number,
+    sequence_ledger,
+    sequence_time,
     num_subentries, 
     inflation_destination, 
     flags,    
@@ -61,6 +69,7 @@ SELECT account_id,
     last_modified_ledger, 
     ledger_entry_change,
     closed_at,
-    deleted
+    deleted,
+    sponsor
 FROM current_accts   
 WHERE rank_number = 1

--- a/dags/ddls/queries/v_claimable_balances_current.sql
+++ b/dags/ddls/queries/v_claimable_balances_current.sql
@@ -1,0 +1,46 @@
+-- Finds the latest state of each claimable balance in the `claimable_balances` table.
+-- Ranks each record (grain: one row per balance id) using 
+-- last modified ledger sequence number. View includes all claimable balances.
+-- (Deleted and Existing). View matches the Horizon snapshotted state tables.
+WITH current_balances AS 
+(
+    SELECT B.balance_id,
+        B.asset_type,
+        B.asset_code,
+        B.asset_issuer,
+        B.asset_amount,
+        B.sponsor,
+        B.flags,
+        B.last_modified_ledger,
+        B.ledger_entry_change,
+        L.closed_at,
+        B.deleted,
+        DENSE_RANK() OVER(PARTITION BY B.balance_id ORDER BY B.last_modified_ledger DESC) AS rank_number
+    FROM `hubble-261722.crypto_stellar_internal_2.claimable_balances` B
+    JOIN `hubble-261722.crypto_stellar_internal_2.history_ledgers` L
+        ON B.last_modified_ledger = L.sequence
+    GROUP BY balance_id,
+        asset_type,
+        asset_code,
+        asset_issuer,
+        asset_amount,
+        sponsor,
+        flags,
+        last_modified_ledger, 
+        ledger_entry_change,
+        closed_at,
+        deleted
+    )
+SELECT balance_id,
+    asset_type,
+    asset_code,
+    asset_issuer,
+    asset_amount,
+    sponsor,
+    flags,
+    last_modified_ledger, 
+    ledger_entry_change,
+    closed_at,
+    deleted
+FROM current_balances  
+WHERE rank_number = 1

--- a/dags/ddls/queries/v_liquidity_pools_current.sql
+++ b/dags/ddls/queries/v_liquidity_pools_current.sql
@@ -20,7 +20,7 @@ WITH current_lps AS
         LP.last_modified_ledger,
         L.closed_at,
         LP.deleted,
-        DENSE_RANK() OVER(PARTITION BY liquidity_pool_id ORDER BY LP.last_modified_ledger DESC) AS rank_number
+        DENSE_RANK() OVER(PARTITION BY liquidity_pool_id ORDER BY LP.last_modified_ledger DESC LP.batch_insert_ts DESC) AS rank_number
     FROM `PROJECT.DATASET.liquidity_pools` LP
     JOIN `PROJECT.DATASET.history_ledgers` L
         ON LP.last_modified_ledger = L.sequence
@@ -41,4 +41,20 @@ SELECT liquidity_pool_id,
     deleted
 FROM current_lps 
 WHERE rank_number = 1
+group by liquidity_pool_id, 
+    fee, 
+    trustline_count, 
+    pool_share_count,
+    asset_pair, 
+    asset_a_code,
+    asset_a_issuer,
+    asset_a_type,
+    asset_b_code, 
+    asset_b_issuer, 
+    asset_b_type,
+    asset_a_amount, 
+    asset_b_amount,
+    last_modified_ledger, 
+    closed_at,
+    deleted
     

--- a/dags/ddls/queries/v_offers_current.sql
+++ b/dags/ddls/queries/v_offers_current.sql
@@ -1,0 +1,63 @@
+WITH current_offers AS 
+(
+    SELECT O.seller_id,
+        O.offer_id,
+        O.selling_asset_type,
+        O.selling_asset_code,
+        O.selling_asset_issuer,
+        O.buying_asset_type,
+        O.buying_asset_code,
+        O.buying_asset_issuer,
+        O.amount,
+        O.pricen,
+        O.priced,
+        O.price,
+        O.flags,
+        O.last_modified_ledger,
+        L.closed_at,
+        O.ledger_entry_change,
+        O.deleted,
+        O.sponsor,
+        DENSE_RANK() OVER(PARTITION BY O.seller_id, O.offer_id ORDER BY O.last_modified_ledger DESC) AS rank_number
+    FROM `hubble-261722.crypto_stellar_internal_2.offers` O
+    JOIN `hubble-261722.crypto_stellar_internal_2.history_ledgers` L
+        ON O.last_modified_ledger = L.sequence
+    GROUP BY seller_id,
+        offer_id,
+        selling_asset_type,
+        selling_asset_code,
+        selling_asset_issuer,
+        buying_asset_type,
+        buying_asset_code,
+        buying_asset_issuer,
+        amount,
+        pricen,
+        priced,
+        price,
+        flags,
+        last_modified_ledger,
+        closed_at,
+        ledger_entry_change,
+        deleted,
+        sponsor
+    )
+SELECT seller_id,
+    offer_id,
+    selling_asset_type,
+    selling_asset_code,
+    selling_asset_issuer,
+    buying_asset_type,
+    buying_asset_code,
+    buying_asset_issuer,
+    amount,
+    pricen,
+    priced,
+    price,
+    flags,
+    last_modified_ledger,
+    closed_at,
+    ledger_entry_change,
+    deleted,
+    sponsor
+FROM current_offers 
+WHERE rank_number = 1

--- a/dags/stellar_etl_airflow/build_export_task.py
+++ b/dags/stellar_etl_airflow/build_export_task.py
@@ -59,7 +59,7 @@ def generate_etl_cmd(command, base_filename, cmd_type, use_gcs=False, use_testne
     We need to subtract 1 ledger from the end so that there is no overlap. However, sometimes the start ledger equals the end ledger.
     By setting the end=max(start, end-1), we ensure every range is valid.
     '''
-    if cmd_type == 'archive':
+    if cmd_type in ('archive', 'bounded-core'):
         end_ledger = '{{ [ti.xcom_pull(task_ids="get_ledger_range_from_times")["end"]-1, ti.xcom_pull(task_ids="get_ledger_range_from_times")["start"]] | max}}'
 
     image_output_path, core_exec, core_cfg = get_path_variables(use_testnet)

--- a/schemas/accounts_schema.json
+++ b/schemas/accounts_schema.json
@@ -108,5 +108,15 @@
     "mode": "NULLABLE",
     "name": "num_sponsoring",
     "type": "INTEGER"
+  },
+  { 
+    "mode": "NULLABLE",
+    "name": "sequence_ledger",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "sequence_time",
+    "type": "TIMESTAMP"
   }
 ]

--- a/schemas/history_transactions_schema.json
+++ b/schemas/history_transactions_schema.json
@@ -108,5 +108,30 @@
     "mode": "NULLABLE",
     "name": "batch_insert_ts",
     "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "ledger_bounds",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "min_account_sequence",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "min_account_sequence_age",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "min_account_sequence_ledger_gap",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "REPEATED",
+    "name": "extra_signers",
+    "type": "string"
   }
 ]


### PR DESCRIPTION
Updates Airflow DAGs to recognize new Protocol19 fields for `accounts` and `history_transactions`

Closes [GH#253](https://github.com/stellar/hubble/issues/253)

PR also ensures that views are up-to-date with state table schema and adds current snapshot views for remaining missing state tables (offers, claimable_balances, account_signers)