### PR TITLE
Remove deprecated field from `enriched_hist_ops`

### DIFF
--- a/dags/queries/enriched_history_operations.sql
+++ b/dags/queries/enriched_history_operations.sql
@@ -85,7 +85,6 @@ SELECT
   , details.reserve_a_withdraw_amount
   , details.reserve_b_withdraw_amount
   -- operation fields
-  , null as op_application_order
   , ho.id AS op_id
   , source_account AS op_source_account
   , source_account_muxed AS op_source_account_muxed
@@ -94,7 +93,6 @@ SELECT
   -- transaction fields
   , transaction_hash
   , ledger_sequence
-  , NULL AS txn_application_order
   , ht.account AS txn_account
   , account_sequence
   , max_fee


### PR DESCRIPTION
This PR removes the `application_order` (deprecated since [PR#176](https://github.com/stellar/stellar-etl/commit/ac3939df5b71b655c97698b4adfbf7b1d1b65590) from `stellar-etl` repository) field from the query that generates `enriched_history_operations` table.