### PR TITLE
Update timing on dags

### DIFF
--- a/dags/history_archive_with_captive_core_dag.py
+++ b/dags/history_archive_with_captive_core_dag.py
@@ -144,9 +144,6 @@ delete_enrich_ma_op_task = build_delete_data_task(
 delete_old_effects_task = build_delete_data_task(
     dag, internal_project, internal_dataset, table_names["effects"]
 )
-delete_old_effects_pub_task = build_delete_data_task(
-    dag, public_project, public_dataset, table_names["effects"]
-)
 delete_old_effects_pub_new_task = build_delete_data_task(
     dag, public_project, public_dataset_new, table_names["effects"]
 )
@@ -225,16 +222,6 @@ send_trades_to_pub_task = build_gcs_to_bq_task(
     public_project,
     public_dataset,
     table_names["trades"],
-    "",
-    partition=True,
-    cluster=True,
-)
-send_effects_to_pub_task = build_gcs_to_bq_task(
-    dag,
-    effects_export_task.task_id,
-    public_project,
-    public_dataset,
-    table_names["effects"],
     "",
     partition=True,
     cluster=True,
@@ -382,7 +369,6 @@ trade_export_task >> delete_old_trade_pub_new_task >> send_trades_to_pub_new_tas
     >> delete_old_effects_task
     >> send_effects_to_bq_task
 )
-effects_export_task >> delete_old_effects_pub_task >> send_effects_to_pub_task
 effects_export_task >> delete_old_effects_pub_new_task >> send_effects_to_pub_new_task
 (
     time_task

--- a/dags/partnership_assets_dag.py
+++ b/dags/partnership_assets_dag.py
@@ -12,7 +12,7 @@ dag = DAG(
     default_args=get_default_dag_args(),
     start_date=datetime.datetime(2022, 4, 1, 0, 0),
     description="This DAG runs dbt to create the partnership asset intermediate tables and aggregate tables.",
-    schedule_interval="0 10 * * *",  # Daily 10 AM UTC
+    schedule_interval="30 16 * * *",  # Daily 16:30 UTC, after cloud function
     params={},
     max_active_runs=1,
 )

--- a/dags/state_table_dag.py
+++ b/dags/state_table_dag.py
@@ -78,9 +78,6 @@ Bigquery. If it does, the records are deleted prior to reinserting the batch.
 delete_acc_task = build_delete_data_task(
     dag, internal_project, internal_dataset, table_names["accounts"]
 )
-delete_acc_pub_task = build_delete_data_task(
-    dag, public_project, public_dataset, table_names["accounts"]
-)
 delete_acc_pub_new_task = build_delete_data_task(
     dag, public_project, public_dataset_new, table_names["accounts"]
 )
@@ -96,17 +93,11 @@ delete_bal_pub_new_task = build_delete_data_task(
 delete_off_task = build_delete_data_task(
     dag, internal_project, internal_dataset, table_names["offers"]
 )
-delete_off_pub_task = build_delete_data_task(
-    dag, public_project, public_dataset, table_names["offers"]
-)
 delete_off_pub_new_task = build_delete_data_task(
     dag, public_project, public_dataset_new, table_names["offers"]
 )
 delete_pool_task = build_delete_data_task(
     dag, internal_project, internal_dataset, table_names["liquidity_pools"]
-)
-delete_pool_pub_task = build_delete_data_task(
-    dag, public_project, public_dataset, table_names["liquidity_pools"]
 )
 delete_pool_pub_new_task = build_delete_data_task(
     dag, public_project, public_dataset_new, table_names["liquidity_pools"]
@@ -114,17 +105,11 @@ delete_pool_pub_new_task = build_delete_data_task(
 delete_sign_task = build_delete_data_task(
     dag, internal_project, internal_dataset, table_names["signers"]
 )
-delete_sign_pub_task = build_delete_data_task(
-    dag, public_project, public_dataset, table_names["signers"]
-)
 delete_sign_pub_new_task = build_delete_data_task(
     dag, public_project, public_dataset_new, table_names["signers"]
 )
 delete_trust_task = build_delete_data_task(
     dag, internal_project, internal_dataset, table_names["trustlines"]
-)
-delete_trust_pub_task = build_delete_data_task(
-    dag, public_project, public_dataset, table_names["trustlines"]
 )
 delete_trust_pub_new_task = build_delete_data_task(
     dag, public_project, public_dataset_new, table_names["trustlines"]
@@ -201,16 +186,6 @@ The apply tasks receive the location of the file in Google Cloud storage through
 Then, the task merges the entries in the file with the entries in the corresponding table in BigQuery.
 Entries are updated, deleted, or inserted as needed.
 """
-send_acc_to_pub_task = build_gcs_to_bq_task(
-    dag,
-    changes_task.task_id,
-    public_project,
-    public_dataset,
-    table_names["accounts"],
-    "/*-accounts.txt",
-    partition=True,
-    cluster=True,
-)
 send_bal_to_pub_task = build_gcs_to_bq_task(
     dag,
     changes_task.task_id,
@@ -218,46 +193,6 @@ send_bal_to_pub_task = build_gcs_to_bq_task(
     public_dataset,
     table_names["claimable_balances"],
     "/*-claimable_balances.txt",
-    partition=True,
-    cluster=True,
-)
-send_off_to_pub_task = build_gcs_to_bq_task(
-    dag,
-    changes_task.task_id,
-    public_project,
-    public_dataset,
-    table_names["offers"],
-    "/*-offers.txt",
-    partition=True,
-    cluster=True,
-)
-send_pool_to_pub_task = build_gcs_to_bq_task(
-    dag,
-    changes_task.task_id,
-    public_project,
-    public_dataset,
-    table_names["liquidity_pools"],
-    "/*-liquidity_pools.txt",
-    partition=True,
-    cluster=True,
-)
-send_sign_to_pub_task = build_gcs_to_bq_task(
-    dag,
-    changes_task.task_id,
-    public_project,
-    public_dataset,
-    table_names["signers"],
-    "/*-signers.txt",
-    partition=True,
-    cluster=True,
-)
-send_trust_to_pub_task = build_gcs_to_bq_task(
-    dag,
-    changes_task.task_id,
-    public_project,
-    public_dataset,
-    table_names["trustlines"],
-    "/*-trustlines.txt",
     partition=True,
     cluster=True,
 )
@@ -327,13 +262,11 @@ send_trust_to_pub_new_task = build_gcs_to_bq_task(
 )
 
 date_task >> changes_task >> write_acc_stats >> delete_acc_task >> send_acc_to_bq_task
-write_acc_stats >> delete_acc_pub_task >> send_acc_to_pub_task
 write_acc_stats >> delete_acc_pub_new_task >> send_acc_to_pub_new_task
 date_task >> changes_task >> write_bal_stats >> delete_bal_task >> send_bal_to_bq_task
 write_bal_stats >> delete_bal_pub_task >> send_bal_to_pub_task
 write_bal_stats >> delete_bal_pub_new_task >> send_bal_to_pub_new_task
 date_task >> changes_task >> write_off_stats >> delete_off_task >> send_off_to_bq_task
-write_off_stats >> delete_off_pub_task >> send_off_to_pub_task
 write_off_stats >> delete_off_pub_new_task >> send_off_to_pub_new_task
 (
     date_task
@@ -342,7 +275,6 @@ write_off_stats >> delete_off_pub_new_task >> send_off_to_pub_new_task
     >> delete_pool_task
     >> send_pool_to_bq_task
 )
-write_pool_stats >> delete_pool_pub_task >> send_pool_to_pub_task
 write_pool_stats >> delete_pool_pub_new_task >> send_pool_to_pub_new_task
 (
     date_task
@@ -351,7 +283,6 @@ write_pool_stats >> delete_pool_pub_new_task >> send_pool_to_pub_new_task
     >> delete_sign_task
     >> send_sign_to_bq_task
 )
-write_sign_stats >> delete_sign_pub_task >> send_sign_to_pub_task
 write_sign_stats >> delete_sign_pub_new_task >> send_sign_to_pub_new_task
 (
     date_task
@@ -360,5 +291,4 @@ write_sign_stats >> delete_sign_pub_new_task >> send_sign_to_pub_new_task
     >> delete_trust_task
     >> send_trust_to_bq_task
 )
-write_trust_stats >> delete_trust_pub_task >> send_trust_to_pub_task
 write_trust_stats >> delete_trust_pub_new_task >> send_trust_to_pub_new_task


### PR DESCRIPTION
Two Changes: 

- The partnership_assets pipeline is executing before getting the latest day's pricing. This is causing several fields, like daily volume, to be 0 for the current date. Adjusting the execution schedule to run _after_ the upstream cloud function
- The MGI transformation pipeline needs a dependency on the upstream DAG. I created a cross dependency task that will wait on the upstream DAG to complete before starting execution. This is due to some delays we've seen in delivery times from MGI.