### PR TITLE
Update state tables views to remove duplicates

### DIFF
--- a/dags/ddls/queries/v_account_signers_current.sql
+++ b/dags/ddls/queries/v_account_signers_current.sql
@@ -12,7 +12,7 @@ WITH current_signers AS
         L.closed_at,
         S.ledger_entry_change,
         S.deleted,
-        DENSE_RANK() OVER(PARTITION BY S.account_id, S.signer ORDER BY S.last_modified_ledger DESC) AS rank_number
+        DENSE_RANK() OVER(PARTITION BY S.account_id, S.signer ORDER BY S.last_modified_ledger DESC, S.ledger_entry_change DESC) AS rank_number
     FROM `hubble-261722.crypto_stellar_internal_2.account_signers` S
     JOIN `hubble-261722.crypto_stellar_internal_2.history_ledgers` L
         ON S.last_modified_ledger = L.sequence

--- a/dags/ddls/queries/v_accounts_current.sql
+++ b/dags/ddls/queries/v_accounts_current.sql
@@ -24,7 +24,7 @@ WITH current_accts AS
         L.closed_at,
         A.deleted,
         sponsor,
-        DENSE_RANK() OVER(PARTITION BY A.account_id ORDER BY A.last_modified_ledger DESC) AS rank_number
+        DENSE_RANK() OVER(PARTITION BY A.account_id ORDER BY A.last_modified_ledger DESC, A.ledger_entry_change DESC) AS rank_number
     FROM `hubble-261722.crypto_stellar_internal_2.accounts` A
     JOIN `hubble-261722.crypto_stellar_internal_2.history_ledgers` L
         ON A.last_modified_ledger = L.sequence

--- a/dags/ddls/queries/v_claimable_balances_current.sql
+++ b/dags/ddls/queries/v_claimable_balances_current.sql
@@ -15,7 +15,7 @@ WITH current_balances AS
         B.ledger_entry_change,
         L.closed_at,
         B.deleted,
-        DENSE_RANK() OVER(PARTITION BY B.balance_id ORDER BY B.last_modified_ledger DESC) AS rank_number
+        DENSE_RANK() OVER(PARTITION BY B.balance_id ORDER BY B.last_modified_ledger DESC, B.ledger_entry_change DESC) AS rank_number
     FROM `hubble-261722.crypto_stellar_internal_2.claimable_balances` B
     JOIN `hubble-261722.crypto_stellar_internal_2.history_ledgers` L
         ON B.last_modified_ledger = L.sequence

--- a/dags/ddls/queries/v_liquidity_pools_current.sql
+++ b/dags/ddls/queries/v_liquidity_pools_current.sql
@@ -18,9 +18,10 @@ WITH current_lps AS
         LP.asset_a_amount, 
         LP.asset_b_amount,
         LP.last_modified_ledger,
+        LP.ledger_entry_change,
         L.closed_at,
         LP.deleted,
-        DENSE_RANK() OVER(PARTITION BY liquidity_pool_id ORDER BY LP.last_modified_ledger DESC LP.batch_insert_ts DESC) AS rank_number
+        DENSE_RANK() OVER(PARTITION BY liquidity_pool_id ORDER BY LP.last_modified_ledger DESC LP.ledger_entry_change DESC) AS rank_number
     FROM `PROJECT.DATASET.liquidity_pools` LP
     JOIN `PROJECT.DATASET.history_ledgers` L
         ON LP.last_modified_ledger = L.sequence
@@ -37,6 +38,7 @@ SELECT liquidity_pool_id,
     asset_a_amount, 
     asset_b_amount,
     last_modified_ledger, 
+    ledger_entry_change,
     closed_at,
     deleted
 FROM current_lps 
@@ -55,6 +57,7 @@ group by liquidity_pool_id,
     asset_a_amount, 
     asset_b_amount,
     last_modified_ledger, 
+    ledger_entry_change,
     closed_at,
     deleted
     

--- a/dags/ddls/queries/v_offers_current.sql
+++ b/dags/ddls/queries/v_offers_current.sql
@@ -18,7 +18,7 @@ WITH current_offers AS
         O.ledger_entry_change,
         O.deleted,
         O.sponsor,
-        DENSE_RANK() OVER(PARTITION BY O.seller_id, O.offer_id ORDER BY O.last_modified_ledger DESC) AS rank_number
+        DENSE_RANK() OVER(PARTITION BY O.seller_id, O.offer_id ORDER BY O.last_modified_ledger DESC, O.ledger_entry_change DESC) AS rank_number
     FROM `hubble-261722.crypto_stellar_internal_2.offers` O
     JOIN `hubble-261722.crypto_stellar_internal_2.history_ledgers` L
         ON O.last_modified_ledger = L.sequence

--- a/dags/ddls/queries/v_trust_lines_current.sql
+++ b/dags/ddls/queries/v_trust_lines_current.sql
@@ -16,9 +16,10 @@ WITH current_tls AS
         TL.sponsor,
         TL.trust_line_limit,
         TL.last_modified_ledger,
+        TL.ledger_entry_change,
         L.closed_at,
         TL.deleted,
-        DENSE_RANK() OVER(PARTITION BY TL.account_id, TL.asset_code, TL.asset_issuer, TL.liquidity_pool_id ORDER BY TL.last_modified_ledger DESC) AS rank_number
+        DENSE_RANK() OVER(PARTITION BY TL.account_id, TL.asset_code, TL.asset_issuer, TL.liquidity_pool_id ORDER BY TL.last_modified_ledger DESC, TL.ledger_entry_change DESC) AS rank_number
     FROM `PROJECT.DATASET.trust_lines` TL
     JOIN `PROJECT.DATASET.history_ledgers` L
         ON TL.last_modified_ledger = L.sequence
@@ -34,6 +35,7 @@ WITH current_tls AS
         sponsor, 
         trust_line_limit,
         last_modified_ledger, 
+        ledger_entry_change,
         closed_at, 
         deleted
     )
@@ -49,6 +51,7 @@ SELECT account_id,
     sponsor, 
     trust_line_limit, 
     last_modified_ledger, 
+    ledger_entry_change,
     closed_at,
     deleted
 FROM current_tls  


### PR DESCRIPTION
Hubble has state table views (`v_<tablename>_current`) that represent the present ledger snapshot of the given ledger type. The views had a bug in the fact that deleted entries would show up twice. This was happening because the `last_modified_ledger` does not change for a `deleted`  state change (meaning that the `ledger_entry_change` would be different, but the `last_modified_ledger` would remain unchanged)

This updates the views to rank by _both_ `last_modified_ledger` and `ledger_entry_change` so that there are no ties in the ranking process. If the ledger entry is deleted, the state will be reflected as `deleted` only.