### PR TITLE
Enable public dataset writing

### DIFF
--- a/airflow_variables.txt
+++ b/airflow_variables.txt
@@ -35,6 +35,19 @@
     "api_key_path": "/home/airflow/gcs/data/apiKey.json",
     "bq_dataset": "crypto_stellar_internal_2",
     "bq_project": "hubble-261722",
+    "cluster_fields": { 
+        "accounts": ["account_id","last_modified_ledger"], 
+        "account_signers": ["account_id","last_modified_ledger"], 
+        "claimable_balances": ["balance_id","last_modified_ledger","sponsor"], 
+        "history_assets": ["asset_code","asset_type"], 
+        "history_ledgers": ["sequence","closed_at"], 
+        "history_operations": ["id","transaction_id","source_account"], 
+        "history_trades": ["history_operation_id","ledger_closed_at"], 
+        "history_transactions": ["id","ledger_sequence","account"], 
+        "offers": ["seller_id","last_modified_ledger"], 
+        "liquidity_pools": ["liquidity_pool_id","last_modified_ledger"], 
+        "trust_lines": ["account_id","last_modified_ledger"] 
+    },
     "gcs_exported_data_bucket_name": "us-central1-hubble-2-d948d67b-bucket",
     "gcs_exported_object_prefix": "dag-exported",
     "image_name": "stellar/stellar-etl:e4935a4",
@@ -67,6 +80,8 @@
     },
     "output_path": "/home/airflow/gcs/data/",
     "owner": "SDF",
+    "public_dataset": "crypto_stellar_2",
+    "public_project": "crypto-stellar",
     "resources": {
         "default": {
             "request_cpu": "1.2",

--- a/airflow_variables_dev.txt
+++ b/airflow_variables_dev.txt
@@ -35,6 +35,19 @@
     "api_key_path": "/home/airflow/gcs/data/apiKey.json",
     "bq_dataset": "test_gcp_airflow_internal",
     "bq_project": "test-hubble-319619",
+    "cluster_fields": { 
+        "accounts": ["account_id","last_modified_ledger"], 
+        "account_signers": ["account_id","last_modified_ledger"], 
+        "claimable_balances": ["balance_id","last_modified_ledger","sponsor"], 
+        "history_assets": ["asset_code","asset_type"], 
+        "history_ledgers": ["sequence","closed_at"], 
+        "history_operations": ["id","transaction_id","source_account"], 
+        "history_trades": ["history_operation_id","ledger_closed_at"], 
+        "history_transactions": ["id","ledger_sequence","account"], 
+        "offers": ["seller_id","last_modified_ledger"], 
+        "liquidity_pools": ["liquidity_pool_id","last_modified_ledger"], 
+        "trust_lines": ["account_id","last_modified_ledger"] 
+    },
     "gcs_exported_data_bucket_name": "us-central1-hubble-1pt5-dev-7db0e004-bucket",
     "gcs_exported_object_prefix": "dag-exported",
     "image_name": "stellar/stellar-etl:2426e93",
@@ -66,6 +79,8 @@
     },
     "output_path": "/home/airflow/gcs/data/",
     "owner": "SDF",
+    "public_dataset": "test_crypto_stellar_2",
+    "public_project": "test-hubble-319619",
     "resources": {
         "default": {
             "request_cpu": "1.2",

--- a/dags/ddls/create_partitioned_tables.sh
+++ b/dags/ddls/create_partitioned_tables.sh
@@ -1,4 +1,4 @@
-# /bin/bash -e 
+#! /bin/bash -e 
 #
 #
 ###############################################################################
@@ -18,29 +18,43 @@ cd ../../
 WORKDIR="$(pwd)"
 echo "Current working directory: $WORKDIR"
 
-PROJECT_ID=test-hubble-261722
-DATASET_ID=crypto_stellar_internal_2
+PROJECT_ID=crypto-stellar
+DATASET_ID=crypto_stellar_2
 SCHEMA_DIR=$WORKDIR/schemas/
-PARTITION_TABLES=(history_operations history_transactions history_ledgers)
-TABLES=(history_assets history_trades)
-
+PARTITION_TABLES=(history_operations history_transactions history_ledgers history_assets history_tradesaccounts claimable_balances offers liquidity_pools account_signers trust_lines)
 
 # make partitioned tables
 for table in ${PARTITION_TABLES[@]}
 do 
     echo "Creating partitioned table $table in $DATASET_ID"
+    if [ "$table" = "history_operations" ]; then 
+        cluster=id,transaction_id,source_account
+    elif [ "$table" = "history_transactions" ]; then
+        cluster=id,ledger_sequence,account
+    elif [ "$table" = "history_ledgers" ]; then
+        cluster=sequence,closed_at
+    elif [ "$table" = "history_assets" ]; then
+        cluster=asset_code,asset_type
+    elif [ "$table" = "accounts" ]; then
+        cluster=account_id,last_modified_ledger
+    elif [ "$table" = "claimable_balances" ]; then
+        cluster=balance_id,last_modified_ledger,sponsor
+    elif [ "$table" = "offers" ]; then
+        cluster=seller_id,last_modified_ledger
+    elif [ "$table" = "liquidity_pools" ]; then
+        cluster=liquidity_pool_id,last_modified_ledger
+    elif [ "$table" = "account_signers" ]; then
+        cluster=account_id,last_modified_ledger
+    elif [ "$table" = "trust_lines" ]; then
+        cluster=account_id,last_modified_ledger
+    else 
+        cluster=history_operation_id,ledger_closed_at
+    fi 
     bq mk --table \
     --schema $SCHEMA_DIR${table}_schema.json \
     --time_partitioning_field batch_run_date \
     --time_partitioning_type MONTH \
+    --clustering_fields $cluster \
     $PROJECT_ID:$DATASET_ID.$table
 done
 
-#make non-partitioned tables
-for table in ${TABLES[@]}
-do 
-    echo "Creating table $table in $DATASET_ID"
-    bq mk --table \
-    --schema $SCHEMA_DIR/${table}_schema.json \
-    $PROJECT_ID:$DATASET_ID.$table
-done

--- a/dags/history_archive_with_captive_core_dag.py
+++ b/dags/history_archive_with_captive_core_dag.py
@@ -37,6 +37,10 @@ dag = DAG(
 
 file_names = Variable.get('output_file_names', deserialize_json=True)
 table_names = Variable.get('table_ids', deserialize_json=True)
+internal_project = Variable.get('bq_project')
+internal_dataset = Variable.get('bq_dataset')
+public_project = Variable.get('public_project')
+public_dataset = Variable.get('public_dataset')
 use_testnet = ast.literal_eval(Variable.get("use_testnet"))
 
 '''
@@ -76,8 +80,17 @@ delete_old_trade_task = build_delete_data_task(dag, table_names['trades'])
 The send tasks receive the location of the file in Google Cloud storage through Airflow's XCOM system.
 Then, the task merges the unique entries in the file into the corresponding table in BigQuery. 
 '''
-send_ops_to_bq_task = build_gcs_to_bq_task(dag, op_export_task.task_id, table_names['operations'], '', partition=True)
-send_trades_to_bq_task = build_gcs_to_bq_task(dag, trade_export_task.task_id, table_names['trades'], '', partition=False)
+send_ops_to_bq_task = build_gcs_to_bq_task(dag, op_export_task.task_id, internal_project, internal_dataset, table_names['operations'], '', partition=True, cluster=False)
+send_trades_to_bq_task = build_gcs_to_bq_task(dag, trade_export_task.task_id, internal_project, internal_dataset, table_names['trades'], '', partition=False, cluster=False)
+
+'''
+The send tasks receive the location of the file in Google Cloud storage through Airflow's XCOM system.
+Then, the task merges the unique entries in the file into the corresponding table in BigQuery. 
+'''
+send_ops_to_pub_task = build_gcs_to_bq_task(dag, op_export_task.task_id, public_project, public_dataset, table_names['operations'], '', partition=True, cluster=True)
+send_trades_to_pub_task = build_gcs_to_bq_task(dag, trade_export_task.task_id, public_project, public_dataset, table_names['trades'], '', partition=True, cluster=True)
  
 time_task >> write_op_stats >> op_export_task >> delete_old_op_task >> send_ops_to_bq_task
+delete_old_op_task >> send_ops_to_pub_task
 time_task >> write_trade_stats >> trade_export_task  >> delete_old_trade_task >> send_trades_to_bq_task
+delete_old_trade_task >> send_trades_to_pub_task


### PR DESCRIPTION
In an effort to retire the Hubble 1.0 pipeline, we need the ability to write the transformed `stellar-etl` data to public datasets. Namely, `crypto-stellar:crypto_stellar`. The easiest way to do this is by creating an additional `GCSToBigquery` airflow task that writes the dataset to a publicly specified location. 

For the public dataset, I'd like to introduce clustering to our tables to create efficiencies in complex queries. By clustering fields based on common join keys, we can add granularity in the table organization beyond partitioning. In a future PR, we should work on making the Hubble 2.0 tables backwards compatible so that they are also clustered on the same fields.

This PR covers those changes:

* Adding a `public_project` and `public_dataset` parameter 
* Creating new Airflow tasks that will write the data to the public datasets
* Modifying the DAG definition so that two tasks run _in parallel_ after `delete_<name>_task`
* Updating the `create_tables` DDL script for optimized table format
* Allowing tables to contain `cluster_fields` which are defined in the `airflow_variables.txt` parameter file.