### PR TITLE
Fix `ephemeral_storage` syntax

### DIFF
--- a/airflow_variables.txt
+++ b/airflow_variables.txt
@@ -93,21 +93,21 @@
             "requests": {
                 "cpu": "1.2",
                 "memory": "5Gi",
-                "ephemeral_storage": "10Mi",
+                "ephemeral-storage": "10Mi",
             },
         },
         "cc": {
             "requests": {
                 "cpu": "1.2",
                 "memory": "15Gi",
-                "ephemeral_storage": "10Gi",
+                "ephemeral-storage": "10Gi",
             },
         },
         "state": {
             "requests": {
                 "cpu": "1.2",
                 "memory": "20Gi",
-                "ephemeral_storage": "12Gi",
+                "ephemeral-storage": "12Gi",
             },
         }
     },

--- a/airflow_variables_dev.txt
+++ b/airflow_variables_dev.txt
@@ -92,21 +92,21 @@
             "requests": {
                 "cpu": "1.2",
                 "memory": "5Gi",
-                "ephemeral_storage": "10Mi",
+                "ephemeral-storage": "10Mi",
             },
         },
         "cc": {
             "requests": {
                 "cpu": "1.2",
                 "memory": "15Gi",
-                "ephemeral_storage": "10Gi",
+                "ephemeral-storage": "10Gi",
             },
         },
         "state": {
             "requests": {
                 "cpu": "1.2",
                 "memory": "20Gi",
-                "ephemeral_storage": "12Gi",
+                "ephemeral-storage": "12Gi",
             },
         }
     },


### PR DESCRIPTION
As [seen at the Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#setting-requests-and-limits-for-local-ephemeral-storage) and already tested at Airflow, this PR fixes the `resources` variable with the correct syntax.