### PR TITLE
Add `elementary` profile in `profiles.yml`

### DIFF
--- a/dags/stellar_etl_airflow/build_dbt_task.py
+++ b/dags/stellar_etl_airflow/build_dbt_task.py
@@ -56,6 +56,30 @@ stellar_dbt:
         token_uri: "{dbt_token_uri}"
         auth_provider_x509_cert_url: "{dbt_auth_provider_x509_cert_url}"
         client_x509_cert_url: "{dbt_client_x509_cert_url}"
+elementary:
+  target: {dbt_target}
+  outputs:
+    default:
+      dataset: elementary
+      maximum_bytes_billed: {dbt_maximum_bytes_billed}
+      job_execution_timeout_seconds: {dbt_job_execution_timeout_seconds}
+      job_retries: {dbt_job_retries}
+      location: us
+      method: service-account-json
+      project: "{dbt_project}"
+      threads: {dbt_threads}
+      type: bigquery
+      keyfile_json:
+        type: "service_account"
+        project_id: "{dbt_project}"
+        private_key_id: "{dbt_private_key_id}"
+        private_key: "{dbt_private_key}"
+        client_email: "{dbt_client_email}"
+        client_id: "{dbt_client_id}"
+        auth_uri: "{dbt_auth_uri}"
+        token_uri: "{dbt_token_uri}"
+        auth_provider_x509_cert_url: "{dbt_auth_provider_x509_cert_url}"
+        client_x509_cert_url: "{dbt_client_x509_cert_url}"
 """
 
     create_dbt_profile_cmd = f"echo '{profiles_yml}' > profiles.yml;"
@@ -96,6 +120,7 @@ def build_dbt_task(
                 create_dbt_profile_cmd,
                 execution_date,
                 "dbt ",
+                "--no-use-colors",
                 command_type,
                 " --select",
                 model_name,


### PR DESCRIPTION
This PR adds a profile to the `profiles.yml` so the `elementary` hook can access to BigQuery.

This follows the docs: https://docs.elementary-data.com/deployment-and-configuration/elementary-in-production