### PR TITLE
Changes needed to upgrade Airflow version

### DIFF
--- a/airflow_variables_dev.json
+++ b/airflow_variables_dev.json
@@ -210,23 +210,23 @@
   "resources": {
     "default": {
       "requests": {
-        "cpu": "1.2",
-        "memory": "5Gi",
+        "cpu": "0.3",
+        "memory": "900Mi",
         "ephemeral-storage": "10Mi"
       }
     },
     "cc": {
       "requests": {
-        "cpu": "3.5",
-        "memory": "15Gi",
-        "ephemeral-storage": "10Gi"
+        "cpu": "0.3",
+        "memory": "900Mi",
+        "ephemeral-storage": "1Gi"
       }
     },
     "state": {
       "requests": {
-        "cpu": "3.5",
-        "memory": "20Gi",
-        "ephemeral-storage": "12Gi"
+        "cpu": "0.3",
+        "memory": "900Mi",
+        "ephemeral-storage": "1Gi"
       }
     }
   },

--- a/dags/stellar_etl_airflow/build_export_task.py
+++ b/dags/stellar_etl_airflow/build_export_task.py
@@ -134,7 +134,7 @@ def build_export_task(dag, cmd_type, command, filename, use_gcs=False, use_testn
         do_xcom_push=True,
         is_delete_operator_pod=True,
         startup_timeout_seconds=720,
-        resources=k8s.V1ResourceRequirements(requests=resources_requests),
+        container_resources=k8s.V1ResourceRequirements(requests=resources_requests),
         in_cluster=in_cluster,
         config_file=config_file_location,
         affinity=affinity,

--- a/dags/stellar_etl_airflow/build_time_task.py
+++ b/dags/stellar_etl_airflow/build_time_task.py
@@ -50,7 +50,7 @@ def build_time_task(dag, use_testnet=False, use_next_exec_time=True, resource_cf
          in_cluster=in_cluster,
          config_file=config_file_location,
          affinity=affinity,
-         resources=k8s.V1ResourceRequirements(requests=resources_requests),
+         container_resources=k8s.V1ResourceRequirements(requests=resources_requests),
          on_failure_callback=alert_after_max_retries,
          image_pull_policy=Variable.get('image_pull_policy')
      ) 


### PR DESCRIPTION
This PR replaces the deprecated argument `resources` from `KubernetesPodOperator` to `container_resources`
and
modify the resources values requested by pods on the Airflow `dev` environment (needed after downscaling machine type).