### PR TITLE
Add `asset_id` to `history_assets` table

### DIFF
--- a/dags/queries/history_assets.sql
+++ b/dags/queries/history_assets.sql
@@ -52,6 +52,7 @@ select
     , new_load_dedup.batch_id
     , new_load_dedup.batch_run_date
     , new_load_dedup.batch_insert_ts
+    , new_load_dedup.asset_id
 from exclude_duplicates
 left join
     new_load_dedup on


### PR DESCRIPTION
This PR adds the missing field `asset_id` in the query that deduplicates the `history_assets` table.