### PR TITLE
inserted cluster and partition fields

### DIFF
--- a/airflow_variables.json
+++ b/airflow_variables.json
@@ -121,13 +121,13 @@
       "liquidity_pool_id", 
       "last_modified_ledger" 
     ], 
-    "enriched_history_operations_te": [
+    "enriched_history_operations": [
       "ledger_sequence", 
       "transaction_id", 
       "account", 
       "type"
     ], 
-    "enriched_meaningful_history_operations_te": [
+    "enriched_meaningful_history_operations": [
       "ledger_sequence", 
       "transaction_id", 
       "account", 

--- a/airflow_variables.json
+++ b/airflow_variables.json
@@ -63,59 +63,76 @@
   "bq_dataset": "crypto_stellar_internal_2",
   "bq_project": "hubble-261722",
   "cluster_fields": {
-    "accounts": [
-      "account_id",
+    "accounts": [ 
+      "account_id", 
+      "last_modified_ledger" 
+    ], 
+    "account_signers": [ 
+      "account_id", 
+      "signer",
+      "last_modified_ledger" 
+    ], 
+    "claimable_balances": [ 
+      "asset_id", 
       "last_modified_ledger"
-    ],
-    "account_signers": [
-      "account_id",
-      "last_modified_ledger"
-    ],
-    "claimable_balances": [
-      "balance_id",
-      "last_modified_ledger",
-      "sponsor"
-    ],
-    "history_assets": [
-      "asset_code",
-      "asset_type",
-      "asset_issuer"
-    ],
-    "history_effects": [
-      "address",
-      "operation_id",
-      "type"
-    ],
-    "history_ledgers": [
-      "sequence",
-      "closed_at"
-    ],
+    ], 
+    "history_assets": [ 
+      "asset_code", 
+      "asset_issuer", 
+      "asset_type" 
+    ], 
+    "history_effects": [ 
+      "address", 
+      "operation_id", 
+      "type" 
+    ], 
+    "history_ledgers": [ 
+      "sequence", 
+      "closed_at" 
+    ], 
     "history_operations": [
-      "id",
-      "transaction_id",
-      "source_account"
-    ],
+      "transaction_id", 
+      "source_account", 
+      "type"
+    ], 
     "history_trades": [
-      "history_operation_id",
-      "ledger_closed_at"
-    ],
-    "history_transactions": [
-      "id",
-      "ledger_sequence",
-      "account"
-    ],
+      "selling_asset_id", 
+      "buying_asset_id", 
+      "trade_type" 
+    ], 
+    "history_transactions": [ 
+      "account", 
+      "ledger_sequence", 
+      "successful" 
+    ], 
     "offers": [
-      "seller_id",
-      "last_modified_ledger"
-    ],
-    "liquidity_pools": [
-      "liquidity_pool_id",
-      "last_modified_ledger"
-    ],
-    "trust_lines": [
-      "account_id",
-      "last_modified_ledger"
-    ]
+      "selling_asset_id", 
+      "buying_asset_id", 
+      "last_modified_ledger" 
+    ], 
+    "liquidity_pools": [ 
+      "liquidity_pool_id", 
+      "asset_a_id", 
+      "asset_b_id" , 
+      "last_modified_ledger" 
+    ], "trust_lines": [ 
+      "account_id", 
+      "asset_id", 
+      "liquidity_pool_id", 
+      "last_modified_ledger" 
+    ], 
+    "enriched_history_operations_te": [
+      "ledger_sequence", 
+      "transaction_id", 
+      "account", 
+      "type"
+    ], 
+    "enriched_meaningful_history_operations_te": [
+      "ledger_sequence", 
+      "transaction_id", 
+      "account", 
+      "type"
+    ] 
   },
   "gcs_exported_data_bucket_name": "us-central1-hubble-2-d948d67b-bucket",
   "gcs_exported_object_prefix": "dag-exported",
@@ -161,6 +178,50 @@
     },
     "history_assets": {
       "type": "MONTH",
+      "field": "batch_run_date"
+    },
+    "accounts": {
+      "type": "MONTH", 
+      "field": "batch_run_date"
+    }, 
+    "account_signers": {
+      "type": "MONTH", 
+      "field": "batch_run_date"
+    }, 
+    "claimable_balances": {
+      "type": "MONTH", 
+      "field": "batch_run_date"
+    },
+    "history_effects": {
+      "type": "MONTH", 
+      "field": "batch_run_date"
+    }, 
+    "history_ledgers": {
+      "type": "MONTH", 
+      "field": "closed_at"
+    }, 
+    "history_operations":{
+      "type": "MONTH", 
+      "field": "batch_run_date"
+    }, 
+    "history_trades": {
+      "type": "MONTH", 
+      "field": "ledger_closed_at"
+    }, 
+    "history_transactions": {
+      "type": "MONTH", 
+      "field": "batch_run_date"
+    }, 
+    "offers": {
+      "type": "MONTH", 
+      "field": "batch_run_date"
+    }, 
+    "liquidity_pools": {
+      "type": "MONTH", 
+      "field": "batch_run_date"
+    }, 
+    "trust_lines": {
+      "type": "MONTH", 
       "field": "batch_run_date"
     }
   },

--- a/airflow_variables_dev.json
+++ b/airflow_variables_dev.json
@@ -44,58 +44,75 @@
   "bq_dataset": "test_gcp_airflow_internal",
   "bq_project": "test-hubble-319619",
   "cluster_fields": {
-    "accounts": [
-      "account_id",
+    "accounts": [ 
+      "account_id", 
+      "last_modified_ledger" 
+    ], 
+    "account_signers": [ 
+      "account_id", 
+      "signer",
+      "last_modified_ledger" 
+    ], 
+    "claimable_balances": [ 
+      "asset_id", 
       "last_modified_ledger"
-    ],
-    "account_signers": [
-      "account_id",
-      "last_modified_ledger"
-    ],
-    "claimable_balances": [
-      "balance_id",
-      "last_modified_ledger",
-      "sponsor"
-    ],
-    "history_assets": [
-      "asset_code",
-      "asset_type",
-      "asset_issuer"
-    ],
-    "history_effects": [
-      "address",
-      "operation_id",
-      "type"
-    ],
-    "history_ledgers": [
-      "sequence",
-      "closed_at"
-    ],
+    ], 
+    "history_assets": [ 
+      "asset_code", 
+      "asset_issuer", 
+      "asset_type" 
+    ], 
+    "history_effects": [ 
+      "address", 
+      "operation_id", 
+      "type" 
+    ], 
+    "history_ledgers": [ 
+      "sequence", 
+      "closed_at" 
+    ], 
     "history_operations": [
-      "id",
-      "transaction_id",
-      "source_account"
-    ],
+      "transaction_id", 
+      "source_account", 
+      "type"
+    ], 
     "history_trades": [
-      "history_operation_id",
-      "ledger_closed_at"
-    ],
-    "history_transactions": [
-      "id",
-      "ledger_sequence",
-      "account"
-    ],
+      "selling_asset_id", 
+      "buying_asset_id", 
+      "trade_type" 
+    ], 
+    "history_transactions": [ 
+      "account", 
+      "ledger_sequence", 
+      "successful" 
+    ], 
     "offers": [
-      "seller_id",
-      "last_modified_ledger"
-    ],
-    "liquidity_pools": [
-      "liquidity_pool_id",
-      "last_modified_ledger"
-    ],
-    "trust_lines": [
-      "account_id",
-      "last_modified_ledger"
+      "selling_asset_id", 
+      "buying_asset_id", 
+      "last_modified_ledger" 
+    ], 
+    "liquidity_pools": [ 
+      "liquidity_pool_id", 
+      "asset_a_id", 
+      "asset_b_id" , 
+      "last_modified_ledger" 
+    ], "trust_lines": [ 
+      "account_id", 
+      "asset_id", 
+      "liquidity_pool_id", 
+      "last_modified_ledger" 
+    ], 
+    "enriched_history_operations_te": [
+      "ledger_sequence", 
+      "transaction_id", 
+      "account", 
+      "type"
+    ], 
+    "enriched_meaningful_history_operations_te": [
+      "ledger_sequence", 
+      "transaction_id", 
+      "account", 
+      "type"
     ]
   },
   "gcs_exported_data_bucket_name": "us-central1-hubble-1pt5-dev-7db0e004-bucket",
@@ -141,6 +158,50 @@
     },
     "history_assets": {
       "type": "MONTH",
+      "field": "batch_run_date"
+    },
+    "accounts": {
+      "type": "MONTH", 
+      "field": "batch_run_date"
+    }, 
+    "account_signers": {
+      "type": "MONTH", 
+      "field": "batch_run_date"
+    }, 
+    "claimable_balances": {
+      "type": "MONTH", 
+      "field": "batch_run_date"
+    },
+    "history_effects": {
+      "type": "MONTH", 
+      "field": "batch_run_date"
+    }, 
+    "history_ledgers": {
+      "type": "MONTH", 
+      "field": "closed_at"
+    }, 
+    "history_operations":{
+      "type": "MONTH", 
+      "field": "batch_run_date"
+    }, 
+    "history_trades": {
+      "type": "MONTH", 
+      "field": "ledger_closed_at"
+    }, 
+    "history_transactions": {
+      "type": "MONTH", 
+      "field": "batch_run_date"
+    }, 
+    "offers": {
+      "type": "MONTH", 
+      "field": "batch_run_date"
+    }, 
+    "liquidity_pools": {
+      "type": "MONTH", 
+      "field": "batch_run_date"
+    }, 
+    "trust_lines": {
+      "type": "MONTH", 
       "field": "batch_run_date"
     }
   },

--- a/airflow_variables_dev.json
+++ b/airflow_variables_dev.json
@@ -102,13 +102,13 @@
       "liquidity_pool_id", 
       "last_modified_ledger" 
     ], 
-    "enriched_history_operations_te": [
+    "enriched_history_operations": [
       "ledger_sequence", 
       "transaction_id", 
       "account", 
       "type"
     ], 
-    "enriched_meaningful_history_operations_te": [
+    "enriched_meaningful_history_operations": [
       "ledger_sequence", 
       "transaction_id", 
       "account", 

--- a/dags/bucket_list_dag.py
+++ b/dags/bucket_list_dag.py
@@ -97,12 +97,12 @@ The apply tasks receive the location of the file in Google Cloud storage through
 Then, the task merges the entries in the file with the entries in the corresponding table in BigQuery. 
 Entries are updated, deleted, or inserted as needed.
 '''
-send_acc_to_bq_task = build_gcs_to_bq_task(dag, export_acc_task.task_id, internal_project, internal_dataset, table_names['accounts'], '', partition=False, cluster=False)
-send_bal_to_bq_task = build_gcs_to_bq_task(dag, export_bal_task.task_id, internal_project, internal_dataset, table_names['claimable_balances'], '', partition=False, cluster=False)
-send_off_to_bq_task = build_gcs_to_bq_task(dag, export_off_task.task_id, internal_project, internal_dataset, table_names['offers'], '', partition=False, cluster=False)
-send_pool_to_bq_task = build_gcs_to_bq_task(dag, export_pool_task.task_id, internal_project, internal_dataset, table_names['liquidity_pools'], '', partition=False, cluster=False)
-send_sign_to_bq_task = build_gcs_to_bq_task(dag, export_trust_task.task_id, internal_project, internal_dataset, table_names['signers'], '',  partition=False, cluster=False)
-send_trust_to_bq_task = build_gcs_to_bq_task(dag, export_trust_task.task_id, internal_project, internal_dataset, table_names['trustlines'], '',  partition=False, cluster=False)
+send_acc_to_bq_task = build_gcs_to_bq_task(dag, export_acc_task.task_id, internal_project, internal_dataset, table_names['accounts'], '', partition=True, cluster=True)
+send_bal_to_bq_task = build_gcs_to_bq_task(dag, export_bal_task.task_id, internal_project, internal_dataset, table_names['claimable_balances'], '', partition=True, cluster=True)
+send_off_to_bq_task = build_gcs_to_bq_task(dag, export_off_task.task_id, internal_project, internal_dataset, table_names['offers'], '', partition=True, cluster=True)
+send_pool_to_bq_task = build_gcs_to_bq_task(dag, export_pool_task.task_id, internal_project, internal_dataset, table_names['liquidity_pools'], '', partition=True, cluster=True)
+send_sign_to_bq_task = build_gcs_to_bq_task(dag, export_trust_task.task_id, internal_project, internal_dataset, table_names['signers'], '',  partition=True, cluster=True)
+send_trust_to_bq_task = build_gcs_to_bq_task(dag, export_trust_task.task_id, internal_project, internal_dataset, table_names['trustlines'], '',  partition=True, cluster=True)
 
 '''
 The apply tasks receive the location of the file in Google Cloud storage through Airflow's XCOM system.

--- a/dags/history_archive_with_captive_core_dag.py
+++ b/dags/history_archive_with_captive_core_dag.py
@@ -95,10 +95,10 @@ delete_old_tx_pub_task = build_delete_data_task(dag, public_project, public_data
 The send tasks receive the location of the file in Google Cloud storage through Airflow's XCOM system.
 Then, the task merges the unique entries in the file into the corresponding table in BigQuery.
 '''
-send_ops_to_bq_task = build_gcs_to_bq_task(dag, op_export_task.task_id, internal_project, internal_dataset, table_names['operations'], '', partition=True, cluster=False)
-send_trades_to_bq_task = build_gcs_to_bq_task(dag, trade_export_task.task_id, internal_project, internal_dataset, table_names['trades'], '', partition=False, cluster=False)
+send_ops_to_bq_task = build_gcs_to_bq_task(dag, op_export_task.task_id, internal_project, internal_dataset, table_names['operations'], '', partition=True, cluster=True)
+send_trades_to_bq_task = build_gcs_to_bq_task(dag, trade_export_task.task_id, internal_project, internal_dataset, table_names['trades'], '', partition=True, cluster=True)
 send_effects_to_bq_task = build_gcs_to_bq_task(dag, effects_export_task.task_id, internal_project, internal_dataset, table_names['effects'], '', partition=True, cluster=True)
-send_txs_to_bq_task = build_gcs_to_bq_task(dag, tx_export_task.task_id, internal_project, internal_dataset, table_names['transactions'], '', partition=True, cluster=False)
+send_txs_to_bq_task = build_gcs_to_bq_task(dag, tx_export_task.task_id, internal_project, internal_dataset, table_names['transactions'], '', partition=True, cluster=True)
 
 '''
 The send tasks receive the location of the file in Google Cloud storage through Airflow's XCOM system.
@@ -115,9 +115,9 @@ Must wait on history_archive_without_captive_core_dag to finish before beginning
 The internal dataset also creates a filtered table, `enriched_meaningful_history_operations` which filters down to only relevant asset ops.
 '''
 wait_on_dag = build_cross_deps(dag, "wait_on_ledgers_txs", "history_archive_without_captive_core")
-insert_enriched_hist_task = build_bq_insert_job(dag, internal_project, internal_dataset, "enriched_history_operations", partition=True)
-insert_enriched_hist_pub_task = build_bq_insert_job(dag, public_project, public_dataset, "enriched_history_operations", partition=True)
-insert_enriched_ma_hist_task = build_bq_insert_job(dag, internal_project, internal_dataset, "enriched_meaningful_history_operations", partition=True)
+insert_enriched_hist_task = build_bq_insert_job(dag, internal_project, internal_dataset, "enriched_history_operations", partition=True, cluster=True)
+insert_enriched_hist_pub_task = build_bq_insert_job(dag, public_project, public_dataset, "enriched_history_operations", partition=True, cluster=True)
+insert_enriched_ma_hist_task = build_bq_insert_job(dag, internal_project, internal_dataset, "enriched_meaningful_history_operations", partition=True, cluster=True)
 
 time_task >> write_op_stats >> op_export_task >> delete_old_op_task >> send_ops_to_bq_task >> wait_on_dag >> delete_enrich_op_task 
 delete_enrich_op_task >> insert_enriched_hist_task >> delete_enrich_ma_op_task >> insert_enriched_ma_hist_task

--- a/dags/history_archive_without_captive_core_dag.py
+++ b/dags/history_archive_without_captive_core_dag.py
@@ -84,7 +84,7 @@ The send tasks receive the location of the file in Google Cloud storage through 
 Then, the task merges the unique entries in the file into the corresponding table in BigQuery. 
 '''
 send_ledgers_to_bq_task = build_gcs_to_bq_task(dag, ledger_export_task.task_id, internal_project, internal_dataset, table_names['ledgers'], '', partition=True, cluster=False)
-send_assets_to_bq_task = build_gcs_to_bq_task(dag, asset_export_task.task_id, internal_project, internal_dataset, table_names['assets'], '', partition=False, cluster=False)
+send_assets_to_bq_task = build_gcs_to_bq_task(dag, asset_export_task.task_id, internal_project, internal_dataset, table_names['assets'], '', partition=True, cluster=True)
 
 '''
 The send tasks receive the location of the file in Google Cloud storage through Airflow's XCOM system.
@@ -97,7 +97,7 @@ send_assets_to_pub_task = build_gcs_to_bq_task(dag, asset_export_task.task_id, p
 The tasks below use a job in BigQuery to deduplicate the table history_assets_stg.
 The job refreshes the table history_assets with only new records.
 '''
-dedup_assets_bq_task = build_bq_insert_job(dag, internal_project, internal_dataset, table_names['assets'], partition=False, cluster=False, create=True)
+dedup_assets_bq_task = build_bq_insert_job(dag, internal_project, internal_dataset, table_names['assets'], partition=True, cluster=True, create=True)
 dedup_assets_pub_task = build_bq_insert_job(dag, public_project, public_dataset, table_names['assets'], partition=True, cluster=True, create=True)
 
 time_task >> write_ledger_stats >> ledger_export_task >> delete_old_ledger_task >> send_ledgers_to_bq_task

--- a/dags/state_table_dag.py
+++ b/dags/state_table_dag.py
@@ -85,12 +85,12 @@ The apply tasks receive the location of the file in Google Cloud storage through
 Then, the task merges the entries in the file with the entries in the corresponding table in BigQuery. 
 Entries are updated, deleted, or inserted as needed.
 '''
-send_acc_to_bq_task = build_gcs_to_bq_task(dag, changes_task.task_id, internal_project, internal_dataset, table_names['accounts'], '/*-accounts.txt', partition=False, cluster=False)
-send_bal_to_bq_task = build_gcs_to_bq_task(dag, changes_task.task_id, internal_project, internal_dataset, table_names['claimable_balances'], '/*-claimable_balances.txt', partition=False, cluster=False)
-send_off_to_bq_task = build_gcs_to_bq_task(dag, changes_task.task_id, internal_project, internal_dataset, table_names['offers'], '/*-offers.txt', partition=False, cluster=False)
-send_pool_to_bq_task = build_gcs_to_bq_task(dag, changes_task.task_id, internal_project, internal_dataset, table_names['liquidity_pools'], '/*-liquidity_pools.txt', partition=False, cluster=False)
-send_sign_to_bq_task = build_gcs_to_bq_task(dag, changes_task.task_id, internal_project, internal_dataset, table_names['signers'], '/*-signers.txt', partition=False, cluster=False)
-send_trust_to_bq_task = build_gcs_to_bq_task(dag, changes_task.task_id, internal_project, internal_dataset, table_names['trustlines'], '/*-trustlines.txt', partition=False, cluster=False)
+send_acc_to_bq_task = build_gcs_to_bq_task(dag, changes_task.task_id, internal_project, internal_dataset, table_names['accounts'], '/*-accounts.txt', partition=True, cluster=True)
+send_bal_to_bq_task = build_gcs_to_bq_task(dag, changes_task.task_id, internal_project, internal_dataset, table_names['claimable_balances'], '/*-claimable_balances.txt', partition=True, cluster=True)
+send_off_to_bq_task = build_gcs_to_bq_task(dag, changes_task.task_id, internal_project, internal_dataset, table_names['offers'], '/*-offers.txt', partition=True, cluster=True)
+send_pool_to_bq_task = build_gcs_to_bq_task(dag, changes_task.task_id, internal_project, internal_dataset, table_names['liquidity_pools'], '/*-liquidity_pools.txt', partition=True, cluster=True)
+send_sign_to_bq_task = build_gcs_to_bq_task(dag, changes_task.task_id, internal_project, internal_dataset, table_names['signers'], '/*-signers.txt', partition=True, cluster=True)
+send_trust_to_bq_task = build_gcs_to_bq_task(dag, changes_task.task_id, internal_project, internal_dataset, table_names['trustlines'], '/*-trustlines.txt', partition=True, cluster=True)
 
 '''
 The apply tasks receive the location of the file in Google Cloud storage through Airflow's XCOM system.

--- a/schemas/claimable_balances_schema.json
+++ b/schemas/claimable_balances_schema.json
@@ -411,6 +411,11 @@
     },
     {
       "mode": "NULLABLE",
+      "name": "asset_id",
+      "type": "INTEGER"
+    },
+    {
+      "mode": "NULLABLE",
       "name": "asset_amount",
       "type": "FLOAT"
     },

--- a/schemas/enriched_history_operations_schema.json
+++ b/schemas/enriched_history_operations_schema.json
@@ -1,103 +1,130 @@
 [
-    {
+  {
+    "mode": "NULLABLE",
+    "name": "account",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "op_account_muxed",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "op_account_muxed_id",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "op_account_id",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "amount",
+    "type": "FLOAT"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "asset",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "asset_code",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "asset_issuer",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "asset_type",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "asset_id",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "authorize",
+    "type": "BOOLEAN"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "balance_id",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "buying_asset_code",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "buying_asset_issuer",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "buying_asset_type",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "buying_asset_id",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "claimant",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "claimant_muxed",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "claimant_muxed_id",
+    "type": "STRING"
+  },
+  {
+    "fields": [
+      {
         "mode": "NULLABLE",
-        "name": "account",
+        "name": "destination",
         "type": "STRING"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "op_account_muxed",
-        "type": "STRING"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "op_account_muxed_id",
-        "type": "STRING"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "op_account_id",
-        "type": "STRING"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "amount",
-        "type": "FLOAT"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "asset",
-        "type": "STRING"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "asset_code",
-        "type": "STRING"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "asset_issuer",
-        "type": "STRING"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "asset_type",
-        "type": "STRING"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "authorize",
-        "type": "BOOLEAN"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "balance_id",
-        "type": "STRING"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "buying_asset_code",
-        "type": "STRING"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "buying_asset_issuer",
-        "type": "STRING"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "buying_asset_type",
-        "type": "STRING"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "claimant",
-        "type": "STRING"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "claimant_muxed",
-        "type": "STRING"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "claimant_muxed_id",
-        "type": "STRING"
-    },
-    {
-      "fields": [
+      },
+      {
+        "fields": [
           {
             "mode": "NULLABLE",
-            "name": "destination",
+            "name": "unconditional",
+            "type": "BOOLEAN"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "abs_before",
             "type": "STRING"
           },
           {
+            "mode": "NULLABLE",
+            "name": "rel_before",
+            "type": "INTEGER"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "abs_before_epoch",
+            "type": "INTEGER"
+          },
+          {
             "fields": [
-              {
-                "mode": "NULLABLE",
-                "name": "unconditional",
-                "type": "BOOLEAN"
-              },
               {
                 "mode": "NULLABLE",
                 "name": "abs_before",
@@ -110,8 +137,13 @@
               },
               {
                 "mode": "NULLABLE",
+                "name": "unconditional",
+                "type": "BOOLEAN"
+              },
+              {
+                "mode": "NULLABLE",
                 "name": "abs_before_epoch",
-                "type": "INTEGER" 
+                "type": "INTEGER"
               },
               {
                 "fields": [
@@ -133,88 +165,115 @@
                   {
                     "mode": "NULLABLE",
                     "name": "abs_before_epoch",
-                    "type": "INTEGER" 
+                    "type": "INTEGER"
+                  }
+                ],
+                "mode": "REPEATED",
+                "name": "not",
+                "type": "RECORD"
+              },
+              {
+                "fields": [
+                  {
+                    "mode": "NULLABLE",
+                    "name": "abs_before",
+                    "type": "STRING"
                   },
                   {
-                    "fields": [
-                      {
-                        "mode": "NULLABLE",
-                        "name": "abs_before",
-                        "type": "STRING"
-                      },
-                      {
-                        "mode": "NULLABLE",
-                        "name": "rel_before",
-                        "type": "INTEGER"
-                      },
-                      {
-                        "mode": "NULLABLE",
-                        "name": "unconditional",
-                        "type": "BOOLEAN"
-                      },
-                      {
-                        "mode": "NULLABLE",
-                        "name": "abs_before_epoch",
-                        "type": "INTEGER" 
-                      }
-                    ],
-                    "mode": "REPEATED",
-                    "name": "not",
-                    "type": "RECORD"
+                    "mode": "NULLABLE",
+                    "name": "rel_before",
+                    "type": "INTEGER"
                   },
                   {
-                    "fields": [
-                      {
-                        "mode": "NULLABLE",
-                        "name": "abs_before",
-                        "type": "STRING"
-                      },
-                      {
-                        "mode": "NULLABLE",
-                        "name": "rel_before",
-                        "type": "INTEGER"
-                      },
-                      {
-                        "mode": "NULLABLE",
-                        "name": "unconditional",
-                        "type": "BOOLEAN"
-                      },
-                      {
-                        "mode": "NULLABLE",
-                        "name": "abs_before_epoch",
-                        "type": "INTEGER" 
-                      }
-                    ],
-                    "mode": "REPEATED",
-                    "name": "or",
-                    "type": "RECORD"
+                    "mode": "NULLABLE",
+                    "name": "unconditional",
+                    "type": "BOOLEAN"
                   },
                   {
-                    "fields": [
-                      {
-                        "mode": "NULLABLE",
-                        "name": "abs_before",
-                        "type": "STRING"
-                      },
-                      {
-                        "mode": "NULLABLE",
-                        "name": "rel_before",
-                        "type": "INTEGER"
-                      },
-                      {
-                        "mode": "NULLABLE",
-                        "name": "unconditional",
-                        "type": "BOOLEAN"
-                      },
-                      {
-                        "mode": "NULLABLE",
-                        "name": "abs_before_epoch",
-                        "type": "INTEGER" 
-                      }
-                    ],
-                    "mode": "REPEATED",
-                    "name": "and",
-                    "type": "RECORD"
+                    "mode": "NULLABLE",
+                    "name": "abs_before_epoch",
+                    "type": "INTEGER"
+                  }
+                ],
+                "mode": "REPEATED",
+                "name": "or",
+                "type": "RECORD"
+              },
+              {
+                "fields": [
+                  {
+                    "mode": "NULLABLE",
+                    "name": "abs_before",
+                    "type": "STRING"
+                  },
+                  {
+                    "mode": "NULLABLE",
+                    "name": "rel_before",
+                    "type": "INTEGER"
+                  },
+                  {
+                    "mode": "NULLABLE",
+                    "name": "unconditional",
+                    "type": "BOOLEAN"
+                  },
+                  {
+                    "mode": "NULLABLE",
+                    "name": "abs_before_epoch",
+                    "type": "INTEGER"
+                  }
+                ],
+                "mode": "REPEATED",
+                "name": "and",
+                "type": "RECORD"
+              }
+            ],
+            "mode": "REPEATED",
+            "name": "and",
+            "type": "RECORD"
+          },
+          {
+            "fields": [
+              {
+                "mode": "NULLABLE",
+                "name": "abs_before",
+                "type": "STRING"
+              },
+              {
+                "mode": "NULLABLE",
+                "name": "rel_before",
+                "type": "INTEGER"
+              },
+              {
+                "mode": "NULLABLE",
+                "name": "unconditional",
+                "type": "BOOLEAN"
+              },
+              {
+                "mode": "NULLABLE",
+                "name": "abs_before_epoch",
+                "type": "INTEGER"
+              },
+              {
+                "fields": [
+                  {
+                    "mode": "NULLABLE",
+                    "name": "abs_before",
+                    "type": "STRING"
+                  },
+                  {
+                    "mode": "NULLABLE",
+                    "name": "rel_before",
+                    "type": "INTEGER"
+                  },
+                  {
+                    "mode": "NULLABLE",
+                    "name": "unconditional",
+                    "type": "BOOLEAN"
+                  },
+                  {
+                    "mode": "NULLABLE",
+                    "name": "abs_before_epoch",
+                    "type": "INTEGER"
                   }
                 ],
                 "mode": "REPEATED",
@@ -241,93 +300,12 @@
                   {
                     "mode": "NULLABLE",
                     "name": "abs_before_epoch",
-                    "type": "INTEGER" 
-                  },
-                  {
-                    "fields": [
-                    {
-                      "mode": "NULLABLE",
-                      "name": "abs_before",
-                      "type": "STRING" 
-                    },
-                    {
-                      "mode": "NULLABLE",
-                      "name": "rel_before",
-                      "type": "INTEGER"
-                    },
-                    {
-                      "mode": "NULLABLE",
-                      "name": "unconditional",
-                      "type": "BOOLEAN"
-                    },
-                    {
-                      "mode": "NULLABLE",
-                      "name": "abs_before_epoch",
-                      "type": "INTEGER" 
-                    }
-                  ],
-                  "mode": "REPEATED",
-                  "name": "and",
-                  "type": "RECORD"
-                  },
-                  {
-                    "fields": [
-                    {
-                      "mode": "NULLABLE",
-                      "name": "abs_before",
-                      "type": "STRING" 
-                    },
-                    {
-                      "mode": "NULLABLE",
-                      "name": "rel_before",
-                      "type": "INTEGER"
-                    },
-                    {
-                      "mode": "NULLABLE",
-                      "name": "unconditional",
-                      "type": "BOOLEAN"
-                    },
-                    {
-                      "mode": "NULLABLE",
-                      "name": "abs_before_epoch",
-                      "type": "INTEGER" 
-                    }
-                  ],
-                  "mode": "REPEATED",
-                  "name": "or",
-                  "type": "RECORD"
-                  },
-                  {
-                    "fields": [
-                    {
-                      "mode": "NULLABLE",
-                      "name": "abs_before",
-                      "type": "STRING" 
-                    },
-                    {
-                      "mode": "NULLABLE",
-                      "name": "rel_before",
-                      "type": "INTEGER"
-                    },
-                    {
-                      "mode": "NULLABLE",
-                      "name": "unconditional",
-                      "type": "BOOLEAN"
-                    },
-                    {
-                      "mode": "NULLABLE",
-                      "name": "abs_before_epoch",
-                      "type": "INTEGER" 
-                    }
-                  ],
-                  "mode": "REPEATED",
-                  "name": "not",
-                  "type": "RECORD"
+                    "type": "INTEGER"
                   }
                 ],
                 "mode": "REPEATED",
-                "name": "not",
-                "type": "RECORD" 
+                "name": "or",
+                "type": "RECORD"
               },
               {
                 "fields": [
@@ -343,827 +321,858 @@
                   },
                   {
                     "mode": "NULLABLE",
-                    "name": "abs_before_epoch",
-                    "type": "INTEGER" 
+                    "name": "unconditional",
+                    "type": "BOOLEAN"
                   },
                   {
-                    "fields": [
-                      {
-                        "mode": "NULLABLE",
-                        "name": "abs_before",
-                        "type": "STRING"
-                      },
-                      {
-                        "mode": "NULLABLE",
-                        "name": "rel_before",
-                        "type": "INTEGER"
-                      },
-                      {
-                        "mode": "NULLABLE",
-                        "name": "unconditional",
-                        "type": "BOOLEAN"
-                      },
-                      {
-                        "mode": "NULLABLE",
-                        "name": "abs_before_epoch",
-                        "type": "INTEGER" 
-                      }
-                    ],
-                    "mode": "REPEATED",
-                    "name": "not",
-                    "type": "RECORD"
+                    "mode": "NULLABLE",
+                    "name": "abs_before_epoch",
+                    "type": "INTEGER"
+                  }
+                ],
+                "mode": "REPEATED",
+                "name": "not",
+                "type": "RECORD"
+              }
+            ],
+            "mode": "REPEATED",
+            "name": "not",
+            "type": "RECORD"
+          },
+          {
+            "fields": [
+              {
+                "mode": "NULLABLE",
+                "name": "abs_before",
+                "type": "STRING"
+              },
+              {
+                "mode": "NULLABLE",
+                "name": "rel_before",
+                "type": "INTEGER"
+              },
+              {
+                "mode": "NULLABLE",
+                "name": "abs_before_epoch",
+                "type": "INTEGER"
+              },
+              {
+                "fields": [
+                  {
+                    "mode": "NULLABLE",
+                    "name": "abs_before",
+                    "type": "STRING"
+                  },
+                  {
+                    "mode": "NULLABLE",
+                    "name": "rel_before",
+                    "type": "INTEGER"
                   },
                   {
                     "mode": "NULLABLE",
                     "name": "unconditional",
-                    "type": "BOOLEAN" 
+                    "type": "BOOLEAN"
                   },
                   {
-                    "fields": [
-                      {
-                        "mode": "NULLABLE",
-                        "name": "abs_before",
-                        "type": "STRING"
-                      },
-                      {
-                        "mode": "NULLABLE",
-                        "name": "rel_before",
-                        "type": "INTEGER"
-                      },
-                      {
-                        "mode": "NULLABLE",
-                        "name": "unconditional",
-                        "type": "BOOLEAN"
-                      },
-                      {
-                        "mode": "NULLABLE",
-                        "name": "abs_before_epoch",
-                        "type": "INTEGER" 
-                      }
-                    ],
-                    "mode": "REPEATED",
-                    "name": "or",
-                    "type": "RECORD"
+                    "mode": "NULLABLE",
+                    "name": "abs_before_epoch",
+                    "type": "INTEGER"
+                  }
+                ],
+                "mode": "REPEATED",
+                "name": "not",
+                "type": "RECORD"
+              },
+              {
+                "mode": "NULLABLE",
+                "name": "unconditional",
+                "type": "BOOLEAN"
+              },
+              {
+                "fields": [
+                  {
+                    "mode": "NULLABLE",
+                    "name": "abs_before",
+                    "type": "STRING"
                   },
                   {
-                    "fields": [
-                      {
-                        "mode": "NULLABLE",
-                        "name": "abs_before",
-                        "type": "STRING"
-                      },
-                      {
-                        "mode": "NULLABLE",
-                        "name": "rel_before",
-                        "type": "INTEGER"
-                      },
-                      {
-                        "mode": "NULLABLE",
-                        "name": "unconditional",
-                        "type": "BOOLEAN"
-                      },
-                      {
-                        "mode": "NULLABLE",
-                        "name": "abs_before_epoch",
-                        "type": "INTEGER" 
-                      },
-                      {
-                        "fields": [
-                          {
-                            "mode": "NULLABLE",
-                            "name": "abs_before",
-                            "type": "STRING"
-                          },
-                          {
-                            "mode": "NULLABLE",
-                            "name": "rel_before",
-                            "type": "INTEGER"
-                          },
-                          {
-                            "mode": "NULLABLE",
-                            "name": "unconditional",
-                            "type": "BOOLEAN"
-                          },
-                          {
-                            "mode": "NULLABLE",
-                            "name": "abs_before_epoch",
-                            "type": "INTEGER" 
-                          } 
-                        ],
-                        "mode": "REPEATED",
-                        "name": "not",
-                        "type": "RECORD"
-                      }
-                    ],
-                    "mode": "REPEATED",
-                    "name": "and",
-                    "type": "RECORD"
+                    "mode": "NULLABLE",
+                    "name": "rel_before",
+                    "type": "INTEGER"
+                  },
+                  {
+                    "mode": "NULLABLE",
+                    "name": "unconditional",
+                    "type": "BOOLEAN"
+                  },
+                  {
+                    "mode": "NULLABLE",
+                    "name": "abs_before_epoch",
+                    "type": "INTEGER"
                   }
                 ],
                 "mode": "REPEATED",
                 "name": "or",
                 "type": "RECORD"
+              },
+              {
+                "fields": [
+                  {
+                    "mode": "NULLABLE",
+                    "name": "abs_before",
+                    "type": "STRING"
+                  },
+                  {
+                    "mode": "NULLABLE",
+                    "name": "rel_before",
+                    "type": "INTEGER"
+                  },
+                  {
+                    "mode": "NULLABLE",
+                    "name": "unconditional",
+                    "type": "BOOLEAN"
+                  },
+                  {
+                    "mode": "NULLABLE",
+                    "name": "abs_before_epoch",
+                    "type": "INTEGER"
+                  },
+                  {
+                    "fields": [
+                      {
+                        "mode": "NULLABLE",
+                        "name": "abs_before",
+                        "type": "STRING"
+                      },
+                      {
+                        "mode": "NULLABLE",
+                        "name": "rel_before",
+                        "type": "INTEGER"
+                      },
+                      {
+                        "mode": "NULLABLE",
+                        "name": "unconditional",
+                        "type": "BOOLEAN"
+                      },
+                      {
+                        "mode": "NULLABLE",
+                        "name": "abs_before_epoch",
+                        "type": "INTEGER"
+                      }
+                    ],
+                    "mode": "REPEATED",
+                    "name": "not",
+                    "type": "RECORD"
+                  }
+                ],
+                "mode": "REPEATED",
+                "name": "and",
+                "type": "RECORD"
               }
             ],
             "mode": "REPEATED",
-            "name": "predicate",
+            "name": "or",
             "type": "RECORD"
           }
         ],
         "mode": "REPEATED",
-        "name": "claimants",
+        "name": "predicate",
         "type": "RECORD"
-    },
-    {
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "claimants",
+    "type": "RECORD"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "data_account_id",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "data_name",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "from",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "from_muxed",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "from_muxed_id",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "funder",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "funder_muxed",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "funder_muxed_id",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "high_threshold",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "home_domain",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "inflation_dest",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "into",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "into_muxed",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "into_muxed_id",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "limit",
+    "type": "FLOAT"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "low_threshold",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "master_key_weight",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "med_threshold",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "name",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "offer_id",
+    "type": "INTEGER"
+  },
+  {
+    "fields": [
+      {
         "mode": "NULLABLE",
-        "name": "data_account_id",
+        "name": "asset_code",
         "type": "STRING"
-    },
-    {
+      },
+      {
         "mode": "NULLABLE",
-        "name": "data_name",
+        "name": "asset_issuer",
         "type": "STRING"
-    },
-    {
+      },
+      {
         "mode": "NULLABLE",
-        "name": "from",
+        "name": "asset_type",
         "type": "STRING"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "from_muxed",
-        "type": "STRING"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "from_muxed_id",
-        "type": "STRING"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "funder",
-        "type": "STRING"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "funder_muxed",
-        "type": "STRING"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "funder_muxed_id",
-        "type": "STRING"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "high_threshold",
-        "type": "INTEGER"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "home_domain",
-        "type": "STRING"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "inflation_dest",
-        "type": "STRING"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "into",
-        "type": "STRING"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "into_muxed",
-        "type": "STRING"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "into_muxed_id",
-        "type": "STRING"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "limit",
-        "type": "FLOAT"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "low_threshold",
-        "type": "INTEGER"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "master_key_weight",
-        "type": "INTEGER"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "med_threshold",
-        "type": "INTEGER"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "name",
-        "type": "STRING"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "offer_id",
-        "type": "INTEGER"
-    },
-    {
-        "fields": [
-            {
-                "mode": "NULLABLE",
-                "name": "asset_code",
-                "type": "STRING"
-            },
-            {
-                "mode": "NULLABLE",
-                "name": "asset_issuer",
-                "type": "STRING"
-            },
-            {
-                "mode": "NULLABLE",
-                "name": "asset_type",
-                "type": "STRING"
-            }
-        ],
-        "mode": "REPEATED",
-        "name": "path",
-        "type": "RECORD"
-        
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "price",
-        "type": "FLOAT"
-    },
-    {
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "path",
+    "type": "RECORD"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "price",
+    "type": "FLOAT"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "d",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "n",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "selling_asset_code",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "selling_asset_issuer",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "selling_asset_type",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "selling_asset_id",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "REPEATED",
+    "name": "set_flags",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "REPEATED",
+    "name": "set_flags_s",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "signer_account_id",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "signer_key",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "signer_weight",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "source_amount",
+    "type": "FLOAT"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "source_asset_code",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "source_asset_issuer",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "source_asset_type",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "source_asset_id",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "source_max",
+    "type": "FLOAT"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "starting_balance",
+    "type": "FLOAT"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "to",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "to_muxed",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "to_muxed_id",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "trustee",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "trustee_muxed",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "trustee_muxed_id",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "trustor",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "trustor_muxed",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "trustor_muxed_id",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "trustline_account_id",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "trustline_asset",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "value",
+    "type": "STRING"
+  },
+  {
+    "mode": "REPEATED",
+    "name": "clear_flags",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "REPEATED",
+    "name": "clear_flags_s",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "destination_min",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "bump_to",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "sponsor",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "sponsored_id",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "begin_sponsor",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "begin_sponsor_muxed",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "begin_sponsor_muxed_id",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "authorize_to_maintain_liabilities",
+    "type": "BOOLEAN"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "clawback_enabled",
+    "type": "BOOLEAN"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "liquidity_pool_id",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "reserve_a_asset_type",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "reserve_a_asset_id",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "reserve_a_asset_code",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "reserve_a_asset_issuer",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "reserve_a_max_amount",
+    "type": "FLOAT"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "reserve_a_deposit_amount",
+    "type": "FLOAT"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "reserve_b_asset_type",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "reserve_b_asset_id",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "reserve_b_asset_code",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "reserve_b_asset_issuer",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "reserve_b_max_amount",
+    "type": "FLOAT"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "reserve_b_deposit_amount",
+    "type": "FLOAT"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "min_price",
+    "type": "FLOAT"
+  },
+  {
+    "fields": [
+      {
         "mode": "NULLABLE",
         "name": "d",
         "type": "INTEGER"
-    },
-    {
+      },
+      {
         "mode": "NULLABLE",
         "name": "n",
         "type": "INTEGER"
-    },
-    {
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "min_price_r",
+    "type": "RECORD"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "max_price",
+    "type": "FLOAT"
+  },
+  {
+    "fields": [
+      {
         "mode": "NULLABLE",
-        "name": "selling_asset_code",
-        "type": "STRING"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "selling_asset_issuer",
-        "type": "STRING"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "selling_asset_type",
-        "type": "STRING"
-    },
-    {
-        "mode": "REPEATED",
-        "name": "set_flags",
+        "name": "d",
         "type": "INTEGER"
-    },
-    {
-        "mode": "REPEATED",
-        "name": "set_flags_s",
-        "type": "STRING"
-    },
-    {
+      },
+      {
         "mode": "NULLABLE",
-        "name": "signer_account_id",
-        "type": "STRING"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "signer_key",
-        "type": "STRING"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "signer_weight",
+        "name": "n",
         "type": "INTEGER"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "source_amount",
-        "type": "FLOAT"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "source_asset_code",
-        "type": "STRING"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "source_asset_issuer",
-        "type": "STRING"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "source_asset_type",
-        "type": "STRING"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "source_max",
-        "type": "FLOAT"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "starting_balance",
-        "type": "FLOAT"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "to",
-        "type": "STRING"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "to_muxed",
-        "type": "STRING"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "to_muxed_id",
-        "type": "STRING"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "trustee",
-        "type": "STRING"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "trustee_muxed",
-        "type": "STRING"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "trustee_muxed_id",
-        "type": "STRING"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "trustor",
-        "type": "STRING"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "trustor_muxed",
-        "type": "STRING"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "trustor_muxed_id",
-        "type": "STRING"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "trustline_account_id",
-        "type": "STRING"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "trustline_asset",
-        "type": "STRING"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "value",
-        "type": "STRING"
-    },
-    {
-        "mode": "REPEATED",
-        "name": "clear_flags",
-        "type": "INTEGER"
-    },
-    {
-        "mode": "REPEATED",
-        "name": "clear_flags_s",
-        "type": "STRING"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "destination_min",
-        "type": "STRING"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "bump_to",
-        "type": "STRING"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "sponsor",
-        "type": "STRING"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "sponsored_id",
-        "type": "STRING"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "begin_sponsor",
-        "type": "STRING"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "begin_sponsor_muxed",
-        "type": "STRING"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "begin_sponsor_muxed_id",
-        "type": "STRING"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "authorize_to_maintain_liabilities",
-        "type": "BOOLEAN"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "clawback_enabled",
-        "type": "BOOLEAN"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "liquidity_pool_id",
-        "type": "STRING"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "reserve_a_asset_type",
-        "type": "STRING"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "reserve_a_asset_code",
-        "type": "STRING"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "reserve_a_asset_issuer",
-        "type": "STRING"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "reserve_a_max_amount",
-        "type": "FLOAT"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "reserve_a_deposit_amount",
-        "type": "FLOAT"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "reserve_b_asset_type",
-        "type": "STRING"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "reserve_b_asset_code",
-        "type": "STRING"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "reserve_b_asset_issuer",
-        "type": "STRING"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "reserve_b_max_amount",
-        "type": "FLOAT"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "reserve_b_deposit_amount",
-        "type": "FLOAT"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "min_price",
-        "type": "FLOAT"
-    },
-    {
-        "fields": [
-            {
-                "mode": "NULLABLE",
-                "name": "d",
-                "type": "INTEGER"
-            },
-            {
-                "mode": "NULLABLE",
-                "name": "n",
-                "type": "INTEGER"
-            }
-        ],
-        "mode": "REPEATED",
-        "name": "min_price_r",
-        "type": "RECORD"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "max_price",
-        "type": "FLOAT"
-    },
-    {
-        "fields": [
-            {
-                "mode": "NULLABLE",
-                "name": "d",
-                "type": "INTEGER"
-            },
-            {
-                "mode": "NULLABLE",
-                "name": "n",
-                "type": "INTEGER"
-            }
-        ],
-        "mode": "REPEATED",
-        "name": "max_price_r",
-        "type": "RECORD"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "shares_received",
-        "type": "FLOAT"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "reserve_a_min_amount",
-        "type": "FLOAT"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "reserve_b_min_amount",
-        "type": "FLOAT"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "shares",
-        "type": "FLOAT"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "reserve_a_withdraw_amount",
-        "type": "FLOAT"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "reserve_b_withdraw_amount",
-        "type": "FLOAT"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "op_id",
-        "type": "INTEGER"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "op_source_account",
-        "type": "STRING"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "op_source_account_muxed",
-        "type": "STRING"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "transaction_id",
-        "type": "INTEGER"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "type",
-        "type": "INTEGER"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "type_string",
-        "type": "string"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "transaction_hash",
-        "type": "STRING"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "ledger_sequence",
-        "type": "INTEGER"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "txn_account",
-        "type": "STRING"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "account_sequence",
-        "type": "INTEGER"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "max_fee",
-        "type": "INTEGER"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "txn_operation_count",
-        "type": "INTEGER"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "txn_created_at",
-        "type": "TIMESTAMP"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "memo_type",
-        "type": "STRING"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "memo",
-        "type": "STRING"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "time_bounds",
-        "type": "STRING"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "successful",
-        "type": "BOOLEAN"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "fee_charged",
-        "type": "INTEGER"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "fee_account",
-        "type": "STRING"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "new_max_fee",
-        "type": "INTEGER"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "account_muxed",
-        "type": "STRING"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "fee_account_muxed",
-        "type": "STRING"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "ledger_hash",
-        "type": "STRING"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "previous_ledger_hash",
-        "type": "STRING"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "transaction_count",
-        "type": "INTEGER"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "ledger_operation_count",
-        "type": "INTEGER"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "closed_at",
-        "type": "TIMESTAMP"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "ledger_id",
-        "type": "INTEGER"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "total_coins",
-        "type": "INTEGER"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "fee_pool",
-        "type": "INTEGER"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "base_fee",
-        "type": "INTEGER"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "base_reserve",
-        "type": "INTEGER"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "max_tx_set_size",
-        "type": "INTEGER"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "protocol_version",
-        "type": "INTEGER"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "successful_transaction_count",
-        "type": "INTEGER"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "failed_transaction_count",
-        "type": "INTEGER"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "batch_id",
-        "type": "STRING"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "batch_run_date",
-        "type": "DATETIME"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "batch_insert_ts",
-        "type": "TIMESTAMP"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "ledger_bounds",
-        "type": "STRING"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "min_account_sequence",
-        "type": "INTEGER"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "min_account_sequence_age",
-        "type": "INTEGER"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "min_account_sequence_ledger_gap",
-        "type": "INTEGER"
-    },
-    {
-        "mode": "REPEATED",
-        "name": "extra_signers",
-        "type": "STRING"
-    },
-    {
-      "mode": "NULLABLE",
-      "name": "tx_envelope",
-      "type": "STRING"
-    },
-    {
-      "mode": "NULLABLE",
-      "name": "tx_result",
-      "type": "STRING"
-    },
-    {
-      "mode": "NULLABLE",
-      "name": "tx_meta",
-      "type": "STRING"
-    },
-    {
-      "mode": "NULLABLE",
-      "name": "tx_fee_meta",
-      "type": "STRING"
-    }
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "max_price_r",
+    "type": "RECORD"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "shares_received",
+    "type": "FLOAT"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "reserve_a_min_amount",
+    "type": "FLOAT"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "reserve_b_min_amount",
+    "type": "FLOAT"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "shares",
+    "type": "FLOAT"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "reserve_a_withdraw_amount",
+    "type": "FLOAT"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "reserve_b_withdraw_amount",
+    "type": "FLOAT"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "op_id",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "op_source_account",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "op_source_account_muxed",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "transaction_id",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "type",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "type_string",
+    "type": "string"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "transaction_hash",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "ledger_sequence",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "txn_account",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "account_sequence",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "max_fee",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "txn_operation_count",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "txn_created_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "memo_type",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "memo",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "time_bounds",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "successful",
+    "type": "BOOLEAN"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "fee_charged",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "fee_account",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "new_max_fee",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "account_muxed",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "fee_account_muxed",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "ledger_hash",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "previous_ledger_hash",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "transaction_count",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "ledger_operation_count",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "closed_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "ledger_id",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "total_coins",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "fee_pool",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "base_fee",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "base_reserve",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "max_tx_set_size",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "protocol_version",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "successful_transaction_count",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "failed_transaction_count",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "batch_id",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "batch_run_date",
+    "type": "DATETIME"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "batch_insert_ts",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "ledger_bounds",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "min_account_sequence",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "min_account_sequence_age",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "min_account_sequence_ledger_gap",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "REPEATED",
+    "name": "extra_signers",
+    "type": "STRING"
+  }
 ]

--- a/schemas/enriched_history_operations_schema.json
+++ b/schemas/enriched_history_operations_schema.json
@@ -1,346 +1,113 @@
 [
-  {
-    "mode": "NULLABLE",
-    "name": "account",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "op_account_muxed",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "op_account_muxed_id",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "op_account_id",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "amount",
-    "type": "FLOAT"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "asset",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "asset_code",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "asset_issuer",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "asset_type",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "asset_id",
-    "type": "INTEGER"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "authorize",
-    "type": "BOOLEAN"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "balance_id",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "buying_asset_code",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "buying_asset_issuer",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "buying_asset_type",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "buying_asset_id",
-    "type": "INTEGER"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "claimant",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "claimant_muxed",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "claimant_muxed_id",
-    "type": "STRING"
-  },
-  {
-    "fields": [
-      {
+    {
         "mode": "NULLABLE",
-        "name": "destination",
+        "name": "account",
         "type": "STRING"
-      },
-      {
-        "fields": [
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "op_account_muxed",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "op_account_muxed_id",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "op_account_id",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "amount",
+        "type": "FLOAT"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "asset",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "asset_code",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "asset_issuer",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "asset_type",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "asset_id",
+        "type": "INTEGER"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "authorize",
+        "type": "BOOLEAN"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "balance_id",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "buying_asset_code",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "buying_asset_issuer",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "buying_asset_type",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "buying_asset_id",
+        "type": "INTEGER"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "claimant",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "claimant_muxed",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "claimant_muxed_id",
+        "type": "STRING"
+    },
+    {
+      "fields": [
           {
             "mode": "NULLABLE",
-            "name": "unconditional",
-            "type": "BOOLEAN"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "abs_before",
+            "name": "destination",
             "type": "STRING"
           },
           {
-            "mode": "NULLABLE",
-            "name": "rel_before",
-            "type": "INTEGER"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "abs_before_epoch",
-            "type": "INTEGER"
-          },
-          {
             "fields": [
-              {
-                "mode": "NULLABLE",
-                "name": "abs_before",
-                "type": "STRING"
-              },
-              {
-                "mode": "NULLABLE",
-                "name": "rel_before",
-                "type": "INTEGER"
-              },
               {
                 "mode": "NULLABLE",
                 "name": "unconditional",
                 "type": "BOOLEAN"
               },
-              {
-                "mode": "NULLABLE",
-                "name": "abs_before_epoch",
-                "type": "INTEGER"
-              },
-              {
-                "fields": [
-                  {
-                    "mode": "NULLABLE",
-                    "name": "abs_before",
-                    "type": "STRING"
-                  },
-                  {
-                    "mode": "NULLABLE",
-                    "name": "rel_before",
-                    "type": "INTEGER"
-                  },
-                  {
-                    "mode": "NULLABLE",
-                    "name": "unconditional",
-                    "type": "BOOLEAN"
-                  },
-                  {
-                    "mode": "NULLABLE",
-                    "name": "abs_before_epoch",
-                    "type": "INTEGER"
-                  }
-                ],
-                "mode": "REPEATED",
-                "name": "not",
-                "type": "RECORD"
-              },
-              {
-                "fields": [
-                  {
-                    "mode": "NULLABLE",
-                    "name": "abs_before",
-                    "type": "STRING"
-                  },
-                  {
-                    "mode": "NULLABLE",
-                    "name": "rel_before",
-                    "type": "INTEGER"
-                  },
-                  {
-                    "mode": "NULLABLE",
-                    "name": "unconditional",
-                    "type": "BOOLEAN"
-                  },
-                  {
-                    "mode": "NULLABLE",
-                    "name": "abs_before_epoch",
-                    "type": "INTEGER"
-                  }
-                ],
-                "mode": "REPEATED",
-                "name": "or",
-                "type": "RECORD"
-              },
-              {
-                "fields": [
-                  {
-                    "mode": "NULLABLE",
-                    "name": "abs_before",
-                    "type": "STRING"
-                  },
-                  {
-                    "mode": "NULLABLE",
-                    "name": "rel_before",
-                    "type": "INTEGER"
-                  },
-                  {
-                    "mode": "NULLABLE",
-                    "name": "unconditional",
-                    "type": "BOOLEAN"
-                  },
-                  {
-                    "mode": "NULLABLE",
-                    "name": "abs_before_epoch",
-                    "type": "INTEGER"
-                  }
-                ],
-                "mode": "REPEATED",
-                "name": "and",
-                "type": "RECORD"
-              }
-            ],
-            "mode": "REPEATED",
-            "name": "and",
-            "type": "RECORD"
-          },
-          {
-            "fields": [
-              {
-                "mode": "NULLABLE",
-                "name": "abs_before",
-                "type": "STRING"
-              },
-              {
-                "mode": "NULLABLE",
-                "name": "rel_before",
-                "type": "INTEGER"
-              },
-              {
-                "mode": "NULLABLE",
-                "name": "unconditional",
-                "type": "BOOLEAN"
-              },
-              {
-                "mode": "NULLABLE",
-                "name": "abs_before_epoch",
-                "type": "INTEGER"
-              },
-              {
-                "fields": [
-                  {
-                    "mode": "NULLABLE",
-                    "name": "abs_before",
-                    "type": "STRING"
-                  },
-                  {
-                    "mode": "NULLABLE",
-                    "name": "rel_before",
-                    "type": "INTEGER"
-                  },
-                  {
-                    "mode": "NULLABLE",
-                    "name": "unconditional",
-                    "type": "BOOLEAN"
-                  },
-                  {
-                    "mode": "NULLABLE",
-                    "name": "abs_before_epoch",
-                    "type": "INTEGER"
-                  }
-                ],
-                "mode": "REPEATED",
-                "name": "and",
-                "type": "RECORD"
-              },
-              {
-                "fields": [
-                  {
-                    "mode": "NULLABLE",
-                    "name": "abs_before",
-                    "type": "STRING"
-                  },
-                  {
-                    "mode": "NULLABLE",
-                    "name": "rel_before",
-                    "type": "INTEGER"
-                  },
-                  {
-                    "mode": "NULLABLE",
-                    "name": "unconditional",
-                    "type": "BOOLEAN"
-                  },
-                  {
-                    "mode": "NULLABLE",
-                    "name": "abs_before_epoch",
-                    "type": "INTEGER"
-                  }
-                ],
-                "mode": "REPEATED",
-                "name": "or",
-                "type": "RECORD"
-              },
-              {
-                "fields": [
-                  {
-                    "mode": "NULLABLE",
-                    "name": "abs_before",
-                    "type": "STRING"
-                  },
-                  {
-                    "mode": "NULLABLE",
-                    "name": "rel_before",
-                    "type": "INTEGER"
-                  },
-                  {
-                    "mode": "NULLABLE",
-                    "name": "unconditional",
-                    "type": "BOOLEAN"
-                  },
-                  {
-                    "mode": "NULLABLE",
-                    "name": "abs_before_epoch",
-                    "type": "INTEGER"
-                  }
-                ],
-                "mode": "REPEATED",
-                "name": "not",
-                "type": "RECORD"
-              }
-            ],
-            "mode": "REPEATED",
-            "name": "not",
-            "type": "RECORD"
-          },
-          {
-            "fields": [
               {
                 "mode": "NULLABLE",
                 "name": "abs_before",
@@ -354,7 +121,7 @@
               {
                 "mode": "NULLABLE",
                 "name": "abs_before_epoch",
-                "type": "INTEGER"
+                "type": "INTEGER" 
               },
               {
                 "fields": [
@@ -376,66 +143,7 @@
                   {
                     "mode": "NULLABLE",
                     "name": "abs_before_epoch",
-                    "type": "INTEGER"
-                  }
-                ],
-                "mode": "REPEATED",
-                "name": "not",
-                "type": "RECORD"
-              },
-              {
-                "mode": "NULLABLE",
-                "name": "unconditional",
-                "type": "BOOLEAN"
-              },
-              {
-                "fields": [
-                  {
-                    "mode": "NULLABLE",
-                    "name": "abs_before",
-                    "type": "STRING"
-                  },
-                  {
-                    "mode": "NULLABLE",
-                    "name": "rel_before",
-                    "type": "INTEGER"
-                  },
-                  {
-                    "mode": "NULLABLE",
-                    "name": "unconditional",
-                    "type": "BOOLEAN"
-                  },
-                  {
-                    "mode": "NULLABLE",
-                    "name": "abs_before_epoch",
-                    "type": "INTEGER"
-                  }
-                ],
-                "mode": "REPEATED",
-                "name": "or",
-                "type": "RECORD"
-              },
-              {
-                "fields": [
-                  {
-                    "mode": "NULLABLE",
-                    "name": "abs_before",
-                    "type": "STRING"
-                  },
-                  {
-                    "mode": "NULLABLE",
-                    "name": "rel_before",
-                    "type": "INTEGER"
-                  },
-                  {
-                    "mode": "NULLABLE",
-                    "name": "unconditional",
-                    "type": "BOOLEAN"
-                  },
-                  {
-                    "mode": "NULLABLE",
-                    "name": "abs_before_epoch",
-                    "type": "INTEGER"
+                    "type": "INTEGER" 
                   },
                   {
                     "fields": [
@@ -457,722 +165,1035 @@
                       {
                         "mode": "NULLABLE",
                         "name": "abs_before_epoch",
-                        "type": "INTEGER"
+                        "type": "INTEGER" 
                       }
                     ],
                     "mode": "REPEATED",
                     "name": "not",
+                    "type": "RECORD"
+                  },
+                  {
+                    "fields": [
+                      {
+                        "mode": "NULLABLE",
+                        "name": "abs_before",
+                        "type": "STRING"
+                      },
+                      {
+                        "mode": "NULLABLE",
+                        "name": "rel_before",
+                        "type": "INTEGER"
+                      },
+                      {
+                        "mode": "NULLABLE",
+                        "name": "unconditional",
+                        "type": "BOOLEAN"
+                      },
+                      {
+                        "mode": "NULLABLE",
+                        "name": "abs_before_epoch",
+                        "type": "INTEGER" 
+                      }
+                    ],
+                    "mode": "REPEATED",
+                    "name": "or",
+                    "type": "RECORD"
+                  },
+                  {
+                    "fields": [
+                      {
+                        "mode": "NULLABLE",
+                        "name": "abs_before",
+                        "type": "STRING"
+                      },
+                      {
+                        "mode": "NULLABLE",
+                        "name": "rel_before",
+                        "type": "INTEGER"
+                      },
+                      {
+                        "mode": "NULLABLE",
+                        "name": "unconditional",
+                        "type": "BOOLEAN"
+                      },
+                      {
+                        "mode": "NULLABLE",
+                        "name": "abs_before_epoch",
+                        "type": "INTEGER" 
+                      }
+                    ],
+                    "mode": "REPEATED",
+                    "name": "and",
                     "type": "RECORD"
                   }
                 ],
                 "mode": "REPEATED",
                 "name": "and",
                 "type": "RECORD"
+              },
+              {
+                "fields": [
+                  {
+                    "mode": "NULLABLE",
+                    "name": "abs_before",
+                    "type": "STRING"
+                  },
+                  {
+                    "mode": "NULLABLE",
+                    "name": "rel_before",
+                    "type": "INTEGER"
+                  },
+                  {
+                    "mode": "NULLABLE",
+                    "name": "unconditional",
+                    "type": "BOOLEAN"
+                  },
+                  {
+                    "mode": "NULLABLE",
+                    "name": "abs_before_epoch",
+                    "type": "INTEGER" 
+                  },
+                  {
+                    "fields": [
+                    {
+                      "mode": "NULLABLE",
+                      "name": "abs_before",
+                      "type": "STRING" 
+                    },
+                    {
+                      "mode": "NULLABLE",
+                      "name": "rel_before",
+                      "type": "INTEGER"
+                    },
+                    {
+                      "mode": "NULLABLE",
+                      "name": "unconditional",
+                      "type": "BOOLEAN"
+                    },
+                    {
+                      "mode": "NULLABLE",
+                      "name": "abs_before_epoch",
+                      "type": "INTEGER" 
+                    }
+                  ],
+                  "mode": "REPEATED",
+                  "name": "and",
+                  "type": "RECORD"
+                  },
+                  {
+                    "fields": [
+                    {
+                      "mode": "NULLABLE",
+                      "name": "abs_before",
+                      "type": "STRING" 
+                    },
+                    {
+                      "mode": "NULLABLE",
+                      "name": "rel_before",
+                      "type": "INTEGER"
+                    },
+                    {
+                      "mode": "NULLABLE",
+                      "name": "unconditional",
+                      "type": "BOOLEAN"
+                    },
+                    {
+                      "mode": "NULLABLE",
+                      "name": "abs_before_epoch",
+                      "type": "INTEGER" 
+                    }
+                  ],
+                  "mode": "REPEATED",
+                  "name": "or",
+                  "type": "RECORD"
+                  },
+                  {
+                    "fields": [
+                    {
+                      "mode": "NULLABLE",
+                      "name": "abs_before",
+                      "type": "STRING" 
+                    },
+                    {
+                      "mode": "NULLABLE",
+                      "name": "rel_before",
+                      "type": "INTEGER"
+                    },
+                    {
+                      "mode": "NULLABLE",
+                      "name": "unconditional",
+                      "type": "BOOLEAN"
+                    },
+                    {
+                      "mode": "NULLABLE",
+                      "name": "abs_before_epoch",
+                      "type": "INTEGER" 
+                    }
+                  ],
+                  "mode": "REPEATED",
+                  "name": "not",
+                  "type": "RECORD"
+                  }
+                ],
+                "mode": "REPEATED",
+                "name": "not",
+                "type": "RECORD" 
+              },
+              {
+                "fields": [
+                  {
+                    "mode": "NULLABLE",
+                    "name": "abs_before",
+                    "type": "STRING"
+                  },
+                  {
+                    "mode": "NULLABLE",
+                    "name": "rel_before",
+                    "type": "INTEGER"
+                  },
+                  {
+                    "mode": "NULLABLE",
+                    "name": "abs_before_epoch",
+                    "type": "INTEGER" 
+                  },
+                  {
+                    "fields": [
+                      {
+                        "mode": "NULLABLE",
+                        "name": "abs_before",
+                        "type": "STRING"
+                      },
+                      {
+                        "mode": "NULLABLE",
+                        "name": "rel_before",
+                        "type": "INTEGER"
+                      },
+                      {
+                        "mode": "NULLABLE",
+                        "name": "unconditional",
+                        "type": "BOOLEAN"
+                      },
+                      {
+                        "mode": "NULLABLE",
+                        "name": "abs_before_epoch",
+                        "type": "INTEGER" 
+                      }
+                    ],
+                    "mode": "REPEATED",
+                    "name": "not",
+                    "type": "RECORD"
+                  },
+                  {
+                    "mode": "NULLABLE",
+                    "name": "unconditional",
+                    "type": "BOOLEAN" 
+                  },
+                  {
+                    "fields": [
+                      {
+                        "mode": "NULLABLE",
+                        "name": "abs_before",
+                        "type": "STRING"
+                      },
+                      {
+                        "mode": "NULLABLE",
+                        "name": "rel_before",
+                        "type": "INTEGER"
+                      },
+                      {
+                        "mode": "NULLABLE",
+                        "name": "unconditional",
+                        "type": "BOOLEAN"
+                      },
+                      {
+                        "mode": "NULLABLE",
+                        "name": "abs_before_epoch",
+                        "type": "INTEGER" 
+                      }
+                    ],
+                    "mode": "REPEATED",
+                    "name": "or",
+                    "type": "RECORD"
+                  },
+                  {
+                    "fields": [
+                      {
+                        "mode": "NULLABLE",
+                        "name": "abs_before",
+                        "type": "STRING"
+                      },
+                      {
+                        "mode": "NULLABLE",
+                        "name": "rel_before",
+                        "type": "INTEGER"
+                      },
+                      {
+                        "mode": "NULLABLE",
+                        "name": "unconditional",
+                        "type": "BOOLEAN"
+                      },
+                      {
+                        "mode": "NULLABLE",
+                        "name": "abs_before_epoch",
+                        "type": "INTEGER" 
+                      },
+                      {
+                        "fields": [
+                          {
+                            "mode": "NULLABLE",
+                            "name": "abs_before",
+                            "type": "STRING"
+                          },
+                          {
+                            "mode": "NULLABLE",
+                            "name": "rel_before",
+                            "type": "INTEGER"
+                          },
+                          {
+                            "mode": "NULLABLE",
+                            "name": "unconditional",
+                            "type": "BOOLEAN"
+                          },
+                          {
+                            "mode": "NULLABLE",
+                            "name": "abs_before_epoch",
+                            "type": "INTEGER" 
+                          } 
+                        ],
+                        "mode": "REPEATED",
+                        "name": "not",
+                        "type": "RECORD"
+                      }
+                    ],
+                    "mode": "REPEATED",
+                    "name": "and",
+                    "type": "RECORD"
+                  }
+                ],
+                "mode": "REPEATED",
+                "name": "or",
+                "type": "RECORD"
               }
             ],
             "mode": "REPEATED",
-            "name": "or",
+            "name": "predicate",
             "type": "RECORD"
           }
         ],
         "mode": "REPEATED",
-        "name": "predicate",
+        "name": "claimants",
         "type": "RECORD"
-      }
-    ],
-    "mode": "REPEATED",
-    "name": "claimants",
-    "type": "RECORD"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "data_account_id",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "data_name",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "from",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "from_muxed",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "from_muxed_id",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "funder",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "funder_muxed",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "funder_muxed_id",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "high_threshold",
-    "type": "INTEGER"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "home_domain",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "inflation_dest",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "into",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "into_muxed",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "into_muxed_id",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "limit",
-    "type": "FLOAT"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "low_threshold",
-    "type": "INTEGER"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "master_key_weight",
-    "type": "INTEGER"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "med_threshold",
-    "type": "INTEGER"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "name",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "offer_id",
-    "type": "INTEGER"
-  },
-  {
-    "fields": [
-      {
+    },
+    {
         "mode": "NULLABLE",
-        "name": "asset_code",
+        "name": "data_account_id",
         "type": "STRING"
-      },
-      {
+    },
+    {
         "mode": "NULLABLE",
-        "name": "asset_issuer",
+        "name": "data_name",
         "type": "STRING"
-      },
-      {
+    },
+    {
         "mode": "NULLABLE",
-        "name": "asset_type",
+        "name": "from",
         "type": "STRING"
-      }
-    ],
-    "mode": "REPEATED",
-    "name": "path",
-    "type": "RECORD"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "price",
-    "type": "FLOAT"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "d",
-    "type": "INTEGER"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "n",
-    "type": "INTEGER"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "selling_asset_code",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "selling_asset_issuer",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "selling_asset_type",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "selling_asset_id",
-    "type": "INTEGER"
-  },
-  {
-    "mode": "REPEATED",
-    "name": "set_flags",
-    "type": "INTEGER"
-  },
-  {
-    "mode": "REPEATED",
-    "name": "set_flags_s",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "signer_account_id",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "signer_key",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "signer_weight",
-    "type": "INTEGER"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "source_amount",
-    "type": "FLOAT"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "source_asset_code",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "source_asset_issuer",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "source_asset_type",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "source_asset_id",
-    "type": "INTEGER"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "source_max",
-    "type": "FLOAT"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "starting_balance",
-    "type": "FLOAT"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "to",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "to_muxed",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "to_muxed_id",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "trustee",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "trustee_muxed",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "trustee_muxed_id",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "trustor",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "trustor_muxed",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "trustor_muxed_id",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "trustline_account_id",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "trustline_asset",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "value",
-    "type": "STRING"
-  },
-  {
-    "mode": "REPEATED",
-    "name": "clear_flags",
-    "type": "INTEGER"
-  },
-  {
-    "mode": "REPEATED",
-    "name": "clear_flags_s",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "destination_min",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "bump_to",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "sponsor",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "sponsored_id",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "begin_sponsor",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "begin_sponsor_muxed",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "begin_sponsor_muxed_id",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "authorize_to_maintain_liabilities",
-    "type": "BOOLEAN"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "clawback_enabled",
-    "type": "BOOLEAN"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "liquidity_pool_id",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "reserve_a_asset_type",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "reserve_a_asset_id",
-    "type": "INTEGER"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "reserve_a_asset_code",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "reserve_a_asset_issuer",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "reserve_a_max_amount",
-    "type": "FLOAT"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "reserve_a_deposit_amount",
-    "type": "FLOAT"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "reserve_b_asset_type",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "reserve_b_asset_id",
-    "type": "INTEGER"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "reserve_b_asset_code",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "reserve_b_asset_issuer",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "reserve_b_max_amount",
-    "type": "FLOAT"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "reserve_b_deposit_amount",
-    "type": "FLOAT"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "min_price",
-    "type": "FLOAT"
-  },
-  {
-    "fields": [
-      {
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "from_muxed",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "from_muxed_id",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "funder",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "funder_muxed",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "funder_muxed_id",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "high_threshold",
+        "type": "INTEGER"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "home_domain",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "inflation_dest",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "into",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "into_muxed",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "into_muxed_id",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "limit",
+        "type": "FLOAT"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "low_threshold",
+        "type": "INTEGER"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "master_key_weight",
+        "type": "INTEGER"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "med_threshold",
+        "type": "INTEGER"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "name",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "offer_id",
+        "type": "INTEGER"
+    },
+    {
+        "fields": [
+            {
+                "mode": "NULLABLE",
+                "name": "asset_code",
+                "type": "STRING"
+            },
+            {
+                "mode": "NULLABLE",
+                "name": "asset_issuer",
+                "type": "STRING"
+            },
+            {
+                "mode": "NULLABLE",
+                "name": "asset_type",
+                "type": "STRING"
+            }
+        ],
+        "mode": "REPEATED",
+        "name": "path",
+        "type": "RECORD"
+        
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "price",
+        "type": "FLOAT"
+    },
+    {
         "mode": "NULLABLE",
         "name": "d",
         "type": "INTEGER"
-      },
-      {
+    },
+    {
         "mode": "NULLABLE",
         "name": "n",
         "type": "INTEGER"
-      }
-    ],
-    "mode": "REPEATED",
-    "name": "min_price_r",
-    "type": "RECORD"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "max_price",
-    "type": "FLOAT"
-  },
-  {
-    "fields": [
-      {
+    },
+    {
         "mode": "NULLABLE",
-        "name": "d",
-        "type": "INTEGER"
-      },
-      {
+        "name": "selling_asset_code",
+        "type": "STRING"
+    },
+    {
         "mode": "NULLABLE",
-        "name": "n",
+        "name": "selling_asset_issuer",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "selling_asset_type",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "selling_asset_id",
         "type": "INTEGER"
-      }
-    ],
-    "mode": "REPEATED",
-    "name": "max_price_r",
-    "type": "RECORD"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "shares_received",
-    "type": "FLOAT"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "reserve_a_min_amount",
-    "type": "FLOAT"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "reserve_b_min_amount",
-    "type": "FLOAT"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "shares",
-    "type": "FLOAT"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "reserve_a_withdraw_amount",
-    "type": "FLOAT"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "reserve_b_withdraw_amount",
-    "type": "FLOAT"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "op_id",
-    "type": "INTEGER"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "op_source_account",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "op_source_account_muxed",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "transaction_id",
-    "type": "INTEGER"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "type",
-    "type": "INTEGER"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "type_string",
-    "type": "string"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "transaction_hash",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "ledger_sequence",
-    "type": "INTEGER"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "txn_account",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "account_sequence",
-    "type": "INTEGER"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "max_fee",
-    "type": "INTEGER"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "txn_operation_count",
-    "type": "INTEGER"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "txn_created_at",
-    "type": "TIMESTAMP"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "memo_type",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "memo",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "time_bounds",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "successful",
-    "type": "BOOLEAN"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "fee_charged",
-    "type": "INTEGER"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "fee_account",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "new_max_fee",
-    "type": "INTEGER"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "account_muxed",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "fee_account_muxed",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "ledger_hash",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "previous_ledger_hash",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "transaction_count",
-    "type": "INTEGER"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "ledger_operation_count",
-    "type": "INTEGER"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "closed_at",
-    "type": "TIMESTAMP"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "ledger_id",
-    "type": "INTEGER"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "total_coins",
-    "type": "INTEGER"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "fee_pool",
-    "type": "INTEGER"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "base_fee",
-    "type": "INTEGER"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "base_reserve",
-    "type": "INTEGER"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "max_tx_set_size",
-    "type": "INTEGER"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "protocol_version",
-    "type": "INTEGER"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "successful_transaction_count",
-    "type": "INTEGER"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "failed_transaction_count",
-    "type": "INTEGER"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "batch_id",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "batch_run_date",
-    "type": "DATETIME"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "batch_insert_ts",
-    "type": "TIMESTAMP"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "ledger_bounds",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "min_account_sequence",
-    "type": "INTEGER"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "min_account_sequence_age",
-    "type": "INTEGER"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "min_account_sequence_ledger_gap",
-    "type": "INTEGER"
-  },
-  {
-    "mode": "REPEATED",
-    "name": "extra_signers",
-    "type": "STRING"
-  }
+    },
+    {
+        "mode": "REPEATED",
+        "name": "set_flags",
+        "type": "INTEGER"
+    },
+    {
+        "mode": "REPEATED",
+        "name": "set_flags_s",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "signer_account_id",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "signer_key",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "signer_weight",
+        "type": "INTEGER"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "source_amount",
+        "type": "FLOAT"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "source_asset_code",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "source_asset_issuer",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "source_asset_type",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "source_asset_id",
+        "type": "INTEGER"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "source_max",
+        "type": "FLOAT"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "starting_balance",
+        "type": "FLOAT"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "to",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "to_muxed",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "to_muxed_id",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "trustee",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "trustee_muxed",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "trustee_muxed_id",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "trustor",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "trustor_muxed",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "trustor_muxed_id",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "trustline_account_id",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "trustline_asset",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "value",
+        "type": "STRING"
+    },
+    {
+        "mode": "REPEATED",
+        "name": "clear_flags",
+        "type": "INTEGER"
+    },
+    {
+        "mode": "REPEATED",
+        "name": "clear_flags_s",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "destination_min",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "bump_to",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "sponsor",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "sponsored_id",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "begin_sponsor",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "begin_sponsor_muxed",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "begin_sponsor_muxed_id",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "authorize_to_maintain_liabilities",
+        "type": "BOOLEAN"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "clawback_enabled",
+        "type": "BOOLEAN"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "liquidity_pool_id",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "reserve_a_asset_type",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "reserve_a_asset_id",
+        "type": "INTEGER"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "reserve_a_asset_code",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "reserve_a_asset_issuer",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "reserve_a_max_amount",
+        "type": "FLOAT"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "reserve_a_deposit_amount",
+        "type": "FLOAT"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "reserve_b_asset_type",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "reserve_b_asset_id",
+        "type": "INTEGER"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "reserve_b_asset_code",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "reserve_b_asset_issuer",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "reserve_b_max_amount",
+        "type": "FLOAT"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "reserve_b_deposit_amount",
+        "type": "FLOAT"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "min_price",
+        "type": "FLOAT"
+    },
+    {
+        "fields": [
+            {
+                "mode": "NULLABLE",
+                "name": "d",
+                "type": "INTEGER"
+            },
+            {
+                "mode": "NULLABLE",
+                "name": "n",
+                "type": "INTEGER"
+            }
+        ],
+        "mode": "REPEATED",
+        "name": "min_price_r",
+        "type": "RECORD"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "max_price",
+        "type": "FLOAT"
+    },
+    {
+        "fields": [
+            {
+                "mode": "NULLABLE",
+                "name": "d",
+                "type": "INTEGER"
+            },
+            {
+                "mode": "NULLABLE",
+                "name": "n",
+                "type": "INTEGER"
+            }
+        ],
+        "mode": "REPEATED",
+        "name": "max_price_r",
+        "type": "RECORD"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "shares_received",
+        "type": "FLOAT"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "reserve_a_min_amount",
+        "type": "FLOAT"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "reserve_b_min_amount",
+        "type": "FLOAT"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "shares",
+        "type": "FLOAT"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "reserve_a_withdraw_amount",
+        "type": "FLOAT"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "reserve_b_withdraw_amount",
+        "type": "FLOAT"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "op_id",
+        "type": "INTEGER"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "op_source_account",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "op_source_account_muxed",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "transaction_id",
+        "type": "INTEGER"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "type",
+        "type": "INTEGER"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "type_string",
+        "type": "string"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "transaction_hash",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "ledger_sequence",
+        "type": "INTEGER"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "txn_account",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "account_sequence",
+        "type": "INTEGER"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "max_fee",
+        "type": "INTEGER"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "txn_operation_count",
+        "type": "INTEGER"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "txn_created_at",
+        "type": "TIMESTAMP"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "memo_type",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "memo",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "time_bounds",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "successful",
+        "type": "BOOLEAN"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "fee_charged",
+        "type": "INTEGER"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "fee_account",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "new_max_fee",
+        "type": "INTEGER"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "account_muxed",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "fee_account_muxed",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "ledger_hash",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "previous_ledger_hash",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "transaction_count",
+        "type": "INTEGER"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "ledger_operation_count",
+        "type": "INTEGER"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "closed_at",
+        "type": "TIMESTAMP"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "ledger_id",
+        "type": "INTEGER"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "total_coins",
+        "type": "INTEGER"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "fee_pool",
+        "type": "INTEGER"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "base_fee",
+        "type": "INTEGER"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "base_reserve",
+        "type": "INTEGER"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "max_tx_set_size",
+        "type": "INTEGER"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "protocol_version",
+        "type": "INTEGER"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "successful_transaction_count",
+        "type": "INTEGER"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "failed_transaction_count",
+        "type": "INTEGER"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "batch_id",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "batch_run_date",
+        "type": "DATETIME"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "batch_insert_ts",
+        "type": "TIMESTAMP"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "ledger_bounds",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "min_account_sequence",
+        "type": "INTEGER"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "min_account_sequence_age",
+        "type": "INTEGER"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "min_account_sequence_ledger_gap",
+        "type": "INTEGER"
+    },
+    {
+        "mode": "REPEATED",
+        "name": "extra_signers",
+        "type": "STRING"
+    },
+    {
+      "mode": "NULLABLE",
+      "name": "tx_envelope",
+      "type": "STRING"
+    },
+    {
+      "mode": "NULLABLE",
+      "name": "tx_result",
+      "type": "STRING"
+    },
+    {
+      "mode": "NULLABLE",
+      "name": "tx_meta",
+      "type": "STRING"
+    },
+    {
+      "mode": "NULLABLE",
+      "name": "tx_fee_meta",
+      "type": "STRING"
+    }
 ]

--- a/schemas/enriched_meaningful_history_operations_schema.json
+++ b/schemas/enriched_meaningful_history_operations_schema.json
@@ -1,669 +1,669 @@
 [
     {
-      "mode": "NULLABLE",
-      "name": "account",
-      "type": "STRING"
+        "mode": "NULLABLE",
+        "name": "account",
+        "type": "STRING"
     },
     {
-      "mode": "NULLABLE",
-      "name": "amount",
-      "type": "FLOAT"
+        "mode": "NULLABLE",
+        "name": "amount",
+        "type": "FLOAT"
     },
     {
-      "mode": "NULLABLE",
-      "name": "asset_code",
-      "type": "STRING"
+        "mode": "NULLABLE",
+        "name": "asset_code",
+        "type": "STRING"
     },
     {
-      "mode": "NULLABLE",
-      "name": "asset_issuer",
-      "type": "STRING"
+        "mode": "NULLABLE",
+        "name": "asset_issuer",
+        "type": "STRING"
     },
     {
-      "mode": "NULLABLE",
-      "name": "asset_type",
-      "type": "STRING"
+        "mode": "NULLABLE",
+        "name": "asset_type",
+        "type": "STRING"
     },
     {
-      "mode": "NULLABLE",
-      "name": "asset_id",
-      "type": "INTEGER"
+        "mode": "NULLABLE",
+        "name": "asset_id",
+        "type": "INTEGER"
     },
     {
-      "mode": "NULLABLE",
-      "name": "authorize",
-      "type": "BOOLEAN"
+        "mode": "NULLABLE",
+        "name": "authorize",
+        "type": "BOOLEAN"
     },
     {
-      "mode": "NULLABLE",
-      "name": "balance_id",
-      "type": "STRING"
+        "mode": "NULLABLE",
+        "name": "balance_id",
+        "type": "STRING"
     },
     {
-      "mode": "NULLABLE",
-      "name": "buying_asset_code",
-      "type": "STRING"
+        "mode": "NULLABLE",
+        "name": "buying_asset_code",
+        "type": "STRING"
     },
     {
-      "mode": "NULLABLE",
-      "name": "buying_asset_issuer",
-      "type": "STRING"
+        "mode": "NULLABLE",
+        "name": "buying_asset_issuer",
+        "type": "STRING"
     },
     {
-      "mode": "NULLABLE",
-      "name": "buying_asset_type",
-      "type": "STRING"
+        "mode": "NULLABLE",
+        "name": "buying_asset_type",
+        "type": "STRING"
     },
     {
-      "mode": "NULLABLE",
-      "name": "buying_asset_id",
-      "type": "INTEGER"
+        "mode": "NULLABLE",
+        "name": "buying_asset_id",
+        "type": "INTEGER"
     },
     {
-      "mode": "NULLABLE",
-      "name": "from",
-      "type": "STRING"
+        "mode": "NULLABLE",
+        "name": "from",
+        "type": "STRING"
     },
     {
-      "mode": "NULLABLE",
-      "name": "funder",
-      "type": "STRING"
+        "mode": "NULLABLE",
+        "name": "funder",
+        "type": "STRING"
     },
     {
-      "mode": "NULLABLE",
-      "name": "high_threshold",
-      "type": "INTEGER"
+        "mode": "NULLABLE",
+        "name": "high_threshold",
+        "type": "INTEGER"
     },
     {
-      "mode": "NULLABLE",
-      "name": "home_domain",
-      "type": "STRING"
+        "mode": "NULLABLE",
+        "name": "home_domain",
+        "type": "STRING"
     },
     {
-      "mode": "NULLABLE",
-      "name": "inflation_dest",
-      "type": "STRING"
+        "mode": "NULLABLE",
+        "name": "inflation_dest",
+        "type": "STRING"
     },
     {
-      "mode": "NULLABLE",
-      "name": "into",
-      "type": "STRING"
+        "mode": "NULLABLE",
+        "name": "into",
+        "type": "STRING"
     },
     {
-      "mode": "NULLABLE",
-      "name": "limit",
-      "type": "FLOAT"
+        "mode": "NULLABLE",
+        "name": "limit",
+        "type": "FLOAT"
     },
     {
-      "mode": "NULLABLE",
-      "name": "low_threshold",
-      "type": "INTEGER"
+        "mode": "NULLABLE",
+        "name": "low_threshold",
+        "type": "INTEGER"
     },
     {
-      "mode": "NULLABLE",
-      "name": "master_key_weight",
-      "type": "INTEGER"
+        "mode": "NULLABLE",
+        "name": "master_key_weight",
+        "type": "INTEGER"
     },
     {
-      "mode": "NULLABLE",
-      "name": "med_threshold",
-      "type": "INTEGER"
+        "mode": "NULLABLE",
+        "name": "med_threshold",
+        "type": "INTEGER"
     },
     {
-      "mode": "NULLABLE",
-      "name": "name",
-      "type": "STRING"
+        "mode": "NULLABLE",
+        "name": "name",
+        "type": "STRING"
     },
     {
-      "mode": "NULLABLE",
-      "name": "offer_id",
-      "type": "INTEGER"
+        "mode": "NULLABLE",
+        "name": "offer_id",
+        "type": "INTEGER"
     },
     {
-      "fields": [
-        {
-          "mode": "NULLABLE",
-          "name": "asset_code",
-          "type": "STRING"
-        },
-        {
-          "mode": "NULLABLE",
-          "name": "asset_issuer",
-          "type": "STRING"
-        },
-        {
-          "mode": "NULLABLE",
-          "name": "asset_type",
-          "type": "STRING"
-        }
-      ],
-      "mode": "REPEATED",
-      "name": "path",
-      "type": "RECORD"
+        "fields": [
+            {
+                "mode": "NULLABLE",
+                "name": "asset_code",
+                "type": "STRING"
+            },
+            {
+                "mode": "NULLABLE",
+                "name": "asset_issuer",
+                "type": "STRING"
+            },
+            {
+                "mode": "NULLABLE",
+                "name": "asset_type",
+                "type": "STRING"
+            }
+        ],
+        "mode": "REPEATED",
+        "name": "path",
+        "type": "RECORD"
+        
     },
     {
-      "mode": "NULLABLE",
-      "name": "price",
-      "type": "FLOAT"
+        "mode": "NULLABLE",
+        "name": "price",
+        "type": "FLOAT"
     },
     {
-      "mode": "NULLABLE",
-      "name": "d",
-      "type": "INTEGER"
+        "mode": "NULLABLE",
+        "name": "d",
+        "type": "INTEGER"
     },
     {
-      "mode": "NULLABLE",
-      "name": "n",
-      "type": "INTEGER"
+        "mode": "NULLABLE",
+        "name": "n",
+        "type": "INTEGER"
     },
     {
-      "mode": "NULLABLE",
-      "name": "selling_asset_code",
-      "type": "STRING"
+        "mode": "NULLABLE",
+        "name": "selling_asset_code",
+        "type": "STRING"
     },
     {
-      "mode": "NULLABLE",
-      "name": "selling_asset_issuer",
-      "type": "STRING"
+        "mode": "NULLABLE",
+        "name": "selling_asset_issuer",
+        "type": "STRING"
     },
     {
-      "mode": "NULLABLE",
-      "name": "selling_asset_type",
-      "type": "STRING"
+        "mode": "NULLABLE",
+        "name": "selling_asset_type",
+        "type": "STRING"
     },
     {
-      "mode": "NULLABLE",
-      "name": "selling_asset_id",
-      "type": "INTEGER"
+        "mode": "NULLABLE",
+        "name": "selling_asset_id",
+        "type": "INTEGER"
     },
     {
-      "mode": "REPEATED",
-      "name": "set_flags",
-      "type": "INTEGER"
+        "mode": "REPEATED",
+        "name": "set_flags",
+        "type": "INTEGER"
     },
     {
-      "mode": "REPEATED",
-      "name": "set_flags_s",
-      "type": "STRING"
+        "mode": "REPEATED",
+        "name": "set_flags_s",
+        "type": "STRING"
     },
     {
-      "mode": "NULLABLE",
-      "name": "signer_key",
-      "type": "STRING"
+        "mode": "NULLABLE",
+        "name": "signer_key",
+        "type": "STRING"
     },
     {
-      "mode": "NULLABLE",
-      "name": "signer_weight",
-      "type": "INTEGER"
+        "mode": "NULLABLE",
+        "name": "signer_weight",
+        "type": "INTEGER"
     },
     {
-      "mode": "NULLABLE",
-      "name": "source_amount",
-      "type": "FLOAT"
+        "mode": "NULLABLE",
+        "name": "source_amount",
+        "type": "FLOAT"
     },
     {
-      "mode": "NULLABLE",
-      "name": "source_asset_code",
-      "type": "STRING"
+        "mode": "NULLABLE",
+        "name": "source_asset_code",
+        "type": "STRING"
     },
     {
-      "mode": "NULLABLE",
-      "name": "source_asset_issuer",
-      "type": "STRING"
+        "mode": "NULLABLE",
+        "name": "source_asset_issuer",
+        "type": "STRING"
     },
     {
-      "mode": "NULLABLE",
-      "name": "source_asset_type",
-      "type": "STRING"
+        "mode": "NULLABLE",
+        "name": "source_asset_type",
+        "type": "STRING"
     },
     {
-      "mode": "NULLABLE",
-      "name": "source_asset_id",
-      "type": "INTEGER"
+        "mode": "NULLABLE",
+        "name": "source_asset_id",
+        "type": "INTEGER"
     },
     {
-      "mode": "NULLABLE",
-      "name": "source_max",
-      "type": "FLOAT"
+        "mode": "NULLABLE",
+        "name": "source_max",
+        "type": "FLOAT"
     },
     {
-      "mode": "NULLABLE",
-      "name": "starting_balance",
-      "type": "FLOAT"
+        "mode": "NULLABLE",
+        "name": "starting_balance",
+        "type": "FLOAT"
     },
     {
-      "mode": "NULLABLE",
-      "name": "to",
-      "type": "STRING"
+        "mode": "NULLABLE",
+        "name": "to",
+        "type": "STRING"
     },
     {
-      "mode": "NULLABLE",
-      "name": "trustee",
-      "type": "STRING"
+        "mode": "NULLABLE",
+        "name": "trustee",
+        "type": "STRING"
     },
     {
-      "mode": "NULLABLE",
-      "name": "trustor",
-      "type": "STRING"
+        "mode": "NULLABLE",
+        "name": "trustor",
+        "type": "STRING"
     },
     {
-      "mode": "NULLABLE",
-      "name": "trustline_asset",
-      "type": "STRING"
+        "mode": "NULLABLE",
+        "name": "trustline_asset",
+        "type": "STRING"
     },
     {
-      "mode": "NULLABLE",
-      "name": "value",
-      "type": "STRING"
+        "mode": "NULLABLE",
+        "name": "value",
+        "type": "STRING"
     },
     {
-      "mode": "REPEATED",
-      "name": "clear_flags",
-      "type": "INTEGER"
+        "mode": "REPEATED",
+        "name": "clear_flags",
+        "type": "INTEGER"
     },
     {
-      "mode": "REPEATED",
-      "name": "clear_flags_s",
-      "type": "STRING"
+        "mode": "REPEATED",
+        "name": "clear_flags_s",
+        "type": "STRING"
     },
     {
-      "mode": "NULLABLE",
-      "name": "destination_min",
-      "type": "STRING"
+        "mode": "NULLABLE",
+        "name": "destination_min",
+        "type": "STRING"
     },
     {
-      "mode": "NULLABLE",
-      "name": "bump_to",
-      "type": "STRING"
+        "mode": "NULLABLE",
+        "name": "bump_to",
+        "type": "STRING"
     },
     {
-      "mode": "NULLABLE",
-      "name": "sponsor",
-      "type": "STRING"
+        "mode": "NULLABLE",
+        "name": "sponsor",
+        "type": "STRING"
     },
     {
-      "mode": "NULLABLE",
-      "name": "sponsored_id",
-      "type": "STRING"
+        "mode": "NULLABLE",
+        "name": "sponsored_id",
+        "type": "STRING"
     },
     {
-      "mode": "NULLABLE",
-      "name": "begin_sponsor",
-      "type": "STRING"
+        "mode": "NULLABLE",
+        "name": "begin_sponsor",
+        "type": "STRING"
     },
     {
-      "mode": "NULLABLE",
-      "name": "authorize_to_maintain_liabilities",
-      "type": "BOOLEAN"
+        "mode": "NULLABLE",
+        "name": "authorize_to_maintain_liabilities",
+        "type": "BOOLEAN"
     },
     {
-      "mode": "NULLABLE",
-      "name": "clawback_enabled",
-      "type": "BOOLEAN"
+        "mode": "NULLABLE",
+        "name": "clawback_enabled",
+        "type": "BOOLEAN"
     },
     {
-      "mode": "NULLABLE",
-      "name": "liquidity_pool_id",
-      "type": "STRING"
+        "mode": "NULLABLE",
+        "name": "liquidity_pool_id",
+        "type": "STRING"
     },
     {
-      "mode": "NULLABLE",
-      "name": "reserve_a_asset_type",
-      "type": "STRING"
+        "mode": "NULLABLE",
+        "name": "reserve_a_asset_type",
+        "type": "STRING"
     },
     {
-      "mode": "NULLABLE",
-      "name": "reserve_a_asset_id",
-      "type": "INTEGER"
+        "mode": "NULLABLE",
+        "name": "reserve_a_asset_id",
+        "type": "INTEGER"
     },
     {
-      "mode": "NULLABLE",
-      "name": "reserve_a_asset_code",
-      "type": "STRING"
+        "mode": "NULLABLE",
+        "name": "reserve_a_asset_code",
+        "type": "STRING"
     },
     {
-      "mode": "NULLABLE",
-      "name": "reserve_a_asset_issuer",
-      "type": "STRING"
+        "mode": "NULLABLE",
+        "name": "reserve_a_asset_issuer",
+        "type": "STRING"
     },
     {
-      "mode": "NULLABLE",
-      "name": "reserve_a_max_amount",
-      "type": "FLOAT"
+        "mode": "NULLABLE",
+        "name": "reserve_a_max_amount",
+        "type": "FLOAT"
     },
     {
-      "mode": "NULLABLE",
-      "name": "reserve_a_deposit_amount",
-      "type": "FLOAT"
+        "mode": "NULLABLE",
+        "name": "reserve_a_deposit_amount",
+        "type": "FLOAT"
     },
     {
-      "mode": "NULLABLE",
-      "name": "reserve_b_asset_type",
-      "type": "STRING"
+        "mode": "NULLABLE",
+        "name": "reserve_b_asset_type",
+        "type": "STRING"
     },
     {
-      "mode": "NULLABLE",
-      "name": "reserve_b_asset_id",
-      "type": "INTEGER"
+        "mode": "NULLABLE",
+        "name": "reserve_b_asset_id",
+        "type": "INTEGER"
     },
     {
-      "mode": "NULLABLE",
-      "name": "reserve_b_asset_code",
-      "type": "STRING"
+        "mode": "NULLABLE",
+        "name": "reserve_b_asset_code",
+        "type": "STRING"
     },
     {
-      "mode": "NULLABLE",
-      "name": "reserve_b_asset_issuer",
-      "type": "STRING"
+        "mode": "NULLABLE",
+        "name": "reserve_b_asset_issuer",
+        "type": "STRING"
     },
     {
-      "mode": "NULLABLE",
-      "name": "reserve_b_max_amount",
-      "type": "FLOAT"
+        "mode": "NULLABLE",
+        "name": "reserve_b_max_amount",
+        "type": "FLOAT"
     },
     {
-      "mode": "NULLABLE",
-      "name": "reserve_b_deposit_amount",
-      "type": "FLOAT"
+        "mode": "NULLABLE",
+        "name": "reserve_b_deposit_amount",
+        "type": "FLOAT"
     },
     {
-      "mode": "NULLABLE",
-      "name": "min_price",
-      "type": "FLOAT"
+        "mode": "NULLABLE",
+        "name": "min_price",
+        "type": "FLOAT"
     },
     {
-      "fields": [
-        {
-          "mode": "NULLABLE",
-          "name": "d",
-          "type": "INTEGER"
-        },
-        {
-          "mode": "NULLABLE",
-          "name": "n",
-          "type": "INTEGER"
-        }
-      ],
-      "mode": "REPEATED",
-      "name": "min_price_r",
-      "type": "RECORD"
+        "fields": [
+            {
+                "mode": "NULLABLE",
+                "name": "d",
+                "type": "INTEGER"
+            },
+            {
+                "mode": "NULLABLE",
+                "name": "n",
+                "type": "INTEGER"
+            }
+        ],
+        "mode": "REPEATED",
+        "name": "min_price_r",
+        "type": "RECORD"
     },
     {
-      "mode": "NULLABLE",
-      "name": "max_price",
-      "type": "FLOAT"
+        "mode": "NULLABLE",
+        "name": "max_price",
+        "type": "FLOAT"
     },
     {
-      "fields": [
-        {
-          "mode": "NULLABLE",
-          "name": "d",
-          "type": "INTEGER"
-        },
-        {
-          "mode": "NULLABLE",
-          "name": "n",
-          "type": "INTEGER"
-        }
-      ],
-      "mode": "REPEATED",
-      "name": "max_price_r",
-      "type": "RECORD"
+        "fields": [
+            {
+                "mode": "NULLABLE",
+                "name": "d",
+                "type": "INTEGER"
+            },
+            {
+                "mode": "NULLABLE",
+                "name": "n",
+                "type": "INTEGER"
+            }
+        ],
+        "mode": "REPEATED",
+        "name": "max_price_r",
+        "type": "RECORD"
     },
     {
-      "mode": "NULLABLE",
-      "name": "shares_received",
-      "type": "FLOAT"
+        "mode": "NULLABLE",
+        "name": "shares_received",
+        "type": "FLOAT"
     },
     {
-      "mode": "NULLABLE",
-      "name": "reserve_a_min_amount",
-      "type": "FLOAT"
+        "mode": "NULLABLE",
+        "name": "reserve_a_min_amount",
+        "type": "FLOAT"
     },
     {
-      "mode": "NULLABLE",
-      "name": "reserve_b_min_amount",
-      "type": "FLOAT"
+        "mode": "NULLABLE",
+        "name": "reserve_b_min_amount",
+        "type": "FLOAT"
     },
     {
-      "mode": "NULLABLE",
-      "name": "shares",
-      "type": "FLOAT"
+        "mode": "NULLABLE",
+        "name": "shares",
+        "type": "FLOAT"
     },
     {
-      "mode": "NULLABLE",
-      "name": "reserve_a_withdraw_amount",
-      "type": "FLOAT"
+        "mode": "NULLABLE",
+        "name": "reserve_a_withdraw_amount",
+        "type": "FLOAT"
     },
     {
-      "mode": "NULLABLE",
-      "name": "reserve_b_withdraw_amount",
-      "type": "FLOAT"
+        "mode": "NULLABLE",
+        "name": "reserve_b_withdraw_amount",
+        "type": "FLOAT"
     },
     {
-      "mode": "NULLABLE",
-      "name": "op_id",
-      "type": "INTEGER"
+        "mode": "NULLABLE",
+        "name": "op_id",
+        "type": "INTEGER"
     },
     {
-      "mode": "NULLABLE",
-      "name": "op_source_account",
-      "type": "STRING"
+        "mode": "NULLABLE",
+        "name": "op_source_account",
+        "type": "STRING"
     },
     {
-      "mode": "NULLABLE",
-      "name": "op_source_account_muxed",
-      "type": "STRING"
+        "mode": "NULLABLE",
+        "name": "op_source_account_muxed",
+        "type": "STRING"
     },
     {
-      "mode": "NULLABLE",
-      "name": "transaction_id",
-      "type": "INTEGER"
+        "mode": "NULLABLE",
+        "name": "transaction_id",
+        "type": "INTEGER"
     },
     {
-      "mode": "NULLABLE",
-      "name": "type",
-      "type": "INTEGER"
+        "mode": "NULLABLE",
+        "name": "type",
+        "type": "INTEGER"
     },
     {
-      "mode": "NULLABLE",
-      "name": "transaction_hash",
-      "type": "STRING"
+        "mode": "NULLABLE",
+        "name": "transaction_hash",
+        "type": "STRING"
     },
     {
-      "mode": "NULLABLE",
-      "name": "ledger_sequence",
-      "type": "INTEGER"
+        "mode": "NULLABLE",
+        "name": "ledger_sequence",
+        "type": "INTEGER"
     },
     {
-      "mode": "NULLABLE",
-      "name": "txn_account",
-      "type": "STRING"
+        "mode": "NULLABLE",
+        "name": "txn_account",
+        "type": "STRING"
     },
     {
-      "mode": "NULLABLE",
-      "name": "account_sequence",
-      "type": "INTEGER"
+        "mode": "NULLABLE",
+        "name": "account_sequence",
+        "type": "INTEGER"
     },
     {
-      "mode": "NULLABLE",
-      "name": "max_fee",
-      "type": "INTEGER"
+        "mode": "NULLABLE",
+        "name": "max_fee",
+        "type": "INTEGER"
     },
     {
-      "mode": "NULLABLE",
-      "name": "txn_operation_count",
-      "type": "INTEGER"
+        "mode": "NULLABLE",
+        "name": "txn_operation_count",
+        "type": "INTEGER"
     },
     {
-      "mode": "NULLABLE",
-      "name": "txn_created_at",
-      "type": "TIMESTAMP"
+        "mode": "NULLABLE",
+        "name": "txn_created_at",
+        "type": "TIMESTAMP"
     },
     {
-      "mode": "NULLABLE",
-      "name": "memo_type",
-      "type": "STRING"
+        "mode": "NULLABLE",
+        "name": "memo_type",
+        "type": "STRING"
     },
     {
-      "mode": "NULLABLE",
-      "name": "memo",
-      "type": "STRING"
+        "mode": "NULLABLE",
+        "name": "memo",
+        "type": "STRING"
     },
     {
-      "mode": "NULLABLE",
-      "name": "time_bounds",
-      "type": "STRING"
+        "mode": "NULLABLE",
+        "name": "time_bounds",
+        "type": "STRING"
     },
     {
-      "mode": "NULLABLE",
-      "name": "successful",
-      "type": "BOOLEAN"
+        "mode": "NULLABLE",
+        "name": "successful",
+        "type": "BOOLEAN"
     },
     {
-      "mode": "NULLABLE",
-      "name": "fee_charged",
-      "type": "INTEGER"
+        "mode": "NULLABLE",
+        "name": "fee_charged",
+        "type": "INTEGER"
     },
     {
-      "mode": "NULLABLE",
-      "name": "fee_account",
-      "type": "STRING"
+        "mode": "NULLABLE",
+        "name": "fee_account",
+        "type": "STRING"
     },
     {
-      "mode": "NULLABLE",
-      "name": "new_max_fee",
-      "type": "INTEGER"
+        "mode": "NULLABLE",
+        "name": "new_max_fee",
+        "type": "INTEGER"
     },
     {
-      "mode": "NULLABLE",
-      "name": "account_muxed",
-      "type": "STRING"
+        "mode": "NULLABLE",
+        "name": "account_muxed",
+        "type": "STRING"
     },
     {
-      "mode": "NULLABLE",
-      "name": "fee_account_muxed",
-      "type": "STRING"
+        "mode": "NULLABLE",
+        "name": "fee_account_muxed",
+        "type": "STRING"
     },
     {
-      "mode": "NULLABLE",
-      "name": "ledger_hash",
-      "type": "STRING"
+        "mode": "NULLABLE",
+        "name": "ledger_hash",
+        "type": "STRING"
     },
     {
-      "mode": "NULLABLE",
-      "name": "previous_ledger_hash",
-      "type": "STRING"
+        "mode": "NULLABLE",
+        "name": "previous_ledger_hash",
+        "type": "STRING"
     },
     {
-      "mode": "NULLABLE",
-      "name": "transaction_count",
-      "type": "INTEGER"
+        "mode": "NULLABLE",
+        "name": "transaction_count",
+        "type": "INTEGER"
     },
     {
-      "mode": "NULLABLE",
-      "name": "ledger_operation_count",
-      "type": "INTEGER"
+        "mode": "NULLABLE",
+        "name": "ledger_operation_count",
+        "type": "INTEGER"
     },
     {
-      "mode": "NULLABLE",
-      "name": "closed_at",
-      "type": "TIMESTAMP"
+        "mode": "NULLABLE",
+        "name": "closed_at",
+        "type": "TIMESTAMP"
     },
     {
-      "mode": "NULLABLE",
-      "name": "ledger_id",
-      "type": "INTEGER"
+        "mode": "NULLABLE",
+        "name": "ledger_id",
+        "type": "INTEGER"
     },
     {
-      "mode": "NULLABLE",
-      "name": "total_coins",
-      "type": "INTEGER"
+        "mode": "NULLABLE",
+        "name": "total_coins",
+        "type": "INTEGER"
     },
     {
-      "mode": "NULLABLE",
-      "name": "fee_pool",
-      "type": "INTEGER"
+        "mode": "NULLABLE",
+        "name": "fee_pool",
+        "type": "INTEGER"
     },
     {
-      "mode": "NULLABLE",
-      "name": "base_fee",
-      "type": "INTEGER"
+        "mode": "NULLABLE",
+        "name": "base_fee",
+        "type": "INTEGER"
     },
     {
-      "mode": "NULLABLE",
-      "name": "base_reserve",
-      "type": "INTEGER"
+        "mode": "NULLABLE",
+        "name": "base_reserve",
+        "type": "INTEGER"
     },
     {
-      "mode": "NULLABLE",
-      "name": "max_tx_set_size",
-      "type": "INTEGER"
+        "mode": "NULLABLE",
+        "name": "max_tx_set_size",
+        "type": "INTEGER"
     },
     {
-      "mode": "NULLABLE",
-      "name": "protocol_version",
-      "type": "INTEGER"
+        "mode": "NULLABLE",
+        "name": "protocol_version",
+        "type": "INTEGER"
     },
     {
-      "mode": "NULLABLE",
-      "name": "successful_transaction_count",
-      "type": "INTEGER"
+        "mode": "NULLABLE",
+        "name": "successful_transaction_count",
+        "type": "INTEGER"
     },
     {
-      "mode": "NULLABLE",
-      "name": "failed_transaction_count",
-      "type": "INTEGER"
+        "mode": "NULLABLE",
+        "name": "failed_transaction_count",
+        "type": "INTEGER"
     },
     {
-      "mode": "NULLABLE",
-      "name": "batch_id",
-      "type": "STRING"
+        "mode": "NULLABLE",
+        "name": "batch_id",
+        "type": "STRING"
     },
     {
-      "mode": "NULLABLE",
-      "name": "batch_run_date",
-      "type": "DATETIME"
+        "mode": "NULLABLE",
+        "name": "batch_run_date",
+        "type": "DATETIME"
     },
     {
-      "mode": "NULLABLE",
-      "name": "batch_insert_ts",
-      "type": "TIMESTAMP"
+        "mode": "NULLABLE",
+        "name": "batch_insert_ts",
+        "type": "TIMESTAMP"
     },
     {
-      "mode": "NULLABLE",
-      "name": "code",
-      "type": "STRING"
+        "mode": "NULLABLE",
+        "name": "code",
+        "type": "STRING"
     },
     {
-      "mode": "NULLABLE",
-      "name": "issuer",
-      "type": "STRING"
+        "mode": "NULLABLE",
+        "name": "issuer",
+        "type": "STRING"
     },
     {
-      "mode": "NULLABLE",
-      "name": "ledger_bounds",
-      "type": "STRING"
+        "mode": "NULLABLE",
+        "name": "ledger_bounds",
+        "type": "STRING"
     },
     {
-      "mode": "NULLABLE",
-      "name": "min_account_sequence",
-      "type": "INTEGER"
+        "mode": "NULLABLE",
+        "name": "min_account_sequence",
+        "type": "INTEGER"
     },
     {
-      "mode": "NULLABLE",
-      "name": "min_account_sequence_age",
-      "type": "INTEGER"
+        "mode": "NULLABLE",
+        "name": "min_account_sequence_age",
+        "type": "INTEGER"
     },
     {
-      "mode": "NULLABLE",
-      "name": "min_account_sequence_ledger_gap",
-      "type": "INTEGER"
+        "mode": "NULLABLE",
+        "name": "min_account_sequence_ledger_gap",
+        "type": "INTEGER"
     },
     {
-      "mode": "REPEATED",
-      "name": "extra_signers",
-      "type": "STRING"
+        "mode": "REPEATED",
+        "name": "extra_signers",
+        "type": "STRING"
     }
-  ]
-  
+]

--- a/schemas/enriched_meaningful_history_operations_schema.json
+++ b/schemas/enriched_meaningful_history_operations_schema.json
@@ -1,639 +1,669 @@
 [
     {
-        "mode": "NULLABLE",
-        "name": "account",
-        "type": "STRING"
+      "mode": "NULLABLE",
+      "name": "account",
+      "type": "STRING"
     },
     {
-        "mode": "NULLABLE",
-        "name": "amount",
-        "type": "FLOAT"
+      "mode": "NULLABLE",
+      "name": "amount",
+      "type": "FLOAT"
     },
     {
-        "mode": "NULLABLE",
-        "name": "asset_code",
-        "type": "STRING"
+      "mode": "NULLABLE",
+      "name": "asset_code",
+      "type": "STRING"
     },
     {
-        "mode": "NULLABLE",
-        "name": "asset_issuer",
-        "type": "STRING"
+      "mode": "NULLABLE",
+      "name": "asset_issuer",
+      "type": "STRING"
     },
     {
-        "mode": "NULLABLE",
-        "name": "asset_type",
-        "type": "STRING"
+      "mode": "NULLABLE",
+      "name": "asset_type",
+      "type": "STRING"
     },
     {
-        "mode": "NULLABLE",
-        "name": "authorize",
-        "type": "BOOLEAN"
+      "mode": "NULLABLE",
+      "name": "asset_id",
+      "type": "INTEGER"
     },
     {
-        "mode": "NULLABLE",
-        "name": "balance_id",
-        "type": "STRING"
+      "mode": "NULLABLE",
+      "name": "authorize",
+      "type": "BOOLEAN"
     },
     {
-        "mode": "NULLABLE",
-        "name": "buying_asset_code",
-        "type": "STRING"
+      "mode": "NULLABLE",
+      "name": "balance_id",
+      "type": "STRING"
     },
     {
-        "mode": "NULLABLE",
-        "name": "buying_asset_issuer",
-        "type": "STRING"
+      "mode": "NULLABLE",
+      "name": "buying_asset_code",
+      "type": "STRING"
     },
     {
-        "mode": "NULLABLE",
-        "name": "buying_asset_type",
-        "type": "STRING"
+      "mode": "NULLABLE",
+      "name": "buying_asset_issuer",
+      "type": "STRING"
     },
     {
-        "mode": "NULLABLE",
-        "name": "from",
-        "type": "STRING"
+      "mode": "NULLABLE",
+      "name": "buying_asset_type",
+      "type": "STRING"
     },
     {
-        "mode": "NULLABLE",
-        "name": "funder",
-        "type": "STRING"
+      "mode": "NULLABLE",
+      "name": "buying_asset_id",
+      "type": "INTEGER"
     },
     {
-        "mode": "NULLABLE",
-        "name": "high_threshold",
-        "type": "INTEGER"
+      "mode": "NULLABLE",
+      "name": "from",
+      "type": "STRING"
     },
     {
-        "mode": "NULLABLE",
-        "name": "home_domain",
-        "type": "STRING"
+      "mode": "NULLABLE",
+      "name": "funder",
+      "type": "STRING"
     },
     {
-        "mode": "NULLABLE",
-        "name": "inflation_dest",
-        "type": "STRING"
+      "mode": "NULLABLE",
+      "name": "high_threshold",
+      "type": "INTEGER"
     },
     {
-        "mode": "NULLABLE",
-        "name": "into",
-        "type": "STRING"
+      "mode": "NULLABLE",
+      "name": "home_domain",
+      "type": "STRING"
     },
     {
-        "mode": "NULLABLE",
-        "name": "limit",
-        "type": "FLOAT"
+      "mode": "NULLABLE",
+      "name": "inflation_dest",
+      "type": "STRING"
     },
     {
-        "mode": "NULLABLE",
-        "name": "low_threshold",
-        "type": "INTEGER"
+      "mode": "NULLABLE",
+      "name": "into",
+      "type": "STRING"
     },
     {
-        "mode": "NULLABLE",
-        "name": "master_key_weight",
-        "type": "INTEGER"
+      "mode": "NULLABLE",
+      "name": "limit",
+      "type": "FLOAT"
     },
     {
-        "mode": "NULLABLE",
-        "name": "med_threshold",
-        "type": "INTEGER"
+      "mode": "NULLABLE",
+      "name": "low_threshold",
+      "type": "INTEGER"
     },
     {
-        "mode": "NULLABLE",
-        "name": "name",
-        "type": "STRING"
+      "mode": "NULLABLE",
+      "name": "master_key_weight",
+      "type": "INTEGER"
     },
     {
-        "mode": "NULLABLE",
-        "name": "offer_id",
-        "type": "INTEGER"
+      "mode": "NULLABLE",
+      "name": "med_threshold",
+      "type": "INTEGER"
     },
     {
-        "fields": [
-            {
-                "mode": "NULLABLE",
-                "name": "asset_code",
-                "type": "STRING"
-            },
-            {
-                "mode": "NULLABLE",
-                "name": "asset_issuer",
-                "type": "STRING"
-            },
-            {
-                "mode": "NULLABLE",
-                "name": "asset_type",
-                "type": "STRING"
-            }
-        ],
-        "mode": "REPEATED",
-        "name": "path",
-        "type": "RECORD"
-        
+      "mode": "NULLABLE",
+      "name": "name",
+      "type": "STRING"
     },
     {
-        "mode": "NULLABLE",
-        "name": "price",
-        "type": "FLOAT"
+      "mode": "NULLABLE",
+      "name": "offer_id",
+      "type": "INTEGER"
     },
     {
-        "mode": "NULLABLE",
-        "name": "d",
-        "type": "INTEGER"
+      "fields": [
+        {
+          "mode": "NULLABLE",
+          "name": "asset_code",
+          "type": "STRING"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "asset_issuer",
+          "type": "STRING"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "asset_type",
+          "type": "STRING"
+        }
+      ],
+      "mode": "REPEATED",
+      "name": "path",
+      "type": "RECORD"
     },
     {
-        "mode": "NULLABLE",
-        "name": "n",
-        "type": "INTEGER"
+      "mode": "NULLABLE",
+      "name": "price",
+      "type": "FLOAT"
     },
     {
-        "mode": "NULLABLE",
-        "name": "selling_asset_code",
-        "type": "STRING"
+      "mode": "NULLABLE",
+      "name": "d",
+      "type": "INTEGER"
     },
     {
-        "mode": "NULLABLE",
-        "name": "selling_asset_issuer",
-        "type": "STRING"
+      "mode": "NULLABLE",
+      "name": "n",
+      "type": "INTEGER"
     },
     {
-        "mode": "NULLABLE",
-        "name": "selling_asset_type",
-        "type": "STRING"
+      "mode": "NULLABLE",
+      "name": "selling_asset_code",
+      "type": "STRING"
     },
     {
-        "mode": "REPEATED",
-        "name": "set_flags",
-        "type": "INTEGER"
+      "mode": "NULLABLE",
+      "name": "selling_asset_issuer",
+      "type": "STRING"
     },
     {
-        "mode": "REPEATED",
-        "name": "set_flags_s",
-        "type": "STRING"
+      "mode": "NULLABLE",
+      "name": "selling_asset_type",
+      "type": "STRING"
     },
     {
-        "mode": "NULLABLE",
-        "name": "signer_key",
-        "type": "STRING"
+      "mode": "NULLABLE",
+      "name": "selling_asset_id",
+      "type": "INTEGER"
     },
     {
-        "mode": "NULLABLE",
-        "name": "signer_weight",
-        "type": "INTEGER"
+      "mode": "REPEATED",
+      "name": "set_flags",
+      "type": "INTEGER"
     },
     {
-        "mode": "NULLABLE",
-        "name": "source_amount",
-        "type": "FLOAT"
+      "mode": "REPEATED",
+      "name": "set_flags_s",
+      "type": "STRING"
     },
     {
-        "mode": "NULLABLE",
-        "name": "source_asset_code",
-        "type": "STRING"
+      "mode": "NULLABLE",
+      "name": "signer_key",
+      "type": "STRING"
     },
     {
-        "mode": "NULLABLE",
-        "name": "source_asset_issuer",
-        "type": "STRING"
+      "mode": "NULLABLE",
+      "name": "signer_weight",
+      "type": "INTEGER"
     },
     {
-        "mode": "NULLABLE",
-        "name": "source_asset_type",
-        "type": "STRING"
+      "mode": "NULLABLE",
+      "name": "source_amount",
+      "type": "FLOAT"
     },
     {
-        "mode": "NULLABLE",
-        "name": "source_max",
-        "type": "FLOAT"
+      "mode": "NULLABLE",
+      "name": "source_asset_code",
+      "type": "STRING"
     },
     {
-        "mode": "NULLABLE",
-        "name": "starting_balance",
-        "type": "FLOAT"
+      "mode": "NULLABLE",
+      "name": "source_asset_issuer",
+      "type": "STRING"
     },
     {
-        "mode": "NULLABLE",
-        "name": "to",
-        "type": "STRING"
+      "mode": "NULLABLE",
+      "name": "source_asset_type",
+      "type": "STRING"
     },
     {
-        "mode": "NULLABLE",
-        "name": "trustee",
-        "type": "STRING"
+      "mode": "NULLABLE",
+      "name": "source_asset_id",
+      "type": "INTEGER"
     },
     {
-        "mode": "NULLABLE",
-        "name": "trustor",
-        "type": "STRING"
+      "mode": "NULLABLE",
+      "name": "source_max",
+      "type": "FLOAT"
     },
     {
-        "mode": "NULLABLE",
-        "name": "trustline_asset",
-        "type": "STRING"
+      "mode": "NULLABLE",
+      "name": "starting_balance",
+      "type": "FLOAT"
     },
     {
-        "mode": "NULLABLE",
-        "name": "value",
-        "type": "STRING"
+      "mode": "NULLABLE",
+      "name": "to",
+      "type": "STRING"
     },
     {
-        "mode": "REPEATED",
-        "name": "clear_flags",
-        "type": "INTEGER"
+      "mode": "NULLABLE",
+      "name": "trustee",
+      "type": "STRING"
     },
     {
-        "mode": "REPEATED",
-        "name": "clear_flags_s",
-        "type": "STRING"
+      "mode": "NULLABLE",
+      "name": "trustor",
+      "type": "STRING"
     },
     {
-        "mode": "NULLABLE",
-        "name": "destination_min",
-        "type": "STRING"
+      "mode": "NULLABLE",
+      "name": "trustline_asset",
+      "type": "STRING"
     },
     {
-        "mode": "NULLABLE",
-        "name": "bump_to",
-        "type": "STRING"
+      "mode": "NULLABLE",
+      "name": "value",
+      "type": "STRING"
     },
     {
-        "mode": "NULLABLE",
-        "name": "sponsor",
-        "type": "STRING"
+      "mode": "REPEATED",
+      "name": "clear_flags",
+      "type": "INTEGER"
     },
     {
-        "mode": "NULLABLE",
-        "name": "sponsored_id",
-        "type": "STRING"
+      "mode": "REPEATED",
+      "name": "clear_flags_s",
+      "type": "STRING"
     },
     {
-        "mode": "NULLABLE",
-        "name": "begin_sponsor",
-        "type": "STRING"
+      "mode": "NULLABLE",
+      "name": "destination_min",
+      "type": "STRING"
     },
     {
-        "mode": "NULLABLE",
-        "name": "authorize_to_maintain_liabilities",
-        "type": "BOOLEAN"
+      "mode": "NULLABLE",
+      "name": "bump_to",
+      "type": "STRING"
     },
     {
-        "mode": "NULLABLE",
-        "name": "clawback_enabled",
-        "type": "BOOLEAN"
+      "mode": "NULLABLE",
+      "name": "sponsor",
+      "type": "STRING"
     },
     {
-        "mode": "NULLABLE",
-        "name": "liquidity_pool_id",
-        "type": "STRING"
+      "mode": "NULLABLE",
+      "name": "sponsored_id",
+      "type": "STRING"
     },
     {
-        "mode": "NULLABLE",
-        "name": "reserve_a_asset_type",
-        "type": "STRING"
+      "mode": "NULLABLE",
+      "name": "begin_sponsor",
+      "type": "STRING"
     },
     {
-        "mode": "NULLABLE",
-        "name": "reserve_a_asset_code",
-        "type": "STRING"
+      "mode": "NULLABLE",
+      "name": "authorize_to_maintain_liabilities",
+      "type": "BOOLEAN"
     },
     {
-        "mode": "NULLABLE",
-        "name": "reserve_a_asset_issuer",
-        "type": "STRING"
+      "mode": "NULLABLE",
+      "name": "clawback_enabled",
+      "type": "BOOLEAN"
     },
     {
-        "mode": "NULLABLE",
-        "name": "reserve_a_max_amount",
-        "type": "FLOAT"
+      "mode": "NULLABLE",
+      "name": "liquidity_pool_id",
+      "type": "STRING"
     },
     {
-        "mode": "NULLABLE",
-        "name": "reserve_a_deposit_amount",
-        "type": "FLOAT"
+      "mode": "NULLABLE",
+      "name": "reserve_a_asset_type",
+      "type": "STRING"
     },
     {
-        "mode": "NULLABLE",
-        "name": "reserve_b_asset_type",
-        "type": "STRING"
+      "mode": "NULLABLE",
+      "name": "reserve_a_asset_id",
+      "type": "INTEGER"
     },
     {
-        "mode": "NULLABLE",
-        "name": "reserve_b_asset_code",
-        "type": "STRING"
+      "mode": "NULLABLE",
+      "name": "reserve_a_asset_code",
+      "type": "STRING"
     },
     {
-        "mode": "NULLABLE",
-        "name": "reserve_b_asset_issuer",
-        "type": "STRING"
+      "mode": "NULLABLE",
+      "name": "reserve_a_asset_issuer",
+      "type": "STRING"
     },
     {
-        "mode": "NULLABLE",
-        "name": "reserve_b_max_amount",
-        "type": "FLOAT"
+      "mode": "NULLABLE",
+      "name": "reserve_a_max_amount",
+      "type": "FLOAT"
     },
     {
-        "mode": "NULLABLE",
-        "name": "reserve_b_deposit_amount",
-        "type": "FLOAT"
+      "mode": "NULLABLE",
+      "name": "reserve_a_deposit_amount",
+      "type": "FLOAT"
     },
     {
-        "mode": "NULLABLE",
-        "name": "min_price",
-        "type": "FLOAT"
+      "mode": "NULLABLE",
+      "name": "reserve_b_asset_type",
+      "type": "STRING"
     },
     {
-        "fields": [
-            {
-                "mode": "NULLABLE",
-                "name": "d",
-                "type": "INTEGER"
-            },
-            {
-                "mode": "NULLABLE",
-                "name": "n",
-                "type": "INTEGER"
-            }
-        ],
-        "mode": "REPEATED",
-        "name": "min_price_r",
-        "type": "RECORD"
+      "mode": "NULLABLE",
+      "name": "reserve_b_asset_id",
+      "type": "INTEGER"
     },
     {
-        "mode": "NULLABLE",
-        "name": "max_price",
-        "type": "FLOAT"
+      "mode": "NULLABLE",
+      "name": "reserve_b_asset_code",
+      "type": "STRING"
     },
     {
-        "fields": [
-            {
-                "mode": "NULLABLE",
-                "name": "d",
-                "type": "INTEGER"
-            },
-            {
-                "mode": "NULLABLE",
-                "name": "n",
-                "type": "INTEGER"
-            }
-        ],
-        "mode": "REPEATED",
-        "name": "max_price_r",
-        "type": "RECORD"
+      "mode": "NULLABLE",
+      "name": "reserve_b_asset_issuer",
+      "type": "STRING"
     },
     {
-        "mode": "NULLABLE",
-        "name": "shares_received",
-        "type": "FLOAT"
+      "mode": "NULLABLE",
+      "name": "reserve_b_max_amount",
+      "type": "FLOAT"
     },
     {
-        "mode": "NULLABLE",
-        "name": "reserve_a_min_amount",
-        "type": "FLOAT"
+      "mode": "NULLABLE",
+      "name": "reserve_b_deposit_amount",
+      "type": "FLOAT"
     },
     {
-        "mode": "NULLABLE",
-        "name": "reserve_b_min_amount",
-        "type": "FLOAT"
+      "mode": "NULLABLE",
+      "name": "min_price",
+      "type": "FLOAT"
     },
     {
-        "mode": "NULLABLE",
-        "name": "shares",
-        "type": "FLOAT"
+      "fields": [
+        {
+          "mode": "NULLABLE",
+          "name": "d",
+          "type": "INTEGER"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "n",
+          "type": "INTEGER"
+        }
+      ],
+      "mode": "REPEATED",
+      "name": "min_price_r",
+      "type": "RECORD"
     },
     {
-        "mode": "NULLABLE",
-        "name": "reserve_a_withdraw_amount",
-        "type": "FLOAT"
+      "mode": "NULLABLE",
+      "name": "max_price",
+      "type": "FLOAT"
     },
     {
-        "mode": "NULLABLE",
-        "name": "reserve_b_withdraw_amount",
-        "type": "FLOAT"
+      "fields": [
+        {
+          "mode": "NULLABLE",
+          "name": "d",
+          "type": "INTEGER"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "n",
+          "type": "INTEGER"
+        }
+      ],
+      "mode": "REPEATED",
+      "name": "max_price_r",
+      "type": "RECORD"
     },
     {
-        "mode": "NULLABLE",
-        "name": "op_id",
-        "type": "INTEGER"
+      "mode": "NULLABLE",
+      "name": "shares_received",
+      "type": "FLOAT"
     },
     {
-        "mode": "NULLABLE",
-        "name": "op_source_account",
-        "type": "STRING"
+      "mode": "NULLABLE",
+      "name": "reserve_a_min_amount",
+      "type": "FLOAT"
     },
     {
-        "mode": "NULLABLE",
-        "name": "op_source_account_muxed",
-        "type": "STRING"
+      "mode": "NULLABLE",
+      "name": "reserve_b_min_amount",
+      "type": "FLOAT"
     },
     {
-        "mode": "NULLABLE",
-        "name": "transaction_id",
-        "type": "INTEGER"
+      "mode": "NULLABLE",
+      "name": "shares",
+      "type": "FLOAT"
     },
     {
-        "mode": "NULLABLE",
-        "name": "type",
-        "type": "INTEGER"
+      "mode": "NULLABLE",
+      "name": "reserve_a_withdraw_amount",
+      "type": "FLOAT"
     },
     {
-        "mode": "NULLABLE",
-        "name": "transaction_hash",
-        "type": "STRING"
+      "mode": "NULLABLE",
+      "name": "reserve_b_withdraw_amount",
+      "type": "FLOAT"
     },
     {
-        "mode": "NULLABLE",
-        "name": "ledger_sequence",
-        "type": "INTEGER"
+      "mode": "NULLABLE",
+      "name": "op_id",
+      "type": "INTEGER"
     },
     {
-        "mode": "NULLABLE",
-        "name": "txn_account",
-        "type": "STRING"
+      "mode": "NULLABLE",
+      "name": "op_source_account",
+      "type": "STRING"
     },
     {
-        "mode": "NULLABLE",
-        "name": "account_sequence",
-        "type": "INTEGER"
+      "mode": "NULLABLE",
+      "name": "op_source_account_muxed",
+      "type": "STRING"
     },
     {
-        "mode": "NULLABLE",
-        "name": "max_fee",
-        "type": "INTEGER"
+      "mode": "NULLABLE",
+      "name": "transaction_id",
+      "type": "INTEGER"
     },
     {
-        "mode": "NULLABLE",
-        "name": "txn_operation_count",
-        "type": "INTEGER"
+      "mode": "NULLABLE",
+      "name": "type",
+      "type": "INTEGER"
     },
     {
-        "mode": "NULLABLE",
-        "name": "txn_created_at",
-        "type": "TIMESTAMP"
+      "mode": "NULLABLE",
+      "name": "transaction_hash",
+      "type": "STRING"
     },
     {
-        "mode": "NULLABLE",
-        "name": "memo_type",
-        "type": "STRING"
+      "mode": "NULLABLE",
+      "name": "ledger_sequence",
+      "type": "INTEGER"
     },
     {
-        "mode": "NULLABLE",
-        "name": "memo",
-        "type": "STRING"
+      "mode": "NULLABLE",
+      "name": "txn_account",
+      "type": "STRING"
     },
     {
-        "mode": "NULLABLE",
-        "name": "time_bounds",
-        "type": "STRING"
+      "mode": "NULLABLE",
+      "name": "account_sequence",
+      "type": "INTEGER"
     },
     {
-        "mode": "NULLABLE",
-        "name": "successful",
-        "type": "BOOLEAN"
+      "mode": "NULLABLE",
+      "name": "max_fee",
+      "type": "INTEGER"
     },
     {
-        "mode": "NULLABLE",
-        "name": "fee_charged",
-        "type": "INTEGER"
+      "mode": "NULLABLE",
+      "name": "txn_operation_count",
+      "type": "INTEGER"
     },
     {
-        "mode": "NULLABLE",
-        "name": "fee_account",
-        "type": "STRING"
+      "mode": "NULLABLE",
+      "name": "txn_created_at",
+      "type": "TIMESTAMP"
     },
     {
-        "mode": "NULLABLE",
-        "name": "new_max_fee",
-        "type": "INTEGER"
+      "mode": "NULLABLE",
+      "name": "memo_type",
+      "type": "STRING"
     },
     {
-        "mode": "NULLABLE",
-        "name": "account_muxed",
-        "type": "STRING"
+      "mode": "NULLABLE",
+      "name": "memo",
+      "type": "STRING"
     },
     {
-        "mode": "NULLABLE",
-        "name": "fee_account_muxed",
-        "type": "STRING"
+      "mode": "NULLABLE",
+      "name": "time_bounds",
+      "type": "STRING"
     },
     {
-        "mode": "NULLABLE",
-        "name": "ledger_hash",
-        "type": "STRING"
+      "mode": "NULLABLE",
+      "name": "successful",
+      "type": "BOOLEAN"
     },
     {
-        "mode": "NULLABLE",
-        "name": "previous_ledger_hash",
-        "type": "STRING"
+      "mode": "NULLABLE",
+      "name": "fee_charged",
+      "type": "INTEGER"
     },
     {
-        "mode": "NULLABLE",
-        "name": "transaction_count",
-        "type": "INTEGER"
+      "mode": "NULLABLE",
+      "name": "fee_account",
+      "type": "STRING"
     },
     {
-        "mode": "NULLABLE",
-        "name": "ledger_operation_count",
-        "type": "INTEGER"
+      "mode": "NULLABLE",
+      "name": "new_max_fee",
+      "type": "INTEGER"
     },
     {
-        "mode": "NULLABLE",
-        "name": "closed_at",
-        "type": "TIMESTAMP"
+      "mode": "NULLABLE",
+      "name": "account_muxed",
+      "type": "STRING"
     },
     {
-        "mode": "NULLABLE",
-        "name": "ledger_id",
-        "type": "INTEGER"
+      "mode": "NULLABLE",
+      "name": "fee_account_muxed",
+      "type": "STRING"
     },
     {
-        "mode": "NULLABLE",
-        "name": "total_coins",
-        "type": "INTEGER"
+      "mode": "NULLABLE",
+      "name": "ledger_hash",
+      "type": "STRING"
     },
     {
-        "mode": "NULLABLE",
-        "name": "fee_pool",
-        "type": "INTEGER"
+      "mode": "NULLABLE",
+      "name": "previous_ledger_hash",
+      "type": "STRING"
     },
     {
-        "mode": "NULLABLE",
-        "name": "base_fee",
-        "type": "INTEGER"
+      "mode": "NULLABLE",
+      "name": "transaction_count",
+      "type": "INTEGER"
     },
     {
-        "mode": "NULLABLE",
-        "name": "base_reserve",
-        "type": "INTEGER"
+      "mode": "NULLABLE",
+      "name": "ledger_operation_count",
+      "type": "INTEGER"
     },
     {
-        "mode": "NULLABLE",
-        "name": "max_tx_set_size",
-        "type": "INTEGER"
+      "mode": "NULLABLE",
+      "name": "closed_at",
+      "type": "TIMESTAMP"
     },
     {
-        "mode": "NULLABLE",
-        "name": "protocol_version",
-        "type": "INTEGER"
+      "mode": "NULLABLE",
+      "name": "ledger_id",
+      "type": "INTEGER"
     },
     {
-        "mode": "NULLABLE",
-        "name": "successful_transaction_count",
-        "type": "INTEGER"
+      "mode": "NULLABLE",
+      "name": "total_coins",
+      "type": "INTEGER"
     },
     {
-        "mode": "NULLABLE",
-        "name": "failed_transaction_count",
-        "type": "INTEGER"
+      "mode": "NULLABLE",
+      "name": "fee_pool",
+      "type": "INTEGER"
     },
     {
-        "mode": "NULLABLE",
-        "name": "batch_id",
-        "type": "STRING"
+      "mode": "NULLABLE",
+      "name": "base_fee",
+      "type": "INTEGER"
     },
     {
-        "mode": "NULLABLE",
-        "name": "batch_run_date",
-        "type": "DATETIME"
+      "mode": "NULLABLE",
+      "name": "base_reserve",
+      "type": "INTEGER"
     },
     {
-        "mode": "NULLABLE",
-        "name": "batch_insert_ts",
-        "type": "TIMESTAMP"
+      "mode": "NULLABLE",
+      "name": "max_tx_set_size",
+      "type": "INTEGER"
     },
     {
-        "mode": "NULLABLE",
-        "name": "code",
-        "type": "STRING"
+      "mode": "NULLABLE",
+      "name": "protocol_version",
+      "type": "INTEGER"
     },
     {
-        "mode": "NULLABLE",
-        "name": "issuer",
-        "type": "STRING"
+      "mode": "NULLABLE",
+      "name": "successful_transaction_count",
+      "type": "INTEGER"
     },
     {
-        "mode": "NULLABLE",
-        "name": "ledger_bounds",
-        "type": "STRING"
+      "mode": "NULLABLE",
+      "name": "failed_transaction_count",
+      "type": "INTEGER"
     },
     {
-        "mode": "NULLABLE",
-        "name": "min_account_sequence",
-        "type": "INTEGER"
+      "mode": "NULLABLE",
+      "name": "batch_id",
+      "type": "STRING"
     },
     {
-        "mode": "NULLABLE",
-        "name": "min_account_sequence_age",
-        "type": "INTEGER"
+      "mode": "NULLABLE",
+      "name": "batch_run_date",
+      "type": "DATETIME"
     },
     {
-        "mode": "NULLABLE",
-        "name": "min_account_sequence_ledger_gap",
-        "type": "INTEGER"
+      "mode": "NULLABLE",
+      "name": "batch_insert_ts",
+      "type": "TIMESTAMP"
     },
     {
-        "mode": "REPEATED",
-        "name": "extra_signers",
-        "type": "STRING"
+      "mode": "NULLABLE",
+      "name": "code",
+      "type": "STRING"
+    },
+    {
+      "mode": "NULLABLE",
+      "name": "issuer",
+      "type": "STRING"
+    },
+    {
+      "mode": "NULLABLE",
+      "name": "ledger_bounds",
+      "type": "STRING"
+    },
+    {
+      "mode": "NULLABLE",
+      "name": "min_account_sequence",
+      "type": "INTEGER"
+    },
+    {
+      "mode": "NULLABLE",
+      "name": "min_account_sequence_age",
+      "type": "INTEGER"
+    },
+    {
+      "mode": "NULLABLE",
+      "name": "min_account_sequence_ledger_gap",
+      "type": "INTEGER"
+    },
+    {
+      "mode": "REPEATED",
+      "name": "extra_signers",
+      "type": "STRING"
     }
-]
+  ]
+  

--- a/schemas/history_operations_schema.json
+++ b/schemas/history_operations_schema.json
@@ -1,4 +1,5 @@
-[{
+[
+  {
     "fields": [
       {
         "mode": "NULLABLE",
@@ -42,6 +43,11 @@
       },
       {
         "mode": "NULLABLE",
+        "name": "asset_id",
+        "type": "INTEGER"
+      },
+      {
+        "mode": "NULLABLE",
         "name": "asset_type",
         "type": "STRING"
       },
@@ -64,6 +70,11 @@
         "mode": "NULLABLE",
         "name": "buying_asset_issuer",
         "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "buying_asset_id",
+        "type": "INTEGER"
       },
       {
         "mode": "NULLABLE",
@@ -117,7 +128,7 @@
               {
                 "mode": "NULLABLE",
                 "name": "abs_before_epoch",
-                "type": "INTEGER" 
+                "type": "INTEGER"
               },
               {
                 "fields": [
@@ -139,7 +150,7 @@
                   {
                     "mode": "NULLABLE",
                     "name": "abs_before_epoch",
-                    "type": "INTEGER" 
+                    "type": "INTEGER"
                   },
                   {
                     "fields": [
@@ -161,7 +172,7 @@
                       {
                         "mode": "NULLABLE",
                         "name": "abs_before_epoch",
-                        "type": "INTEGER" 
+                        "type": "INTEGER"
                       }
                     ],
                     "mode": "REPEATED",
@@ -188,7 +199,7 @@
                       {
                         "mode": "NULLABLE",
                         "name": "abs_before_epoch",
-                        "type": "INTEGER" 
+                        "type": "INTEGER"
                       }
                     ],
                     "mode": "REPEATED",
@@ -215,7 +226,7 @@
                       {
                         "mode": "NULLABLE",
                         "name": "abs_before_epoch",
-                        "type": "INTEGER" 
+                        "type": "INTEGER"
                       }
                     ],
                     "mode": "REPEATED",
@@ -247,112 +258,9 @@
                   {
                     "mode": "NULLABLE",
                     "name": "abs_before_epoch",
-                    "type": "INTEGER" 
-                  },
-                  {
-                    "fields": [
-                    {
-                      "mode": "NULLABLE",
-                      "name": "abs_before",
-                      "type": "STRING" 
-                    },
-                    {
-                      "mode": "NULLABLE",
-                      "name": "rel_before",
-                      "type": "INTEGER"
-                    },
-                    {
-                      "mode": "NULLABLE",
-                      "name": "unconditional",
-                      "type": "BOOLEAN"
-                    },
-                    {
-                      "mode": "NULLABLE",
-                      "name": "abs_before_epoch",
-                      "type": "INTEGER" 
-                    }
-                  ],
-                  "mode": "REPEATED",
-                  "name": "and",
-                  "type": "RECORD"
-                  },
-                  {
-                    "fields": [
-                    {
-                      "mode": "NULLABLE",
-                      "name": "abs_before",
-                      "type": "STRING" 
-                    },
-                    {
-                      "mode": "NULLABLE",
-                      "name": "rel_before",
-                      "type": "INTEGER"
-                    },
-                    {
-                      "mode": "NULLABLE",
-                      "name": "unconditional",
-                      "type": "BOOLEAN"
-                    },
-                    {
-                      "mode": "NULLABLE",
-                      "name": "abs_before_epoch",
-                      "type": "INTEGER" 
-                    }
-                  ],
-                  "mode": "REPEATED",
-                  "name": "or",
-                  "type": "RECORD"
-                  },
-                  {
-                    "fields": [
-                    {
-                      "mode": "NULLABLE",
-                      "name": "abs_before",
-                      "type": "STRING" 
-                    },
-                    {
-                      "mode": "NULLABLE",
-                      "name": "rel_before",
-                      "type": "INTEGER"
-                    },
-                    {
-                      "mode": "NULLABLE",
-                      "name": "unconditional",
-                      "type": "BOOLEAN"
-                    },
-                    {
-                      "mode": "NULLABLE",
-                      "name": "abs_before_epoch",
-                      "type": "INTEGER" 
-                    }
-                  ],
-                  "mode": "REPEATED",
-                  "name": "not",
-                  "type": "RECORD"
-                  }
-                ],
-                "mode": "REPEATED",
-                "name": "not",
-                "type": "RECORD" 
-              },
-              {
-                "fields": [
-                  {
-                    "mode": "NULLABLE",
-                    "name": "abs_before",
-                    "type": "STRING"
-                  },
-                  {
-                    "mode": "NULLABLE",
-                    "name": "rel_before",
                     "type": "INTEGER"
                   },
                   {
-                    "mode": "NULLABLE",
-                    "name": "abs_before_epoch",
-                    "type": "INTEGER" 
-                  },
-                  {
                     "fields": [
                       {
                         "mode": "NULLABLE",
@@ -372,17 +280,12 @@
                       {
                         "mode": "NULLABLE",
                         "name": "abs_before_epoch",
-                        "type": "INTEGER" 
+                        "type": "INTEGER"
                       }
                     ],
                     "mode": "REPEATED",
-                    "name": "not",
+                    "name": "and",
                     "type": "RECORD"
-                  },
-                  {
-                    "mode": "NULLABLE",
-                    "name": "unconditional",
-                    "type": "BOOLEAN" 
                   },
                   {
                     "fields": [
@@ -404,7 +307,7 @@
                       {
                         "mode": "NULLABLE",
                         "name": "abs_before_epoch",
-                        "type": "INTEGER" 
+                        "type": "INTEGER"
                       }
                     ],
                     "mode": "REPEATED",
@@ -431,7 +334,115 @@
                       {
                         "mode": "NULLABLE",
                         "name": "abs_before_epoch",
-                        "type": "INTEGER" 
+                        "type": "INTEGER"
+                      }
+                    ],
+                    "mode": "REPEATED",
+                    "name": "not",
+                    "type": "RECORD"
+                  }
+                ],
+                "mode": "REPEATED",
+                "name": "not",
+                "type": "RECORD"
+              },
+              {
+                "fields": [
+                  {
+                    "mode": "NULLABLE",
+                    "name": "abs_before",
+                    "type": "STRING"
+                  },
+                  {
+                    "mode": "NULLABLE",
+                    "name": "rel_before",
+                    "type": "INTEGER"
+                  },
+                  {
+                    "mode": "NULLABLE",
+                    "name": "abs_before_epoch",
+                    "type": "INTEGER"
+                  },
+                  {
+                    "fields": [
+                      {
+                        "mode": "NULLABLE",
+                        "name": "abs_before",
+                        "type": "STRING"
+                      },
+                      {
+                        "mode": "NULLABLE",
+                        "name": "rel_before",
+                        "type": "INTEGER"
+                      },
+                      {
+                        "mode": "NULLABLE",
+                        "name": "unconditional",
+                        "type": "BOOLEAN"
+                      },
+                      {
+                        "mode": "NULLABLE",
+                        "name": "abs_before_epoch",
+                        "type": "INTEGER"
+                      }
+                    ],
+                    "mode": "REPEATED",
+                    "name": "not",
+                    "type": "RECORD"
+                  },
+                  {
+                    "mode": "NULLABLE",
+                    "name": "unconditional",
+                    "type": "BOOLEAN"
+                  },
+                  {
+                    "fields": [
+                      {
+                        "mode": "NULLABLE",
+                        "name": "abs_before",
+                        "type": "STRING"
+                      },
+                      {
+                        "mode": "NULLABLE",
+                        "name": "rel_before",
+                        "type": "INTEGER"
+                      },
+                      {
+                        "mode": "NULLABLE",
+                        "name": "unconditional",
+                        "type": "BOOLEAN"
+                      },
+                      {
+                        "mode": "NULLABLE",
+                        "name": "abs_before_epoch",
+                        "type": "INTEGER"
+                      }
+                    ],
+                    "mode": "REPEATED",
+                    "name": "or",
+                    "type": "RECORD"
+                  },
+                  {
+                    "fields": [
+                      {
+                        "mode": "NULLABLE",
+                        "name": "abs_before",
+                        "type": "STRING"
+                      },
+                      {
+                        "mode": "NULLABLE",
+                        "name": "rel_before",
+                        "type": "INTEGER"
+                      },
+                      {
+                        "mode": "NULLABLE",
+                        "name": "unconditional",
+                        "type": "BOOLEAN"
+                      },
+                      {
+                        "mode": "NULLABLE",
+                        "name": "abs_before_epoch",
+                        "type": "INTEGER"
                       },
                       {
                         "fields": [
@@ -453,8 +464,8 @@
                           {
                             "mode": "NULLABLE",
                             "name": "abs_before_epoch",
-                            "type": "INTEGER" 
-                          } 
+                            "type": "INTEGER"
+                          }
                         ],
                         "mode": "REPEATED",
                         "name": "not",
@@ -636,6 +647,11 @@
       },
       {
         "mode": "NULLABLE",
+        "name": "selling_asset_id",
+        "type": "INTEGER"
+      },
+      {
+        "mode": "NULLABLE",
         "name": "selling_asset_type",
         "type": "STRING"
       },
@@ -678,6 +694,11 @@
         "mode": "NULLABLE",
         "name": "source_asset_issuer",
         "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "source_asset_id",
+        "type": "INTEGER"
       },
       {
         "mode": "NULLABLE",
@@ -823,11 +844,16 @@
         "mode": "NULLABLE",
         "name": "reserve_a_asset_code",
         "type": "STRING"
-      }, 
+      },
       {
         "mode": "NULLABLE",
         "name": "reserve_a_asset_issuer",
         "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "reserve_a_asset_id",
+        "type": "INTEGER"
       },
       {
         "mode": "NULLABLE",
@@ -848,11 +874,16 @@
         "mode": "NULLABLE",
         "name": "reserve_b_asset_code",
         "type": "STRING"
-      }, 
+      },
       {
         "mode": "NULLABLE",
         "name": "reserve_b_asset_issuer",
         "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "reserve_b_asset_id",
+        "type": "INTEGER"
       },
       {
         "mode": "NULLABLE",
@@ -869,19 +900,19 @@
         "name": "min_price",
         "type": "FLOAT"
       },
-      { "fields": [
-        {
-          "mode": "NULLABLE",
-          "name": "d",
-          "type": "INTEGER"
-        },
-        {
-          "mode": "NULLABLE",
-          "name": "n",
-          "type": "INTEGER"
-        }
-
-      ],
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "d",
+            "type": "INTEGER"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "n",
+            "type": "INTEGER"
+          }
+        ],
         "mode": "REPEATED",
         "name": "min_price_r",
         "type": "RECORD"
@@ -891,19 +922,19 @@
         "name": "max_price",
         "type": "FLOAT"
       },
-      { "fields": [
-        {
-          "mode": "NULLABLE",
-          "name": "d",
-          "type": "INTEGER"
-        },
-        {
-          "mode": "NULLABLE",
-          "name": "n",
-          "type": "INTEGER"
-        }
-
-      ],
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "d",
+            "type": "INTEGER"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "n",
+            "type": "INTEGER"
+          }
+        ],
         "mode": "REPEATED",
         "name": "max_price_r",
         "type": "RECORD"
@@ -911,32 +942,32 @@
       {
         "mode": "NULLABLE",
         "name": "shares_received",
-        "type": "FLOAT" 
+        "type": "FLOAT"
       },
       {
         "mode": "NULLABLE",
         "name": "reserve_a_min_amount",
-        "type": "FLOAT"  
+        "type": "FLOAT"
       },
       {
         "mode": "NULLABLE",
         "name": "reserve_a_withdraw_amount",
-        "type": "FLOAT"  
+        "type": "FLOAT"
       },
       {
         "mode": "NULLABLE",
         "name": "reserve_b_min_amount",
-        "type": "FLOAT"  
+        "type": "FLOAT"
       },
       {
         "mode": "NULLABLE",
         "name": "reserve_b_withdraw_amount",
-        "type": "FLOAT"  
+        "type": "FLOAT"
       },
       {
         "mode": "NULLABLE",
         "name": "shares",
-        "type": "FLOAT"  
+        "type": "FLOAT"
       }
     ],
     "mode": "NULLABLE",
@@ -957,7 +988,6 @@
     "mode": "NULLABLE",
     "name": "source_account_muxed",
     "type": "STRING"
-
   },
   {
     "mode": "NULLABLE",

--- a/schemas/history_trades_schema.json
+++ b/schemas/history_trades_schema.json
@@ -36,6 +36,11 @@
   },
   {
     "mode": "NULLABLE",
+    "name": "selling_asset_id",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
     "name": "selling_amount",
     "type": "FLOAT"
   },
@@ -58,6 +63,11 @@
      "mode": "NULLABLE",
      "name": "buying_asset_type",
      "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "buying_asset_id",
+    "type": "INTEGER"
   },
   {
     "mode": "NULLABLE",

--- a/schemas/liquidity_pools_schema.json
+++ b/schemas/liquidity_pools_schema.json
@@ -41,6 +41,11 @@
     },
     {   
         "mode": "NULLABLE",
+        "name": "asset_a_id",
+        "type": "STRING"
+    },
+    {   
+        "mode": "NULLABLE",
         "name": "asset_a_amount",
         "type": "FLOAT"
     },
@@ -57,6 +62,11 @@
     {   
         "mode": "NULLABLE",
         "name": "asset_b_issuer",
+        "type": "STRING"
+    },
+    {   
+        "mode": "NULLABLE",
+        "name": "asset_b_id",
         "type": "STRING"
     },
     {   

--- a/schemas/offers_schema.json
+++ b/schemas/offers_schema.json
@@ -26,6 +26,11 @@
   },
   {
     "mode": "NULLABLE",
+    "name": "selling_asset_id",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
     "name": "buying_asset_type",
     "type": "STRING"
   },
@@ -38,6 +43,11 @@
     "mode": "NULLABLE",
     "name": "buying_asset_issuer",
     "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "buying_asset_id",
+    "type": "INTEGER"
   },
   {
     "mode": "NULLABLE",

--- a/schemas/trust_lines_schema.json
+++ b/schemas/trust_lines_schema.json
@@ -26,6 +26,11 @@
   },
   {
     "mode": "NULLABLE",
+    "name": "asset_id",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
     "name": "liquidity_pool_id",
     "type": "STRING"  
   },


### PR DESCRIPTION
This PR is related to issue #341, after a review of the tables that will not go to the dbt flow, the tables that have changed history_assets, history_ledgers, history_operations, history_trades, history_transactions, enriched_history_operation, enriched_meaningful_history_operation, account_signers, account, claimable_balances, liquidity_pools, offers, trust_lines.
The clusters were changed and the partitions of the tables that were not partitioned were inserted.