### PR TITLE
Update ledger closed

### DIFF
--- a/airflow_variables.json
+++ b/airflow_variables.json
@@ -173,19 +173,19 @@
     },
     "accounts": {
       "type": "MONTH",
-      "field": "closed_at"
+      "field": "batch_run_date"
     },
     "account_signers": {
       "type": "MONTH",
-      "field": "closed_at"
+      "field": "batch_run_date"
     },
     "claimable_balances": {
       "type": "MONTH",
-      "field": "closed_at"
+      "field": "batch_run_date"
     },
     "history_effects": {
       "type": "MONTH",
-      "field": "closed_at"
+      "field": "batch_run_date"
     },
     "history_ledgers": {
       "type": "MONTH",
@@ -193,7 +193,7 @@
     },
     "history_operations": {
       "type": "MONTH",
-      "field": "closed_at"
+      "field": "batch_run_date"
     },
     "history_trades": {
       "type": "MONTH",
@@ -201,19 +201,19 @@
     },
     "history_transactions": {
       "type": "MONTH",
-      "field": "closed_at"
+      "field": "batch_run_date"
     },
     "offers": {
       "type": "MONTH",
-      "field": "closed_at"
+      "field": "batch_run_date"
     },
     "liquidity_pools": {
       "type": "MONTH",
-      "field": "closed_at"
+      "field": "batch_run_date"
     },
     "trust_lines": {
       "type": "MONTH",
-      "field": "closed_at"
+      "field": "batch_run_date"
     }
   },
   "public_dataset": "crypto_stellar_2",

--- a/airflow_variables.json
+++ b/airflow_variables.json
@@ -173,47 +173,47 @@
     },
     "accounts": {
       "type": "MONTH",
-      "field": "batch_run_date"
+      "field": "closed_at"
     },
     "account_signers": {
       "type": "MONTH",
-      "field": "batch_run_date"
+      "field": "closed_at"
     },
     "claimable_balances": {
       "type": "MONTH",
-      "field": "batch_run_date"
+      "field": "closed_at"
     },
     "history_effects": {
       "type": "MONTH",
-      "field": "batch_run_date"
+      "field": "closed_at"
     },
     "history_ledgers": {
       "type": "MONTH",
-      "field": "batch_run_date"
+      "field": "closed_at"
     },
     "history_operations": {
       "type": "MONTH",
-      "field": "batch_run_date"
+      "field": "closed_at"
     },
     "history_trades": {
       "type": "MONTH",
-      "field": "batch_run_date"
+      "field": "ledger_closed_at"
     },
     "history_transactions": {
       "type": "MONTH",
-      "field": "batch_run_date"
+      "field": "closed_at"
     },
     "offers": {
       "type": "MONTH",
-      "field": "batch_run_date"
+      "field": "closed_at"
     },
     "liquidity_pools": {
       "type": "MONTH",
-      "field": "batch_run_date"
+      "field": "closed_at"
     },
     "trust_lines": {
       "type": "MONTH",
-      "field": "batch_run_date"
+      "field": "closed_at"
     }
   },
   "public_dataset": "crypto_stellar_2",

--- a/airflow_variables.json
+++ b/airflow_variables.json
@@ -127,7 +127,7 @@
   "dbt_token_uri": "https://oauth2.googleapis.com/token",
   "gcs_exported_data_bucket_name": "us-central1-hubble-2-d948d67b-bucket",
   "gcs_exported_object_prefix": "dag-exported",
-  "image_name": "stellar/stellar-etl:5de391d",
+  "image_name": "stellar/stellar-etl:97ff132",
   "image_output_path": "/etl/exported_data/",
   "image_pull_policy": "IfNotPresent",
   "kube_config_location": "",

--- a/airflow_variables.json
+++ b/airflow_variables.json
@@ -189,7 +189,7 @@
     },
     "history_ledgers": {
       "type": "MONTH",
-      "field": "closed_at"
+      "field": "batch_run_date"
     },
     "history_operations": {
       "type": "MONTH",
@@ -197,7 +197,7 @@
     },
     "history_trades": {
       "type": "MONTH",
-      "field": "ledger_closed_at"
+      "field": "batch_run_date"
     },
     "history_transactions": {
       "type": "MONTH",

--- a/airflow_variables_dev.json
+++ b/airflow_variables_dev.json
@@ -149,47 +149,47 @@
     },
     "accounts": {
       "type": "MONTH",
-      "field": "batch_run_date"
+      "field": "closed_at"
     },
     "account_signers": {
       "type": "MONTH",
-      "field": "batch_run_date"
+      "field": "closed_at"
     },
     "claimable_balances": {
       "type": "MONTH",
-      "field": "batch_run_date"
+      "field": "closed_at"
     },
     "history_effects": {
       "type": "MONTH",
-      "field": "batch_run_date"
+      "field": "closed_at"
     },
     "history_ledgers": {
       "type": "MONTH",
-      "field": "batch_run_date"
+      "field": "closed_at"
     },
     "history_operations": {
       "type": "MONTH",
-      "field": "batch_run_date"
+      "field": "closed_at"
     },
     "history_trades": {
       "type": "MONTH",
-      "field": "batch_run_date"
+      "field": "ledger_closed_at"
     },
     "history_transactions": {
       "type": "MONTH",
-      "field": "batch_run_date"
+      "field": "closed_at"
     },
     "offers": {
       "type": "MONTH",
-      "field": "batch_run_date"
+      "field": "closed_at"
     },
     "liquidity_pools": {
       "type": "MONTH",
-      "field": "batch_run_date"
+      "field": "closed_at"
     },
     "trust_lines": {
       "type": "MONTH",
-      "field": "batch_run_date"
+      "field": "closed_at"
     },
     "mgi": {
       "field": "tran_evnt_date",

--- a/airflow_variables_dev.json
+++ b/airflow_variables_dev.json
@@ -137,11 +137,11 @@
   "partition_fields": {
     "enriched_history_operations": {
       "type": "MONTH",
-      "field": "closed_at"
+      "field": "batch_run_date"
     },
     "enriched_meaningful_history_operations": {
       "type": "MONTH",
-      "field": "closed_at"
+      "field": "batch_run_date"
     },
     "history_assets": {
       "type": "MONTH",
@@ -165,7 +165,7 @@
     },
     "history_ledgers": {
       "type": "MONTH",
-      "field": "closed_at"
+      "field": "batch_run_date"
     },
     "history_operations": {
       "type": "MONTH",
@@ -173,7 +173,7 @@
     },
     "history_trades": {
       "type": "MONTH",
-      "field": "ledger_closed_at"
+      "field": "batch_run_date"
     },
     "history_transactions": {
       "type": "MONTH",

--- a/airflow_variables_dev.json
+++ b/airflow_variables_dev.json
@@ -149,19 +149,19 @@
     },
     "accounts": {
       "type": "MONTH",
-      "field": "closed_at"
+      "field": "batch_run_date"
     },
     "account_signers": {
       "type": "MONTH",
-      "field": "closed_at"
+      "field": "batch_run_date"
     },
     "claimable_balances": {
       "type": "MONTH",
-      "field": "closed_at"
+      "field": "batch_run_date"
     },
     "history_effects": {
       "type": "MONTH",
-      "field": "closed_at"
+      "field": "batch_run_date"
     },
     "history_ledgers": {
       "type": "MONTH",
@@ -169,7 +169,7 @@
     },
     "history_operations": {
       "type": "MONTH",
-      "field": "closed_at"
+      "field": "batch_run_date"
     },
     "history_trades": {
       "type": "MONTH",
@@ -177,19 +177,19 @@
     },
     "history_transactions": {
       "type": "MONTH",
-      "field": "closed_at"
+      "field": "batch_run_date"
     },
     "offers": {
       "type": "MONTH",
-      "field": "closed_at"
+      "field": "batch_run_date"
     },
     "liquidity_pools": {
       "type": "MONTH",
-      "field": "closed_at"
+      "field": "batch_run_date"
     },
     "trust_lines": {
       "type": "MONTH",
-      "field": "closed_at"
+      "field": "batch_run_date"
     },
     "mgi": {
       "field": "tran_evnt_date",

--- a/airflow_variables_dev.json
+++ b/airflow_variables_dev.json
@@ -137,11 +137,11 @@
   "partition_fields": {
     "enriched_history_operations": {
       "type": "MONTH",
-      "field": "batch_run_date"
+      "field": "closed_at"
     },
     "enriched_meaningful_history_operations": {
       "type": "MONTH",
-      "field": "batch_run_date"
+      "field": "closed_at"
     },
     "history_assets": {
       "type": "MONTH",

--- a/airflow_variables_dev.json
+++ b/airflow_variables_dev.json
@@ -104,7 +104,7 @@
   "dbt_token_uri": "https://oauth2.googleapis.com/token",
   "gcs_exported_data_bucket_name": "us-central1-hubble-1pt5-dev-7db0e004-bucket",
   "gcs_exported_object_prefix": "dag-exported",
-  "image_name": "stellar/stellar-etl:5de391d",
+  "image_name": "stellar/stellar-etl:97ff132",
   "image_output_path": "/etl/exported_data/",
   "image_pull_policy": "IfNotPresent",
   "kube_config_location": "",

--- a/schemas/account_signers_schema.json
+++ b/schemas/account_signers_schema.json
@@ -48,5 +48,10 @@
     "mode": "NULLABLE",
     "name": "batch_insert_ts",
     "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "closed_at",
+    "type": "TIMESTAMP"
   }
 ]

--- a/schemas/accounts_schema.json
+++ b/schemas/accounts_schema.json
@@ -118,5 +118,10 @@
     "mode": "NULLABLE",
     "name": "sequence_time",
     "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "closed_at",
+    "type": "TIMESTAMP"
   }
 ]

--- a/schemas/claimable_balances_schema.json
+++ b/schemas/claimable_balances_schema.json
@@ -458,5 +458,10 @@
     "mode": "NULLABLE",
     "name": "batch_insert_ts",
     "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "closed_at",
+    "type": "TIMESTAMP"
   }
 ]

--- a/schemas/history_assets_schema.json
+++ b/schemas/history_assets_schema.json
@@ -38,5 +38,10 @@
     "mode": "NULLABLE",
     "name": "batch_insert_ts",
     "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "closed_at",
+    "type": "TIMESTAMP"
   }
 ]

--- a/schemas/history_assets_schema.json
+++ b/schemas/history_assets_schema.json
@@ -38,10 +38,5 @@
     "mode": "NULLABLE",
     "name": "batch_insert_ts",
     "type": "TIMESTAMP"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "closed_at",
-    "type": "TIMESTAMP"
   }
 ]

--- a/schemas/history_effects_schema.json
+++ b/schemas/history_effects_schema.json
@@ -780,5 +780,10 @@
     "mode": "NULLABLE",
     "name": "batch_insert_ts",
     "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "closed_at",
+    "type": "TIMESTAMP"
   }
 ]

--- a/schemas/history_operations_schema.json
+++ b/schemas/history_operations_schema.json
@@ -1018,5 +1018,10 @@
     "mode": "NULLABLE",
     "name": "batch_insert_ts",
     "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "closed_at",
+    "type": "TIMESTAMP"
   }
 ]

--- a/schemas/history_transactions_schema.json
+++ b/schemas/history_transactions_schema.json
@@ -148,5 +148,10 @@
     "mode": "REPEATED",
     "name": "extra_signers",
     "type": "string"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "closed_at",
+    "type": "TIMESTAMP"
   }
 ]

--- a/schemas/liquidity_pools_schema.json
+++ b/schemas/liquidity_pools_schema.json
@@ -103,5 +103,10 @@
     "mode": "NULLABLE",
     "name": "batch_insert_ts",
     "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "closed_at",
+    "type": "TIMESTAMP"
   }
 ]

--- a/schemas/offers_schema.json
+++ b/schemas/offers_schema.json
@@ -108,5 +108,10 @@
     "mode": "NULLABLE",
     "name": "batch_insert_ts",
     "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "closed_at",
+    "type": "TIMESTAMP"
   }
 ]

--- a/schemas/trust_lines_schema.json
+++ b/schemas/trust_lines_schema.json
@@ -93,5 +93,10 @@
     "mode": "NULLABLE",
     "name": "sponsor",
     "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "closed_at",
+    "type": "TIMESTAMP"
   }
 ]


### PR DESCRIPTION
This PR update the schema with new field closed_at in tables: `account`, `account_signers`, `claimabla_balances`, `history_assets`, `history_effects`, `history_operations`, `history_transactions`, `liquidity_pools`, `offers`, and `trust_lines`. Also, update the partition from tables using `closed_at` to `batch_run_date`.