### PR TITLE
Update raw_mgi_stellar_transactions_schema.json

### DIFF
--- a/schemas/raw_mgi_stellar_transactions_schema.json
+++ b/schemas/raw_mgi_stellar_transactions_schema.json
@@ -2,7 +2,7 @@
   {
     "mode": "NULLABLE",
     "name": "src_tran_ref_id",
-    "type": "STRING"
+    "type": "INTEGER"
   },
   {
     "mode": "NULLABLE",


### PR DESCRIPTION
One of the reference ids was misdefined as a `STRING` instead of an `INTEGER`. Now that the schema files are pushed to the correct location, the schema must match the original specifications.