### PR TITLE
Update history_transactions pipeline

### DIFF
--- a/airflow_variables.txt
+++ b/airflow_variables.txt
@@ -50,7 +50,7 @@
     },
     "gcs_exported_data_bucket_name": "us-central1-hubble-2-d948d67b-bucket",
     "gcs_exported_object_prefix": "dag-exported",
-    "image_name": "stellar/stellar-etl:0a9e995",
+    "image_name": "techindicium/stellar-etl@sha256:0d35129388df494170971301d24d9c1ce6786150a8dc17ce6d1a480826d447f1",
     "image_output_path": "/etl/exported_data/",
     "image_pull_policy": "IfNotPresent",
     "kube_config_location": "",

--- a/airflow_variables.txt
+++ b/airflow_variables.txt
@@ -50,7 +50,7 @@
     },
     "gcs_exported_data_bucket_name": "us-central1-hubble-2-d948d67b-bucket",
     "gcs_exported_object_prefix": "dag-exported",
-    "image_name": "techindicium/stellar-etl@sha256:4164014fce82a3f235581bffbf2ad6ce0b625d383c61c90b1c8905795f19e079",
+    "image_name": "stellar/stellar-etl:ed30904",
     "image_output_path": "/etl/exported_data/",
     "image_pull_policy": "IfNotPresent",
     "kube_config_location": "",

--- a/airflow_variables.txt
+++ b/airflow_variables.txt
@@ -50,7 +50,7 @@
     },
     "gcs_exported_data_bucket_name": "us-central1-hubble-2-d948d67b-bucket",
     "gcs_exported_object_prefix": "dag-exported",
-    "image_name": "stellar/stellar-etl:ed30904",
+    "image_name": "stellar/stellar-etl:0f2fd70",
     "image_output_path": "/etl/exported_data/",
     "image_pull_policy": "IfNotPresent",
     "kube_config_location": "",

--- a/airflow_variables.txt
+++ b/airflow_variables.txt
@@ -50,7 +50,7 @@
     },
     "gcs_exported_data_bucket_name": "us-central1-hubble-2-d948d67b-bucket",
     "gcs_exported_object_prefix": "dag-exported",
-    "image_name": "techindicium/stellar-etl@sha256:0d35129388df494170971301d24d9c1ce6786150a8dc17ce6d1a480826d447f1",
+    "image_name": "techindicium/stellar-etl@sha256:4164014fce82a3f235581bffbf2ad6ce0b625d383c61c90b1c8905795f19e079",
     "image_output_path": "/etl/exported_data/",
     "image_pull_policy": "IfNotPresent",
     "kube_config_location": "",

--- a/airflow_variables_dev.txt
+++ b/airflow_variables_dev.txt
@@ -50,7 +50,7 @@
     },
     "gcs_exported_data_bucket_name": "us-central1-hubble-1pt5-dev-7db0e004-bucket",
     "gcs_exported_object_prefix": "dag-exported",
-    "image_name": "stellar/stellar-etl:ed30904",
+    "image_name": "stellar/stellar-etl:0f2fd70",
     "image_output_path": "/etl/exported_data/",
     "image_pull_policy": "IfNotPresent",
     "kube_config_location": "",

--- a/airflow_variables_dev.txt
+++ b/airflow_variables_dev.txt
@@ -50,7 +50,7 @@
     },
     "gcs_exported_data_bucket_name": "us-central1-hubble-1pt5-dev-7db0e004-bucket",
     "gcs_exported_object_prefix": "dag-exported",
-    "image_name": "stellar/stellar-etl:0a9e995",
+    "image_name": "stellar/stellar-etl:ed30904",
     "image_output_path": "/etl/exported_data/",
     "image_pull_policy": "IfNotPresent",
     "kube_config_location": "",

--- a/dags/history_archive_without_captive_core_dag.py
+++ b/dags/history_archive_without_captive_core_dag.py
@@ -67,7 +67,6 @@ script time to copy the file over to the correct directory. If there is no sleep
 starts prematurely and will not load data.
 '''
 ledger_export_task = build_export_task(dag, 'archive', 'export_ledgers', file_names['ledgers'], use_testnet=use_testnet, use_gcs=True)
-tx_export_task = build_export_task(dag, 'archive', 'export_transactions', file_names['transactions'], use_testnet=use_testnet, use_gcs=True)
 asset_export_task = build_export_task(dag, 'archive', 'export_assets', file_names['assets'], use_testnet=use_testnet, use_gcs=True)
 
 '''

--- a/dags/stellar_etl_airflow/build_export_task.py
+++ b/dags/stellar_etl_airflow/build_export_task.py
@@ -13,9 +13,9 @@ def get_path_variables(use_testnet=False):
     '''
         Returns the image output path, core executable path, and core config path.
     '''
-    config = '/etl/docker/stellar-core.cfg'
+    config = '/home/stellar/etl/docker/stellar-core.cfg'
     if use_testnet:
-        config = '/etl/docker/stellar-core_testnet.cfg'
+        config = '/home/stellar/etl/docker/stellar-core_testnet.cfg'
     return Variable.get('image_output_path'), '/usr/bin/stellar-core', config
 
 def select_correct_filename(cmd_type, base_name, batched_name):

--- a/dags/stellar_etl_airflow/build_export_task.py
+++ b/dags/stellar_etl_airflow/build_export_task.py
@@ -14,9 +14,9 @@ def get_path_variables(use_testnet=False):
     '''
         Returns the image output path, core executable path, and core config path.
     '''
-    config = '/home/stellar/etl/docker/stellar-core.cfg'
+    config = '/etl/docker/stellar-core.cfg'
     if use_testnet:
-        config = '/home/stellar/etl/docker/stellar-core_testnet.cfg'
+        config = '/etl/docker/stellar-core_testnet.cfg'
     return Variable.get('image_output_path'), '/usr/bin/stellar-core', config
 
 def select_correct_filename(cmd_type, base_name, batched_name):

--- a/schemas/history_operations_schema.json
+++ b/schemas/history_operations_schema.json
@@ -1,10 +1,5 @@
 [
   {
-    "mode": "NULLABLE",
-    "name": "application_order",
-    "type": "INTEGER"
-  },
-  {
     "fields": [
       {
         "mode": "NULLABLE",
@@ -19,7 +14,7 @@
       {
         "mode": "NULLABLE",
         "name": "account_muxed_id",
-        "type": "INTEGER"
+        "type": "STRING"
       },
       {
         "mode": "NULLABLE",
@@ -94,7 +89,7 @@
       {
         "mode": "NULLABLE",
         "name": "claimant_muxed_id",
-        "type": "INTEGER"
+        "type": "STRING"
       },
       {
         "fields": [
@@ -509,7 +504,7 @@
       {
         "mode": "NULLABLE",
         "name": "from_muxed_id",
-        "type": "INTEGER"
+        "type": "STRING"
       },
       {
         "mode": "NULLABLE",
@@ -524,7 +519,7 @@
       {
         "mode": "NULLABLE",
         "name": "funder_muxed_id",
-        "type": "INTEGER"
+        "type": "STRING"
       },
       {
         "mode": "NULLABLE",
@@ -554,7 +549,7 @@
       {
         "mode": "NULLABLE",
         "name": "into_muxed_id",
-        "type": "INTEGER"
+        "type": "STRING"
       },
       {
         "mode": "NULLABLE",
@@ -713,7 +708,7 @@
       {
         "mode": "NULLABLE",
         "name": "to_muxed_id",
-        "type": "INTEGER"
+        "type": "STRING"
       },
       {
         "mode": "NULLABLE",
@@ -728,7 +723,7 @@
       {
         "mode": "NULLABLE",
         "name": "trustee_muxed_id",
-        "type": "INTEGER"
+        "type": "STRING"
       },
       {
         "mode": "NULLABLE",
@@ -753,7 +748,7 @@
       {
         "mode": "NULLABLE",
         "name": "trustor_muxed_id",
-        "type": "INTEGER"
+        "type": "STRING"
       },
       {
         "mode": "NULLABLE",
@@ -813,7 +808,7 @@
       {
         "mode": "NULLABLE",
         "name": "begin_sponsor_muxed_id",
-        "type": "INTEGER"
+        "type": "STRING"
       },
       {
         "mode": "NULLABLE",
@@ -974,6 +969,11 @@
     "mode": "NULLABLE",
     "name": "type",
     "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "type_string",
+    "type": "STRING"
   },
   {
     "mode": "NULLABLE",

--- a/schemas/history_transactions_schema.json
+++ b/schemas/history_transactions_schema.json
@@ -16,11 +16,6 @@
   },
   {
     "mode": "NULLABLE",
-    "name": "application_order",
-    "type": "INTEGER"
-  },
-  {
-    "mode": "NULLABLE",
     "name": "account",
     "type": "STRING"
   },
@@ -128,6 +123,26 @@
     "mode": "NULLABLE",
     "name": "min_account_sequence_ledger_gap",
     "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "tx_envelope",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "tx_result",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "tx_meta",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "tx_fee_meta",
+    "type": "STRING"
   },
   {
     "mode": "REPEATED",


### PR DESCRIPTION
PR in conjunction with stellar-etl [PR#166](https://github.com/stellar/stellar-etl/pull/166) to update Hubble 2.0 to accommodate `tx_envelope`, `tx_result`, `tx_meta` and `tx_fee_meta` in `history_transactions`.

Closes https://github.com/stellar/hubble/issues/298