### PR TITLE
Change `release.yml` syntax for multiline strings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Create pull request
-        run: |
+        run: >-
           gh pr create \
           --base release \
           --head master \


### PR DESCRIPTION
This PR fixes the mentioned workflow syntax to create a pull request after a pull request is merged.