### PR TITLE
Update airflow sentry alerting levels to fatal

### DIFF
--- a/dags/stellar_etl_airflow/build_gcs_to_bq_task.py
+++ b/dags/stellar_etl_airflow/build_gcs_to_bq_task.py
@@ -40,7 +40,7 @@ class CustomGCSToBigQueryOperator(GCSToBigQueryOperator):
                 )
                 capture_message(
                     f"failed_transforms ({self.failed_transforms}) has exceeded the max value ({self.max_failed_transforms})",
-                    "error",
+                    "fatal",
                 )
         super().pre_execute(**kwargs)
 

--- a/dags/stellar_etl_airflow/default.py
+++ b/dags/stellar_etl_airflow/default.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta
 from airflow.models import Variable
 from sentry_sdk import capture_message, init, push_scope, set_tag
 from sentry_sdk.integrations.logging import LoggingIntegration
+import logging
 
 
 def init_sentry():

--- a/dags/stellar_etl_airflow/default.py
+++ b/dags/stellar_etl_airflow/default.py
@@ -2,12 +2,21 @@ from datetime import datetime, timedelta
 
 from airflow.models import Variable
 from sentry_sdk import capture_message, init, push_scope, set_tag
+from sentry_sdk.integrations.logging import LoggingIntegration
 
 
 def init_sentry():
+    sentry_logging = LoggingIntegration(
+            level=logging.INFO,
+            event_level=logging.FATAL
+    )
+
     init(
         dsn=Variable.get("sentry_dsn"),
         environment=Variable.get("sentry_environment"),
+        integrations=[
+            sentry_logging,
+        ],
     )
     set_tag("image_version", Variable.get("image_name"))
 
@@ -52,5 +61,5 @@ def alert_after_max_retries(context):
             scope.set_extra("duration", ti.duration)
             capture_message(
                 f"The task {ti.task_id} belonging to DAG {ti.dag_id} failed after max retries.",
-                "error",
+                "fatal",
             )


### PR DESCRIPTION
https://stellarorg.atlassian.net/browse/HUBBLE-68

Updated airflow sentry alerting to only send alert event on fatal level errors.

Airflow will now only alert on:
* Max number of retries has been exceeded
* stellar-etl contained failed transformations