### PR TITLE
Add tasks for trade agg

### DIFF
--- a/airflow_variables.json
+++ b/airflow_variables.json
@@ -113,7 +113,7 @@
     "partnership_assets__asset_activity_fact": true,
     "trade_agg": true
   },
-  "dbt_image_name": "chowbao/stellar-dbt:fb02e7a",
+  "dbt_image_name": "stellar/stellar-dbt:fd3476c",
   "dbt_job_execution_timeout_seconds": 6000,
   "dbt_job_retries": 1,
   "dbt_keyfile_profile": "",

--- a/airflow_variables_dev.json
+++ b/airflow_variables_dev.json
@@ -90,7 +90,7 @@
     "partnership_assets__account_holders_activity_fact": true,
     "partnership_assets__asset_activity_fact": true
   },
-  "dbt_image_name": "chowbao/stellar-dbt:31098a7",
+  "dbt_image_name": "stellar/stellar-dbt:fd3476c",
   "dbt_job_execution_timeout_seconds": 300,
   "dbt_job_retries": 1,
   "dbt_keyfile_profile": "",

--- a/dags/marts_tables_dag.py
+++ b/dags/marts_tables_dag.py
@@ -23,6 +23,13 @@ stg_history_ledgers = build_dbt_task(dag, "stg_history_ledgers")
 stg_history_assets = build_dbt_task(dag, "stg_history_assets")
 stg_history_trades = build_dbt_task(dag, "stg_history_trades")
 
+# tasks for intermediate trades tables
+int_trade_agg_day = build_dbt_task(dag, "int_trade_agg_day")
+int_trade_agg_month = build_dbt_task(dag, "int_trade_agg_month")
+int_trade_agg_week = build_dbt_task(dag, "int_trade_agg_week")
+int_trade_agg_year = build_dbt_task(dag, "int_trade_agg_year")
+
+
 # tasks for marts tables
 agg_network_stats = build_dbt_task(dag, "agg_network_stats")
 fee_stats_agg = build_dbt_task(dag, "fee_stats_agg")
@@ -38,4 +45,7 @@ stg_history_ledgers >> fee_stats_agg
 
 stg_history_assets >> history_assets
 
-stg_history_trades >> trade_agg
+stg_history_trades >> int_trade_agg_day >> trade_agg
+stg_history_trades >> int_trade_agg_month >> trade_agg
+stg_history_trades >> int_trade_agg_week >> trade_agg
+stg_history_trades >> int_trade_agg_year >> trade_agg

--- a/dags/marts_tables_dag.py
+++ b/dags/marts_tables_dag.py
@@ -24,17 +24,17 @@ stg_history_assets = build_dbt_task(dag, "stg_history_assets")
 stg_history_trades = build_dbt_task(dag, "stg_history_trades")
 
 # tasks for intermediate trades tables
-int_trade_agg_day = build_dbt_task(dag, "int_trade_agg_day")
-int_trade_agg_month = build_dbt_task(dag, "int_trade_agg_month")
-int_trade_agg_week = build_dbt_task(dag, "int_trade_agg_week")
-int_trade_agg_year = build_dbt_task(dag, "int_trade_agg_year")
+# int_trade_agg_day = build_dbt_task(dag, "int_trade_agg_day")
+# int_trade_agg_month = build_dbt_task(dag, "int_trade_agg_month")
+# int_trade_agg_week = build_dbt_task(dag, "int_trade_agg_week")
+# int_trade_agg_year = build_dbt_task(dag, "int_trade_agg_year")
 
 
 # tasks for marts tables
 agg_network_stats = build_dbt_task(dag, "agg_network_stats")
 fee_stats_agg = build_dbt_task(dag, "fee_stats_agg")
 history_assets = build_dbt_task(dag, "history_assets")
-trade_agg = build_dbt_task(dag, "trade_agg")
+# trade_agg = build_dbt_task(dag, "trade_agg")
 
 # DAG task graph
 # graph for marts tables
@@ -45,7 +45,7 @@ stg_history_ledgers >> fee_stats_agg
 
 stg_history_assets >> history_assets
 
-stg_history_trades >> int_trade_agg_day >> trade_agg
-stg_history_trades >> int_trade_agg_month >> trade_agg
-stg_history_trades >> int_trade_agg_week >> trade_agg
-stg_history_trades >> int_trade_agg_year >> trade_agg
+# stg_history_trades >> int_trade_agg_day >> trade_agg
+# stg_history_trades >> int_trade_agg_month >> trade_agg
+# stg_history_trades >> int_trade_agg_week >> trade_agg
+# stg_history_trades >> int_trade_agg_year >> trade_agg

--- a/dags/mgi_transforms_dag.py
+++ b/dags/mgi_transforms_dag.py
@@ -12,7 +12,7 @@ dag = DAG(
     default_args=get_default_dag_args(),
     start_date=datetime.datetime(2023, 5, 22, 0, 0),
     description="This DAG runs dbt to create the mgi cash in and cash out fact and dimension tables.",
-    schedule_interval="0 11 * * *",  # Daily 10 AM UTC
+    schedule_interval="30 15 * * *",  # Daily 15:30 UTC after MGI pipeline
     params={},
     max_active_runs=1,
 )


### PR DESCRIPTION
Updating the pipeline for `trade_agg` table to add the intermediate tasks to build the table. The table now creates 4 intermediate tables, which calculate the respective stats: 
* day
* week
* month
* year

PR also addresses a timing issue in the mgi pipeline, where the transformations dag runs before the current data is hydrated.