### PR TITLE
Revert getting network variables from template

### DIFF
--- a/dags/bucket_list_dag.py
+++ b/dags/bucket_list_dag.py
@@ -49,8 +49,8 @@ internal_dataset = "{{ var.value.bq_dataset }}"
 public_project = "{{ var.value.public_project }}"
 public_dataset = "{{ var.value.public_dataset }}"
 public_dataset_new = "{{ var.value.public_dataset_new }}"
-use_testnet = "{{ var.value.use_testnet | literal_eval }}"
-use_futurenet = "{{ var.value.use_futurenet | literal_eval }}"
+use_testnet = literal_eval(Variable.get("use_testnet"))
+use_futurenet = literal_eval(Variable.get("use_futurenet"))
 """
 The time task reads in the execution time of the current run, as well as the next
 execution time. It converts these two times into ledger ranges.

--- a/dags/history_archive_with_captive_core_dag.py
+++ b/dags/history_archive_with_captive_core_dag.py
@@ -49,8 +49,8 @@ internal_dataset = "{{ var.value.bq_dataset }}"
 public_project = "{{ var.value.public_project }}"
 public_dataset = "{{ var.value.public_dataset }}"
 public_dataset_new = "{{ var.value.public_dataset_new }}"
-use_testnet = "{{ var.value.use_testnet | literal_eval }}"
-use_futurenet = "{{ var.value.use_futurenet | literal_eval }}"
+use_testnet = literal_eval(Variable.get("use_testnet"))
+use_futurenet = literal_eval(Variable.get("use_futurenet"))
 
 """
 The time task reads in the execution time of the current run, as well as the next

--- a/dags/history_archive_without_captive_core_dag.py
+++ b/dags/history_archive_without_captive_core_dag.py
@@ -48,8 +48,8 @@ internal_dataset = "{{ var.value.bq_dataset }}"
 public_project = "{{ var.value.public_project }}"
 public_dataset = "{{ var.value.public_dataset }}"
 public_dataset_new = "{{ var.value.public_dataset_new }}"
-use_testnet = "{{ var.value.use_testnet | literal_eval }}"
-use_futurenet = "{{ var.value.use_futurenet | literal_eval }}"
+use_testnet = literal_eval(Variable.get("use_testnet"))
+use_futurenet = literal_eval(Variable.get("use_futurenet"))
 
 """
 The time task reads in the execution time of the current run, as well as the next

--- a/dags/state_table_dag.py
+++ b/dags/state_table_dag.py
@@ -47,8 +47,8 @@ internal_dataset = "{{ var.value.bq_dataset }}"
 public_project = "{{ var.value.public_project }}"
 public_dataset = "{{ var.value.public_dataset }}"
 public_dataset_new = "{{ var.value.public_dataset_new }}"
-use_testnet = "{{ var.value.use_testnet | literal_eval }}"
-use_futurenet = "{{ var.value.use_futurenet | literal_eval }}"
+use_testnet = literal_eval(Variable.get("use_testnet"))
+use_futurenet = literal_eval(Variable.get("use_futurenet"))
 
 date_task = build_time_task(dag, use_testnet=use_testnet, use_futurenet=use_futurenet)
 changes_task = build_export_task(


### PR DESCRIPTION
This PR undo getting network variables from template since it didn't parse the values correctly in production.