### PR TITLE
Fix meaningful history ops sql

### DIFF
--- a/dags/queries/enriched_meaningful_history_operations.sql
+++ b/dags/queries/enriched_meaningful_history_operations.sql
@@ -8,7 +8,9 @@ Table is heavily used for Partner Metabase Dashboards.
 NOTE: relevant assets are proprietary internal data and should not be shared externally.
 */
 SELECT
-  *
+  eho.*
+  , ma.code
+  , ma.issuer
 FROM `{project_id}.{dataset_id}.enriched_history_operations` eho
 INNER JOIN `{project_id}.{dataset_id}.meaningful_assets` ma ON
   (eho.asset_code = ma.code AND eho.asset_issuer = ma.issuer) OR


### PR DESCRIPTION
Added the `type` field to the `meaningful_assets` view, which created duplicate column names in the sql for `enriched_meaningful_history_operations` table. This PR fixes the SQL to only select `type` from `history_operations` table and not from the `meaningful_assets` view.