### PR TITLE
Adjust MGI file schema

### DIFF
--- a/schemas/raw_mgi_stellar_transactions_schema.json
+++ b/schemas/raw_mgi_stellar_transactions_schema.json
@@ -101,6 +101,11 @@
   },
   {
     "mode": "NULLABLE",
+    "name": "partnr_sen_phys_line2_addr",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
     "name": "partnr_sen_phys_city_name",
     "type": "STRING"
   },
@@ -122,6 +127,11 @@
   {
     "mode": "NULLABLE",
     "name": "partnr_rec_phys_line1_addr",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "partnr_rec_phys_line2_addr",
     "type": "STRING"
   },
   {


### PR DESCRIPTION
MGI sent more columns beyond the originally propose changes. 

The actual schema also contains: 

* `partnr_rec_phys_line2_addr`
* `partner_send_phys_line2_addr`

Changes add the fields so that the new schema can be read and loaded into the table.