### PR TITLE
Allow snapshots in dbt tasks

### DIFF
--- a/dags/mgi_transforms_dag.py
+++ b/dags/mgi_transforms_dag.py
@@ -17,6 +17,11 @@ dag = DAG(
     max_active_runs=1,
 )
 
+# build snapshot table for raw transactions
+snapshot_raw_mgi_stellar_transactions = built_dbt_task(
+    dag, "snapshot_raw_mgi_stellar_transactions", "snapshot"
+)
+
 # tasks for staging tables for mgi transactions
 stg_mgi_transactions = build_dbt_task(dag, "stg_mgi_transactions")
 

--- a/dags/mgi_transforms_dag.py
+++ b/dags/mgi_transforms_dag.py
@@ -33,4 +33,9 @@ fct_mgi_cashflow = build_dbt_task(dag, "fct_mgi_cashflow")
 
 # DAG task graph
 # graph for partnership_assets__account_holders_activity_fact
-stg_mgi_transactions >> int_mgi_transactions_transformed >> fct_mgi_cashflow
+(
+    snapshot_raw_mgi_stellar_transactions
+    >> stg_mgi_transactions
+    >> int_mgi_transactions_transformed
+    >> fct_mgi_cashflow
+)

--- a/dags/mgi_transforms_dag.py
+++ b/dags/mgi_transforms_dag.py
@@ -18,7 +18,7 @@ dag = DAG(
 )
 
 # build snapshot table for raw transactions
-snapshot_raw_mgi_stellar_transactions = built_dbt_task(
+snapshot_raw_mgi_stellar_transactions = build_dbt_task(
     dag, "snapshot_raw_mgi_stellar_transactions", "snapshot"
 )
 

--- a/dags/stellar_etl_airflow/build_dbt_task.py
+++ b/dags/stellar_etl_airflow/build_dbt_task.py
@@ -60,12 +60,13 @@ stellar_dbt:
     return create_dbt_profile_cmd
 
 
-def build_dbt_task(dag, model_name, resource_cfg="default"):
+def build_dbt_task(dag, model_name, command_type="run", resource_cfg="default"):
     """Create a task to run dbt on a selected model.
 
     args:
         dag: parent dag for this task
         model_name: dbt model_name to run
+        command_type: dbt command name, defaults to "run"
         resource_cfg: the resource config name defined in the airflow 'resources' variable for k8s
 
     returns:
@@ -89,7 +90,9 @@ def build_dbt_task(dag, model_name, resource_cfg="default"):
             [
                 create_dbt_profile_cmd,
                 execution_date,
-                "dbt run --select",
+                "dbt ",
+                command_type,
+                " --select",
                 model_name,
                 dbt_full_refresh,
             ]

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,8 +1,12 @@
 alembic==1.10.4
 apache-airflow==2.3.3
 apache-airflow-providers-cncf-kubernetes==4.4.0
+apache-airflow-providers-common-sql==1.4.0
+apache-airflow-providers-ftp==3.3.1
 apache-airflow-providers-google==8.6.0
+apache-airflow-providers-http==4.3.0
 apache-airflow-providers-imap==3.1.1
+apache-airflow-providers-sqlite==3.3.2
 docker==3.7.3
 freezegun==1.2.0
 jsonlines==3.0

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -2,6 +2,7 @@ alembic==1.10.4
 apache-airflow==2.3.3
 apache-airflow-providers-cncf-kubernetes==4.4.0
 apache-airflow-providers-google==8.6.0
+apache-airflow-providers-imap==3.1.1
 docker==3.7.3
 freezegun==1.2.0
 jsonlines==3.0


### PR DESCRIPTION
Current dbt tasks had `dbt run --select` hardcoded into the command. Snapshot tables use their own command, `dbt snapshot`. PR updates the logic to build the CLI command to allow flexibility in the command type.