### PR TITLE
Improve maintainability of stellar-etl-airflow

### DIFF
--- a/airflow_variables.txt
+++ b/airflow_variables.txt
@@ -121,6 +121,14 @@
         "transactions": "history_transactions",
         "trustlines": "trust_lines"
     },
+    "task_timeout": {
+        "build_batch_stats": 180,
+        "build_bq_insert_job": 180,
+        "build_delete_data_task": 180,
+        "build_export_task": 180,
+        "build_gcs_to_bq_task": 300,
+        "build_time_task": 120
+    },
     "use_testnet": "False",
     "volume_config": "{}",
     "volume_name": "etl-data"

--- a/airflow_variables_dev.txt
+++ b/airflow_variables_dev.txt
@@ -120,6 +120,14 @@
         "transactions": "history_transactions",
         "trustlines": "trust_lines"
     },
+    "task_timeout": {
+        "build_batch_stats": 180,
+        "build_bq_insert_job": 180,
+        "build_delete_data_task": 180,
+        "build_export_task": 180,
+        "build_gcs_to_bq_task": 300,
+        "build_time_task": 120
+    },
     "use_testnet": "True",
     "volume_config": {},
     "volume_name": "etl-data"

--- a/dags/ddls/delete_gcs_files.sh
+++ b/dags/ddls/delete_gcs_files.sh
@@ -1,0 +1,35 @@
+# /bin/bash -e 
+#
+#
+###############################################################################
+# Ad Hoc script to delete any old GCS files 
+#
+# Author: Sydney Wiseman
+# Date: 26 May 2022
+#
+# Script will loop through batch run dates and delete any old files that
+# match a specified pattern. To be used in instances of needing to rerun
+# large amounts of data for the state tables. Since state tables load data
+# via pattern matching, the old data must be removed first.
+#
+# User can pass month number, day number and pattern string to match.
+###############################################################################
+ 
+PATTERN=$1
+YEAR=$2
+MONTH=$3
+START_DAY=$4
+END_DAY=$5
+
+GCS_BUCKET=gs://us-central1-hubble-2-d948d67b-bucket/dag-exported/scheduled__
+
+# make state tables
+for day in $(seq $START_DAY $END_DAY)
+do 
+    echo "Removing files matching pattern $PATTERN for month $MONTH and day $day"
+    if [ $day -lt 10 ]; then
+        gsutil -m rm -rf $GCS_BUCKET$YEAR-$MONTH-0$day*/$PATTERN* 
+    elif [ $day -ge 10 ]; then
+        gsutil -m rm -rf $GCS_BUCKET$YEAR-$MONTH-$day*/$PATTERN* 
+    fi
+done

--- a/dags/stellar_etl_airflow/build_batch_stats.py
+++ b/dags/stellar_etl_airflow/build_batch_stats.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 from airflow.models import Variable
 from airflow.providers.google.cloud.operators.bigquery import BigQueryInsertJobOperator 
 from stellar_etl_airflow import macros
@@ -20,6 +20,7 @@ def build_batch_stats(dag, table):
 
     return BigQueryInsertJobOperator(
         project_id=PROJECT_ID,
+        execution_timeout=timedelta(seconds=180),
         task_id=f"insert_batch_stats_{table}",
         configuration={
             "query": {

--- a/dags/stellar_etl_airflow/build_batch_stats.py
+++ b/dags/stellar_etl_airflow/build_batch_stats.py
@@ -20,8 +20,8 @@ def build_batch_stats(dag, table):
 
     return BigQueryInsertJobOperator(
         project_id=PROJECT_ID,
-        execution_timeout=timedelta(seconds=180),
         task_id=f"insert_batch_stats_{table}",
+        execution_timeout=timedelta(seconds=Variable.get('task_timeout', deserialize_json=True)[build_batch_stats.__name__]),
         configuration={
             "query": {
                 "query": INSERT_ROWS_QUERY,

--- a/dags/stellar_etl_airflow/build_bq_insert_job_task.py
+++ b/dags/stellar_etl_airflow/build_bq_insert_job_task.py
@@ -1,4 +1,5 @@
 import os
+from datetime import timedelta
 # import config
 from airflow.models import Variable
 from airflow.providers.google.cloud.operators.bigquery import BigQueryInsertJobOperator
@@ -43,6 +44,7 @@ def build_bq_insert_job(dag, project, dataset, table, partition):
 
     return BigQueryInsertJobOperator(
         task_id=f"insert_records_{table}_{dataset_type}",
+        execution_timeout=timedelta(seconds=180),
         configuration={
             "query": {
                 "query": query,

--- a/dags/stellar_etl_airflow/build_bq_insert_job_task.py
+++ b/dags/stellar_etl_airflow/build_bq_insert_job_task.py
@@ -1,6 +1,5 @@
 import os
 from datetime import timedelta
-# import config
 from airflow.models import Variable
 from airflow.providers.google.cloud.operators.bigquery import BigQueryInsertJobOperator
 from stellar_etl_airflow import macros
@@ -44,7 +43,7 @@ def build_bq_insert_job(dag, project, dataset, table, partition):
 
     return BigQueryInsertJobOperator(
         task_id=f"insert_records_{table}_{dataset_type}",
-        execution_timeout=timedelta(seconds=180),
+        execution_timeout=timedelta(seconds=Variable.get('task_timeout', deserialize_json=True)[build_bq_insert_job.__name__]),
         configuration={
             "query": {
                 "query": query,

--- a/dags/stellar_etl_airflow/build_delete_data_task.py
+++ b/dags/stellar_etl_airflow/build_delete_data_task.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import timedelta
 from airflow.models import Variable
 from airflow.providers.google.cloud.operators.bigquery import BigQueryInsertJobOperator
 from stellar_etl_airflow import macros
@@ -22,6 +22,7 @@ def build_delete_data_task(dag, project, dataset, table):
     return BigQueryInsertJobOperator(
         project_id=project,
         task_id=f"delete_old_partition_{table}_{dataset_type}",
+        execution_timeout=timedelta(seconds=180),
         configuration={
             "query": {
                 "query": DELETE_ROWS_QUERY,

--- a/dags/stellar_etl_airflow/build_delete_data_task.py
+++ b/dags/stellar_etl_airflow/build_delete_data_task.py
@@ -22,7 +22,7 @@ def build_delete_data_task(dag, project, dataset, table):
     return BigQueryInsertJobOperator(
         project_id=project,
         task_id=f"delete_old_partition_{table}_{dataset_type}",
-        execution_timeout=timedelta(seconds=180),
+        execution_timeout=timedelta(seconds=Variable.get('task_timeout', deserialize_json=True)[build_delete_data_task.__name__]),
         configuration={
             "query": {
                 "query": DELETE_ROWS_QUERY,

--- a/dags/stellar_etl_airflow/build_export_task.py
+++ b/dags/stellar_etl_airflow/build_export_task.py
@@ -118,7 +118,7 @@ def build_export_task(dag, cmd_type, command, filename, use_gcs=False, use_testn
         service_account_name=Variable.get('k8s_service_account'),
         namespace=Variable.get('k8s_namespace'),
         task_id=command + '_task',
-        execution_timeout=timedelta(minutes=180),
+        execution_timeout=timedelta(minutes=Variable.get('task_timeout', deserialize_json=True)[build_export_task.__name__]),
         name=command + '_task',
         image=Variable.get('image_name'),
         cmds=['bash', '-c'],

--- a/dags/stellar_etl_airflow/build_gcs_to_bq_task.py
+++ b/dags/stellar_etl_airflow/build_gcs_to_bq_task.py
@@ -45,7 +45,7 @@ def build_gcs_to_bq_task(dag, export_task_id, project, dataset, data_type, sourc
 
     return GCSToBigQueryOperator(
         task_id=f'send_{data_type}_to_{dataset_type}',
-        execution_timeout=timedelta(seconds=300),
+        execution_timeout=timedelta(seconds=Variable.get('task_timeout', deserialize_json=True)[build_gcs_to_bq_task.__name__]),
         bucket=bucket_name,
         schema_fields=schema_fields,
         autodetect=False,

--- a/dags/stellar_etl_airflow/build_gcs_to_bq_task.py
+++ b/dags/stellar_etl_airflow/build_gcs_to_bq_task.py
@@ -1,7 +1,7 @@
 '''
 This file contains functions for creating Airflow tasks to load files from Google Cloud Storage into BigQuery.
 '''
-import logging
+from datetime import timedelta
 from airflow.providers.google.cloud.transfers.gcs_to_bigquery import GCSToBigQueryOperator
 from airflow.models import Variable
 from stellar_etl_airflow.build_apply_gcs_changes_to_bq_task import read_local_schema
@@ -45,6 +45,7 @@ def build_gcs_to_bq_task(dag, export_task_id, project, dataset, data_type, sourc
 
     return GCSToBigQueryOperator(
         task_id=f'send_{data_type}_to_{dataset_type}',
+        execution_timeout=timedelta(seconds=300),
         bucket=bucket_name,
         schema_fields=schema_fields,
         autodetect=False,

--- a/dags/stellar_etl_airflow/build_time_task.py
+++ b/dags/stellar_etl_airflow/build_time_task.py
@@ -1,6 +1,7 @@
 '''
 This file contains functions for creating Airflow tasks to convert from a time range to a ledger range.
 '''
+from datetime import timedelta
 import logging
 from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import KubernetesPodOperator
 from airflow.models import Variable
@@ -35,6 +36,7 @@ def build_time_task(dag, use_testnet=False, use_next_exec_time=True, resource_cf
     return KubernetesPodOperator(
          task_id='get_ledger_range_from_times',
          name='get_ledger_range_from_times',
+         execution_timeout=timedelta(seconds=120),
          namespace=Variable.get('k8s_namespace'),
          service_account_name=Variable.get('k8s_service_account'),
          image=Variable.get('image_name'),

--- a/dags/stellar_etl_airflow/build_time_task.py
+++ b/dags/stellar_etl_airflow/build_time_task.py
@@ -36,7 +36,7 @@ def build_time_task(dag, use_testnet=False, use_next_exec_time=True, resource_cf
     return KubernetesPodOperator(
          task_id='get_ledger_range_from_times',
          name='get_ledger_range_from_times',
-         execution_timeout=timedelta(seconds=120),
+         execution_timeout=timedelta(seconds=Variable.get('task_timeout', deserialize_json=True)[build_time_task.__name__]),
          namespace=Variable.get('k8s_namespace'),
          service_account_name=Variable.get('k8s_service_account'),
          image=Variable.get('image_name'),


### PR DESCRIPTION
Improvements to Airflow DAGs so that they are easier to maintain and monitor. 
Improvements are twofold: 

1. Incorporate an `execution_timeout` to all DAG tasks
2. Create ad hoc GCS file deletion script to delete large amounts of GCS files based on pattern matching

DAG tasks can spawn hung processes every 3-5 days that never timeout. These tasks will never complete, but require manual intervention to fail the task and restart it. The `execution_timeout` parameter sets an upper limit for a DAG task that will automatically timeout and fail the task if it exceeds the limit. This should reduce the number of manual interventions in Airflow.

In the event that a large amount of data needs to be reingested (eg, change to logic and need to backfill history), the `delete_gcs_files.sh` can be used to clear out the old GCS transformed files so that our transformed file storage can remain clean.