### PR TITLE
Add enriched meaningful hist ops table

### DIFF
--- a/dags/queries/enriched_history_operations.sql
+++ b/dags/queries/enriched_history_operations.sql
@@ -1,3 +1,11 @@
+/*
+Query denormalizes the history_ledgers, history_transactions and history_operations tables at
+the `history_operation_id` level. Table is loaded using an append-only load pattern by batch_id.
+Note: as attributes are added to the `details` blob in history_operations, it is recommended
+to add relevant data as a new field in the enriched_history_operations table.
+
+Table is heavily used for KPI calculation and Metabase Dashboards.
+*/
 SELECT
 -- expanded operations details fields
 details.account, details.amount, details.asset_code, details.asset_issuer, details.asset_type, details.authorize,

--- a/dags/queries/enriched_meaningful_history_operations.sql
+++ b/dags/queries/enriched_meaningful_history_operations.sql
@@ -1,0 +1,20 @@
+/*
+Query filters the enriched_history_operations table down to meaningful/relevant operations
+only. If any asset that is a part of the operation is on the current meaningful asset list,
+the operation is included in the table.
+
+Table is heavily used for Partner Metabase Dashboards.
+
+NOTE: relevant assets are proprietary internal data and should not be shared externally.
+*/
+SELECT
+  *
+FROM `{project_id}.{dataset_id}.enriched_history_operations` eho
+INNER JOIN `{project_id}.{dataset_id}.meaningful_assets` ma ON
+  (eho.asset_code = ma.code AND eho.asset_issuer = ma.issuer) OR
+  (eho.source_asset_code = ma.code AND eho.source_asset_issuer = ma.issuer) OR
+  (eho.selling_asset_code = ma.code AND eho.selling_asset_issuer = ma.issuer) OR
+  (eho.buying_asset_code = ma.code AND eho.buying_asset_issuer = ma.issuer)
+WHERE (eho.successful=true OR eho.successful IS NOT NULL)
+    AND eho.batch_id = '{batch_id}'
+    AND eho.batch_run_date = '{batch_run_date}'

--- a/dags/stellar_etl_airflow/build_time_task.py
+++ b/dags/stellar_etl_airflow/build_time_task.py
@@ -23,7 +23,6 @@ def build_time_task(dag, use_testnet=False, use_next_exec_time=True, resource_cf
     end_time = '{{ subtract_data_interval(dag, data_interval_end).isoformat() }}' if use_next_exec_time else '{{ ts }}'
     command = ["stellar-etl"]
     args = [ "get_ledger_range_from_times", "-s", start_time, "-o", "/airflow/xcom/return.json", '-e', end_time]
-    logging.info(f'Constructing command with args: {args}')
     if use_testnet:
         args.append("--testnet")
     config_file_location = Variable.get('kube_config_location')


### PR DESCRIPTION
Adds derivation code and data population for `enriched_meaningful_history_operations` table. The table filters down the `enriched_history_operations` down to operations that interacted with relevant assets.

The pipeline follows the framework of the `enriched_history_operations` table:
1. Check if the current `batch_id` partition exists in the table. If it does, delete the old one
2. Execute a query parameterized by `batch_id` that will insert fresh data from `enriched_history_operations` table into the final table.