### PR TITLE
Add delete partition tasks to eho

### DIFF
--- a/dags/history_archive_with_captive_core_dag.py
+++ b/dags/history_archive_with_captive_core_dag.py
@@ -119,12 +119,13 @@ insert_enriched_hist_task = build_bq_insert_job(dag, internal_project, internal_
 insert_enriched_hist_pub_task = build_bq_insert_job(dag, public_project, public_dataset, "enriched_history_operations", partition=True)
 insert_enriched_ma_hist_task = build_bq_insert_job(dag, internal_project, internal_dataset, "enriched_meaningful_history_operations", partition=True)
 
-time_task >> write_op_stats >> op_export_task >> delete_old_op_task >> send_ops_to_bq_task >> wait_on_dag >> insert_enriched_hist_task >> delete_enrich_ma_op_task >> insert_enriched_ma_hist_task
-op_export_task >> delete_old_op_pub_task >> send_ops_to_pub_task >> wait_on_dag >> insert_enriched_hist_pub_task
+time_task >> write_op_stats >> op_export_task >> delete_old_op_task >> send_ops_to_bq_task >> wait_on_dag >> delete_enrich_op_task 
+delete_enrich_op_task >> insert_enriched_hist_task >> delete_enrich_ma_op_task >> insert_enriched_ma_hist_task
+op_export_task >> delete_old_op_pub_task >> send_ops_to_pub_task >> wait_on_dag >> delete_enrich_op_pub_task >> insert_enriched_hist_pub_task
 time_task >> write_trade_stats >> trade_export_task  >> delete_old_trade_task >> send_trades_to_bq_task
 trade_export_task >> delete_old_trade_pub_task >> send_trades_to_pub_task
 time_task >> write_effects_stats >> effects_export_task >> delete_old_effects_task >> send_effects_to_bq_task
 time_task >> write_effects_stats >> effects_export_task >> delete_old_effects_pub_task >> send_effects_to_pub_task
 trade_export_task >> delete_old_trade_pub_task >> send_trades_to_pub_task
-time_task >> write_tx_stats >> tx_export_task >> delete_old_tx_task >> send_txs_to_bq_task
-tx_export_task >> delete_old_tx_pub_task >> send_txs_to_pub_task
+time_task >> write_tx_stats >> tx_export_task >> delete_old_tx_task >> send_txs_to_bq_task >> wait_on_dag
+tx_export_task >> delete_old_tx_pub_task >> send_txs_to_pub_task >> wait_on_dag

--- a/dags/queries/enriched_history_operations.sql
+++ b/dags/queries/enriched_history_operations.sql
@@ -7,38 +7,129 @@ Table is heavily used for KPI calculation and Metabase Dashboards.
 */
 SELECT
 -- expanded operations details fields
-details.account, details.amount, details.asset_code, details.asset_issuer, details.asset_type, details.authorize,
-CASE WHEN details.balance_id IS NOT NULL THEN details.balance_id ELSE details.claimable_balance_id END as balance_id, 
-details.buying_asset_code, details.buying_asset_issuer, details.buying_asset_type, details.from, details.funder,
-details.high_threshold, details.home_domain, details.inflation_dest, details.into, details.limit, details.low_threshold,
-details.master_key_weight, details.med_threshold, details.name, details.offer_id, details.path,
-details.price, details.price_r.d, details.price_r.n, details.selling_asset_code, details.selling_asset_issuer, details.selling_asset_type,
-details.set_flags, details.set_flags_s, details.signer_key, details.signer_weight, details.source_amount, details.source_asset_code,
-details.source_asset_issuer, details.source_asset_type, details.source_max, details.starting_balance, details.to, details.trustee,
-details.trustor, details.trustline_asset, details.value, details.clear_flags, details.clear_flags_s, details.destination_min, details.bump_to,
-details.sponsor, details.sponsored_id, details.begin_sponsor, details.authorize_to_maintain_liabilities, details.clawback_enabled,
-details.liquidity_pool_id, details.reserve_a_asset_type, details.reserve_a_asset_code, details.reserve_a_asset_issuer,
-details.reserve_a_max_amount, details.reserve_a_deposit_amount, details.reserve_b_asset_type, details.reserve_b_asset_code,
-details.reserve_b_asset_issuer, details.reserve_b_max_amount, details.reserve_b_deposit_amount, details.min_price,
-details.min_price_r, details.max_price, details.max_price_r,
-details.shares_received, details.reserve_a_min_amount, details.reserve_b_min_amount, details.shares,
-details.reserve_a_withdraw_amount, details.reserve_b_withdraw_amount,
--- operation fields
-null as op_application_order, ho.id as op_id, source_account as op_source_account,
-source_account_muxed as op_source_account_muxed, transaction_id, type,
--- transaction fields
-transaction_hash, ledger_sequence, null as txn_application_order, ht.account as txn_account,
-account_sequence, max_fee, ht.operation_count as txn_operation_count, ht.created_at as txn_created_at,
-memo_type, memo, time_bounds, successful, fee_charged, fee_account, new_max_fee, account_muxed, fee_account_muxed,
--- ledger fields
-ledger_hash, previous_ledger_hash, transaction_count, hl.operation_count as ledger_operation_count, closed_at,
-hl.id as ledger_id, total_coins,
-fee_pool, base_fee, base_reserve, max_tx_set_size, protocol_version, successful_transaction_count, failed_transaction_count,
-ho.batch_id as batch_id, ho.batch_run_date as batch_run_date, current_timestamp() as batch_insert_ts,
---new protocol 19 fields for transaction preconditions
-ht.ledger_bounds as ledger_bounds, ht.min_account_sequence as min_account_sequence, 
-ht.min_account_sequence_age as min_account_sequence_age, ht.min_account_sequence_ledger_gap as min_account_sequence_ledger_gap,
-ht.extra_signers as extra_signers
+  details.account
+  , details.amount
+  , details.asset_code
+  , details.asset_issuer
+  , details.asset_type
+  , details.authorize
+  , CASE WHEN details.balance_id IS NOT NULL THEN details.balance_id ELSE details.claimable_balance_id END as balance_id
+  , details.buying_asset_code
+  , details.buying_asset_issuer
+  , details.buying_asset_type
+  , details.from
+  , details.funder
+  , details.high_threshold
+  , details.home_domain
+  , details.inflation_dest
+  , details.into
+  , details.limit
+  , details.low_threshold
+  , details.master_key_weight
+  , details.med_threshold
+  , details.name
+  , details.offer_id
+  , details.path
+  , details.price
+  , details.price_r.d
+  , details.price_r.n
+  , details.selling_asset_code
+  , details.selling_asset_issuer
+  , details.selling_asset_type
+  , details.set_flags
+  , details.set_flags_s
+  , details.signer_key
+  , details.signer_weight
+  , details.source_amount
+  , details.source_asset_code
+  , details.source_asset_issuer
+  , details.source_asset_type
+  , details.source_max
+  , details.starting_balance
+  , details.to
+  , details.trustee
+  , details.trustor
+  , details.trustline_asset
+  , details.value
+  , details.clear_flags
+  , details.clear_flags_s
+  , details.destination_min
+  , details.bump_to
+  , details.sponsor
+  , details.sponsored_id
+  , details.begin_sponsor
+  , details.authorize_to_maintain_liabilities
+  , details.clawback_enabled
+  , details.liquidity_pool_id
+  , details.reserve_a_asset_type
+  , details.reserve_a_asset_code
+  , details.reserve_a_asset_issuer
+  , details.reserve_a_max_amount
+  , details.reserve_a_deposit_amount
+  , details.reserve_b_asset_type
+  , details.reserve_b_asset_code
+  , details.reserve_b_asset_issuer
+  , details.reserve_b_max_amount
+  , details.reserve_b_deposit_amount
+  , details.min_price
+  , details.min_price_r
+  , details.max_price
+  , details.max_price_r
+  , details.shares_received
+  , details.reserve_a_min_amount
+  , details.reserve_b_min_amount
+  , details.shares
+  , details.reserve_a_withdraw_amount
+  , details.reserve_b_withdraw_amount
+  -- operation fields
+  , null as op_application_order
+  , ho.id as op_id
+  , source_account as op_source_account
+  , source_account_muxed as op_source_account_muxed
+  , transaction_id
+  , type
+  -- transaction fields
+  , transaction_hash
+  , ledger_sequence
+  , null as txn_application_order
+  , ht.account as txn_account
+  , account_sequence
+  , max_fee
+  , ht.operation_count as txn_operation_count
+  , ht.created_at as txn_created_at
+  , memo_type
+  , memo
+  , time_bounds
+  , successful
+  , fee_charged
+  , fee_account
+  , new_max_fee
+  , account_muxed
+  , fee_account_muxed
+  -- ledger fields
+  , ledger_hash
+  , previous_ledger_hash
+  , transaction_count
+  , hl.operation_count as ledger_operation_count
+  , closed_at
+  ,hl.id as ledger_id
+  , total_coins
+  , fee_pool
+  , base_fee
+  , base_reserve
+  , max_tx_set_size
+  , protocol_version
+  , successful_transaction_count
+  , failed_transaction_count
+  , ho.batch_id as batch_id
+  , ho.batch_run_date as batch_run_date
+  , current_timestamp() as batch_insert_ts
+  --new protocol 19 fields for transaction preconditions
+  , ht.ledger_bounds as ledger_bounds
+  , ht.min_account_sequence as min_account_sequence
+  , ht.min_account_sequence_age as min_account_sequence_age
+  , ht.min_account_sequence_ledger_gap as min_account_sequence_ledger_gap
+  , ht.extra_signers as extra_signers
 FROM `{project_id}.{dataset_id}.history_operations` ho
 JOIN `{project_id}.{dataset_id}.history_transactions` ht
     on ho.transaction_id=ht.id

--- a/dags/queries/enriched_history_operations.sql
+++ b/dags/queries/enriched_history_operations.sql
@@ -3,171 +3,47 @@ Query denormalizes the history_ledgers, history_transactions and history_operati
 the `history_operation_id` level. Table is loaded using an append-only load pattern by batch_id.
 Note: as attributes are added to the `details` blob in history_operations, it is recommended
 to add relevant data as a new field in the enriched_history_operations table.
-
 Table is heavily used for KPI calculation and Metabase Dashboards.
 */
 SELECT
-  -- expanded operations details fields
-  details.account
-  , details.account_muxed AS op_account_muxed
-  , details.account_muxed_id AS op_account_muxed_id
-  , details.account_id AS op_account_id
-  , details.amount
-  , details.asset
-  , details.asset_code
-  , details.asset_issuer
-  , details.asset_type
-  , details.authorize
-  , CASE 
-      WHEN details.balance_id IS NOT NULL then details.balance_id 
-      ELSE details.claimable_balance_id 
-  END AS balance_id
-  , details.claimant
-  , details.claimant_muxed
-  , details.claimant_muxed_id
-  , details.claimants
-  , details.data_account_id
-  , details.data_name
-  , details.buying_asset_code
-  , details.buying_asset_issuer
-  , details.buying_asset_type
-  , details.from
-  , details.from_muxed
-  , details.from_muxed_id
-  , details.funder
-  , details.funder_muxed
-  , details.funder_muxed_id
-  , details.high_threshold
-  , details.home_domain
-  , details.inflation_dest
-  , details.into
-  , details.into_muxed
-  , details.into_muxed_id
-  , details.limit
-  , details.low_threshold
-  , details.master_key_weight
-  , details.med_threshold
-  , details.name
-  , details.offer_id
-  , details.path
-  , details.price
-  , details.price_r.d
-  , details.price_r.n
-  , details.selling_asset_code
-  , details.selling_asset_issuer
-  , details.selling_asset_type
-  , details.set_flags
-  , details.set_flags_s
-  , details.signer_account_id
-  , details.signer_key
-  , details.signer_weight
-  , details.source_amount
-  , details.source_asset_code
-  , details.source_asset_issuer
-  , details.source_asset_type
-  , details.source_max
-  , details.starting_balance
-  , details.to
-  , details.to_muxed
-  , details.to_muxed_id
-  , details.trustee
-  , details.trustee_muxed
-  , details.trustee_muxed_id
-  , details.trustor
-  , details.trustor_muxed
-  , details.trustor_muxed_id
-  , details.trustline_account_id
-  , details.trustline_asset
-  , details.value
-  , details.clear_flags
-  , details.clear_flags_s
-  , details.destination_min
-  , details.bump_to
-  , details.sponsor
-  , details.sponsored_id
-  , details.begin_sponsor
-  , details.begin_sponsor_muxed
-  , details.begin_sponsor_muxed_id
-  , details.authorize_to_maintain_liabilities
-  , details.clawback_enabled
-  , details.liquidity_pool_id
-  , details.reserve_a_asset_type
-  , details.reserve_a_asset_code
-  , details.reserve_a_asset_issuer
-  , details.reserve_a_max_amount
-  , details.reserve_a_deposit_amount
-  , details.reserve_b_asset_type
-  , details.reserve_b_asset_code
-  , details.reserve_b_asset_issuer
-  , details.reserve_b_max_amount
-  , details.reserve_b_deposit_amount
-  , details.min_price
-  , details.min_price_r
-  , details.max_price
-  , details.max_price_r
-  , details.shares_received
-  , details.reserve_a_min_amount
-  , details.reserve_b_min_amount
-  , details.shares
-  , details.reserve_a_withdraw_amount
-  , details.reserve_b_withdraw_amount
+-- expanded operations details fields
+details.account, details.amount, details.asset_code, details.asset_issuer, details.asset_type, details.authorize,
+CASE WHEN details.balance_id IS NOT NULL THEN details.balance_id ELSE details.claimable_balance_id END as balance_id, 
+details.buying_asset_code, details.buying_asset_issuer, details.buying_asset_type, details.from, details.funder,
+details.high_threshold, details.home_domain, details.inflation_dest, details.into, details.limit, details.low_threshold,
+details.master_key_weight, details.med_threshold, details.name, details.offer_id, details.path,
+details.price, details.price_r.d, details.price_r.n, details.selling_asset_code, details.selling_asset_issuer, details.selling_asset_type,
+details.set_flags, details.set_flags_s, details.signer_key, details.signer_weight, details.source_amount, details.source_asset_code,
+details.source_asset_issuer, details.source_asset_type, details.source_max, details.starting_balance, details.to, details.trustee,
+details.trustor, details.trustline_asset, details.value, details.clear_flags, details.clear_flags_s, details.destination_min, details.bump_to,
+details.sponsor, details.sponsored_id, details.begin_sponsor, details.authorize_to_maintain_liabilities, details.clawback_enabled,
+details.liquidity_pool_id, details.reserve_a_asset_type, details.reserve_a_asset_code, details.reserve_a_asset_issuer,
+details.reserve_a_max_amount, details.reserve_a_deposit_amount, details.reserve_b_asset_type, details.reserve_b_asset_code,
+details.reserve_b_asset_issuer, details.reserve_b_max_amount, details.reserve_b_deposit_amount, details.min_price,
+details.min_price_r, details.max_price, details.max_price_r,
+details.shares_received, details.reserve_a_min_amount, details.reserve_b_min_amount, details.shares,
+details.reserve_a_withdraw_amount, details.reserve_b_withdraw_amount,
 -- operation fields
-  , ho.id AS op_id
-  , source_account AS op_source_account
-  , source_account_muxed AS op_source_account_muxed
-  , transaction_id
-  , type
-  , type_string
-  -- transaction fields
-  , ht.tx_envelope
-  , ht.tx_result
-  , ht.tx_meta
-  , ht.tx_fee_meta
-  , transaction_hash
-  , ledger_sequence
-  , ht.account AS txn_account
-  , account_sequence
-  , max_fee
-  , ht.operation_count AS txn_operation_count
-  , ht.created_at AS txn_created_at
-  , memo_type
-  , memo
-  , time_bounds
-  , successful
-  , fee_charged
-  , fee_account
-  , new_max_fee
-  , account_muxed
-  , fee_account_muxed
+null as op_application_order, ho.id as op_id, source_account as op_source_account,
+source_account_muxed as op_source_account_muxed, transaction_id, type,
+-- transaction fields
+transaction_hash, ledger_sequence, null as txn_application_order, ht.account as txn_account,
+account_sequence, max_fee, ht.operation_count as txn_operation_count, ht.created_at as txn_created_at,
+memo_type, memo, time_bounds, successful, fee_charged, fee_account, new_max_fee, account_muxed, fee_account_muxed,
 -- ledger fields
-  , ledger_hash
-  , previous_ledger_hash
-  , transaction_count
-  , hl.operation_count AS ledger_operation_count
-  , closed_at
-  , hl.id AS ledger_id
-  , total_coins
-  , fee_pool
-  , base_fee
-  , base_reserve
-  , max_tx_set_size
-  , protocol_version
-  , successful_transaction_count
-  , failed_transaction_count
-  , ho.batch_id AS batch_id
-  , ho.batch_run_date AS batch_run_date
-  , current_timestamp() AS batch_insert_ts
+ledger_hash, previous_ledger_hash, transaction_count, hl.operation_count as ledger_operation_count, closed_at,
+hl.id as ledger_id, total_coins,
+fee_pool, base_fee, base_reserve, max_tx_set_size, protocol_version, successful_transaction_count, failed_transaction_count,
+ho.batch_id as batch_id, ho.batch_run_date as batch_run_date, current_timestamp() as batch_insert_ts,
 --new protocol 19 fields for transaction preconditions
-  , ht.ledger_bounds AS ledger_bounds
-  , ht.min_account_sequence AS min_account_sequence
-  , ht.min_account_sequence_age AS min_account_sequence_age
-  , ht.min_account_sequence_ledger_gap AS min_account_sequence_ledger_gap
-  , ht.extra_signers AS extra_signers
+ht.ledger_bounds as ledger_bounds, ht.min_account_sequence as min_account_sequence, 
+ht.min_account_sequence_age as min_account_sequence_age, ht.min_account_sequence_ledger_gap as min_account_sequence_ledger_gap,
+ht.extra_signers as extra_signers
 FROM `{project_id}.{dataset_id}.history_operations` ho
 JOIN `{project_id}.{dataset_id}.history_transactions` ht
-    ON ho.transaction_id=ht.id
+    on ho.transaction_id=ht.id
 JOIN `{project_id}.{dataset_id}.history_ledgers` hl
-    ON ht.ledger_sequence=hl.sequence
+    on ht.ledger_sequence=hl.sequence
 WHERE ho.batch_id = '{batch_id}'
     AND ho.batch_run_date = '{batch_run_date}'
     AND hl.batch_run_date >= '{prev_batch_run_date}'

--- a/dags/queries/enriched_history_operations.sql
+++ b/dags/queries/enriched_history_operations.sql
@@ -13,7 +13,10 @@ SELECT
   , details.asset_issuer
   , details.asset_type
   , details.authorize
-  , CASE WHEN details.balance_id IS NOT NULL THEN details.balance_id ELSE details.claimable_balance_id END as balance_id
+  , CASE 
+      WHEN details.balance_id IS NOT NULL THEN details.balance_id 
+      ELSE details.claimable_balance_id 
+    END as balance_id
   , details.buying_asset_code
   , details.buying_asset_issuer
   , details.buying_asset_type
@@ -83,20 +86,20 @@ SELECT
   , details.reserve_b_withdraw_amount
   -- operation fields
   , null as op_application_order
-  , ho.id as op_id
-  , source_account as op_source_account
-  , source_account_muxed as op_source_account_muxed
+  , ho.id AS op_id
+  , source_account AS op_source_account
+  , source_account_muxed AS op_source_account_muxed
   , transaction_id
   , type
   -- transaction fields
   , transaction_hash
   , ledger_sequence
-  , null as txn_application_order
-  , ht.account as txn_account
+  , NULL AS txn_application_order
+  , ht.account AS txn_account
   , account_sequence
   , max_fee
-  , ht.operation_count as txn_operation_count
-  , ht.created_at as txn_created_at
+  , ht.operation_count AS txn_operation_count
+  , ht.created_at AS txn_created_at
   , memo_type
   , memo
   , time_bounds
@@ -110,9 +113,9 @@ SELECT
   , ledger_hash
   , previous_ledger_hash
   , transaction_count
-  , hl.operation_count as ledger_operation_count
+  , hl.operation_count AS ledger_operation_count
   , closed_at
-  ,hl.id as ledger_id
+  , hl.id AS ledger_id
   , total_coins
   , fee_pool
   , base_fee
@@ -121,20 +124,20 @@ SELECT
   , protocol_version
   , successful_transaction_count
   , failed_transaction_count
-  , ho.batch_id as batch_id
-  , ho.batch_run_date as batch_run_date
-  , current_timestamp() as batch_insert_ts
+  , ho.batch_id AS batch_id
+  , ho.batch_run_date AS batch_run_date
+  , current_timestamp() AS batch_insert_ts
   --new protocol 19 fields for transaction preconditions
-  , ht.ledger_bounds as ledger_bounds
-  , ht.min_account_sequence as min_account_sequence
-  , ht.min_account_sequence_age as min_account_sequence_age
-  , ht.min_account_sequence_ledger_gap as min_account_sequence_ledger_gap
-  , ht.extra_signers as extra_signers
+  , ht.ledger_bounds AS ledger_bounds
+  , ht.min_account_sequence AS min_account_sequence
+  , ht.min_account_sequence_age AS min_account_sequence_age
+  , ht.min_account_sequence_ledger_gap AS min_account_sequence_ledger_gap
+  , ht.extra_signers AS extra_signers
 FROM `{project_id}.{dataset_id}.history_operations` ho
 JOIN `{project_id}.{dataset_id}.history_transactions` ht
-    on ho.transaction_id=ht.id
+    ON ho.transaction_id=ht.id
 JOIN `{project_id}.{dataset_id}.history_ledgers` hl
-    on ht.ledger_sequence=hl.sequence
+    ON ht.ledger_sequence=hl.sequence
 WHERE ho.batch_id = '{batch_id}'
     AND ho.batch_run_date = '{batch_run_date}'
     AND hl.batch_run_date >= '{prev_batch_run_date}'


### PR DESCRIPTION
Add a new task to dag definition: `delete_enrich_op_task` which will drop old partitions before inserting new records in the `enriched_history_operations` tables