### PR TITLE
New Airflow Task: Copy Tables for current ledger state

### DIFF
--- a/airflow_variables.json
+++ b/airflow_variables.json
@@ -216,6 +216,7 @@
     }
   },
   "public_dataset": "crypto_stellar_2",
+  "public_dataset_new": "crypto_stellar",
   "public_project": "crypto-stellar",
   "bq_dataset_audit_log": "audit_log",
   "resources": {

--- a/airflow_variables.json
+++ b/airflow_variables.json
@@ -261,6 +261,7 @@
   "task_timeout": {
     "build_batch_stats": 180,
     "build_bq_insert_job": 180,
+    "build_copy_table": 180,
     "build_dbt_task": 6000,
     "build_delete_data_task": 180,
     "build_export_task": 180,

--- a/airflow_variables_dev.json
+++ b/airflow_variables_dev.json
@@ -240,6 +240,7 @@
   "task_timeout": {
     "build_batch_stats": 180,
     "build_bq_insert_job": 180,
+    "build_copy_table": 180,
     "build_dbt_task": 300,
     "build_delete_data_task": 180,
     "build_export_task": 180,

--- a/airflow_variables_dev.json
+++ b/airflow_variables_dev.json
@@ -196,6 +196,7 @@
     }
   },
   "public_dataset": "test_crypto_stellar_2",
+  "public_dataset_new": "test_crypto_stellar",
   "public_project": "test-hubble-319619",
   "resources": {
     "default": {

--- a/dags/ledger_current_state_dag.py
+++ b/dags/ledger_current_state_dag.py
@@ -2,6 +2,7 @@ import datetime
 
 from airflow import DAG
 from airflow.models.variable import Variable
+from stellar_etl_airflow.build_copy_table_task import build_copy_table
 from stellar_etl_airflow.build_dbt_task import build_dbt_task
 from stellar_etl_airflow.default import get_default_dag_args, init_sentry
 
@@ -17,6 +18,11 @@ dag = DAG(
     catchup=False,
 )
 
+internal_project = Variable.get("bq_project")
+internal_dataset = Variable.get("bq_project")
+public_project = Variable.get("public_project")
+public_dataset = Variable.get("public_dataset")
+
 # tasks for staging tables for ledger_current_state tables
 stg_account_signers = build_dbt_task(dag, "stg_account_signers")
 stg_history_ledgers = build_dbt_task(dag, "stg_history_ledgers")
@@ -26,11 +32,63 @@ stg_offers = build_dbt_task(dag, "stg_offers")
 stg_trust_lines = build_dbt_task(dag, "stg_trust_lines")
 
 # tasks for ledger_current_state tables
-account_signers_current = build_dbt_task(dag, "account_signers_current")
-accounts_current = build_dbt_task(dag, "accounts_current")
-liquidity_pools_current = build_dbt_task(dag, "liquidity_pools_current")
-offers_current = build_dbt_task(dag, "offers_current")
-trust_lines_current = build_dbt_task(dag, "trust_lines_current")
+account_signers = "account_signers_current"
+account_signers_current = build_dbt_task(dag, account_signers)
+accounts = "accounts_current"
+accounts_current = build_dbt_task(dag, accounts)
+liquidity_pools = "liquidity_pools_current"
+liquidity_pools_current = build_dbt_task(dag, liquidity_pools)
+offers = "offers_current"
+offers_current = build_dbt_task(dag, offers)
+trust_lines = "trust_lines_current"
+trust_lines_current = build_dbt_task(dag, trust_lines)
+
+# copy the tables over to public dataset
+account_signers_public = build_copy_table(
+    dag,
+    internal_project,
+    internal_dataset,
+    account_signers,
+    public_project,
+    public_dataset,
+    account_signers,
+)
+accounts_public = build_copy_table(
+    dag,
+    internal_project,
+    internal_dataset,
+    accounts,
+    public_project,
+    public_dataset,
+    accounts,
+)
+liquidity_pools_public = build_copy_table(
+    dag,
+    internal_project,
+    internal_dataset,
+    liquidity_pools,
+    public_project,
+    public_dataset,
+    liquidity_pools,
+)
+offers_public = build_copy_table(
+    dag,
+    internal_project,
+    internal_dataset,
+    offers,
+    public_project,
+    public_dataset,
+    offers,
+)
+trust_lines_public = build_copy_table(
+    dag,
+    internal_project,
+    internal_dataset,
+    trust_lines,
+    public_project,
+    public_dataset,
+    trust_lines,
+)
 
 # DAG task graph
 # graph for ledger_current_state tables
@@ -48,3 +106,9 @@ stg_history_ledgers >> offers_current
 
 stg_trust_lines >> trust_lines_current
 stg_history_ledgers >> trust_lines_current
+
+account_signers_current >> account_signers_public
+accounts_current >> accounts_public
+liquidity_pools_current >> liquidity_pools_public
+offers_current >> offers_public
+trust_lines_current >> trust_lines_public

--- a/dags/ledger_current_state_dag.py
+++ b/dags/ledger_current_state_dag.py
@@ -21,7 +21,7 @@ dag = DAG(
 internal_project = Variable.get("bq_project")
 internal_dataset = Variable.get("bq_project")
 public_project = Variable.get("public_project")
-public_dataset = Variable.get("public_dataset")
+public_dataset = Variable.get("public_dataset_new")
 
 # tasks for staging tables for ledger_current_state tables
 stg_account_signers = build_dbt_task(dag, "stg_account_signers")

--- a/dags/stellar_etl_airflow/build_copy_table_task.py
+++ b/dags/stellar_etl_airflow/build_copy_table_task.py
@@ -59,5 +59,4 @@ def build_copy_table(
         ),
         on_failure_callback=alert_after_max_retries,
         configuration=configuration,
-        job_type="COPY",
     )

--- a/dags/stellar_etl_airflow/build_copy_table_task.py
+++ b/dags/stellar_etl_airflow/build_copy_table_task.py
@@ -14,7 +14,7 @@ def build_copy_table(
     destination_project,
     destination_dataset,
     destination_table,
-    write_disposition="WRITE_APPEND",
+    write_disposition="WRITE_TRUNCATE",
 ):
     """Create a task to copy a table.
 
@@ -27,7 +27,7 @@ def build_copy_table(
         destination_dataset: destination dataset
         destination_table: destination table
         write_disposition: specifies the action that occurs
-            if the table exists, defaults to "WRITE_APPEND"
+            if the table exists, defaults to "WRITE_TRUNCATE"
 
     returns:
         BigQueryInsertJobOperator

--- a/dags/stellar_etl_airflow/build_copy_table_task.py
+++ b/dags/stellar_etl_airflow/build_copy_table_task.py
@@ -1,0 +1,63 @@
+from datetime import timedelta
+
+from airflow.models import Variable
+from airflow.providers.google.cloud.operators.bigquery import BigQueryInsertJobOperator
+from stellar_etl_airflow import macros
+from stellar_etl_airflow.default import alert_after_max_retries
+
+
+def build_copy_table(
+    dag,
+    source_project,
+    source_dataset,
+    source_table,
+    destination_project,
+    destination_dataset,
+    destination_table,
+    write_disposition="WRITE_APPEND",
+):
+    """Create a task to copy a table.
+
+    args:
+        dag: parent dag for this task
+        source_project: table to copy's project
+        source_dataset: table to copy's dataset
+        source_table: table to copy
+        destination_project: destination project
+        destination_dataset: destination dataset
+        destination_table: destination table
+        write_disposition: specifies the action that occurs
+            if the table exists, defaults to "WRITE_APPEND"
+
+    returns:
+        BigQueryInsertJobOperator
+    """
+
+    configuration = {
+        "copy": {
+            "sourceTable": {
+                "projectId": source_project,
+                "datasetId": source_dataset,
+                "tableId": source_table,
+            },
+            "destinationTable": {
+                "projectId": destination_project,
+                "datasetId": destination_dataset,
+                "tableId": destination_table,
+            },
+            "createDisposition": "CREATE_IF_NEEDED",
+            "writeDisposition": write_disposition,
+        }
+    }
+
+    return BigQueryInsertJobOperator(
+        task_id=f"copy_table_{source_table}",
+        execution_timeout=timedelta(
+            seconds=Variable.get("task_timeout", deserialize_json=True)[
+                build_copy_table.__name__
+            ]
+        ),
+        on_failure_callback=alert_after_max_retries,
+        configuration=configuration,
+        job_type="COPY",
+    )


### PR DESCRIPTION
The current ledger state tables are only available in the internal Hubble dataset. The public dataset also needs access to these tables. There were several options regarding how to make this data available:

1. Create views that pointed to the underlying internal tables,
2. Copy the tables to the public dataset after loading internal
3. Duplicate the dbt jobs to load the tables directly from `stellar-dbt`

I chose not to use views due to limitations of data accessibility. Users would not have access to the underlying table metadata (clustering, partitioning), they could not export the data via BigQuery API, which would limit the ways in which user could interact with the data. Duplicating dbt jobs seemed confusing and messy, we don't want to maintain two copies of the same job, and there should be a single source of truth for these tables.

I opted to build a new Airflow task, `build_copy_task`, that uses the `BigQueryInsertJobOperator` to copy the data from the internal tables to new destination tables in the public dataset. The tasks execute after the tables finish loading from dbt.