### PR TITLE
change autodetect to false in partner_pipeline

### DIFF
--- a/airflow_variables_dev.json
+++ b/airflow_variables_dev.json
@@ -219,7 +219,7 @@
       "table": "raw_mgi_stellar_transactions"
     }
   },
-  "partners_bucket": "ext-partner-sftp",
+  "partners_bucket": "partners_data",
   "public_dataset": "test_crypto_stellar_old",
   "public_dataset_new": "test_crypto_stellar",
   "public_project": "test-hubble-319619",

--- a/dags/ddls/create_default_value_field.sh
+++ b/dags/ddls/create_default_value_field.sh
@@ -22,4 +22,8 @@ echo "Creating default value field $FIELD in $TABLE in $DATASET_ID"
 
 bq query --use_legacy_sql=false \
 "ALTER TABLE \`$PROJECT_ID.$DATASET_ID.$TABLE\` \
+ADD COLUMN $FIELD TIMESTAMP;"
+
+bq query --use_legacy_sql=false \
+"ALTER TABLE \`$PROJECT_ID.$DATASET_ID.$TABLE\` \
 ALTER COLUMN $FIELD SET DEFAULT CURRENT_TIMESTAMP();"

--- a/dags/partner_pipeline_dag.py
+++ b/dags/partner_pipeline_dag.py
@@ -60,7 +60,6 @@ with DAG(
                 PROJECT, DATASET, PARTNERS[partner]["table"]
             ),
             skip_leading_rows=1,
-            autodetect=False,
             schema_fields=read_local_schema(PARTNERS[partner]["table"]),
             write_disposition="WRITE_TRUNCATE",
             dag=dag,

--- a/dags/partner_pipeline_dag.py
+++ b/dags/partner_pipeline_dag.py
@@ -60,6 +60,7 @@ with DAG(
                 PROJECT, DATASET, PARTNERS[partner]["table"]
             ),
             skip_leading_rows=1,
+            autodetect=False,
             schema_fields=read_local_schema(PARTNERS[partner]["table"]),
             write_disposition="WRITE_TRUNCATE",
             dag=dag,

--- a/schemas/raw_mgi_stellar_transactions_schema.json
+++ b/schemas/raw_mgi_stellar_transactions_schema.json
@@ -198,10 +198,5 @@
     "mode": "NULLABLE",
     "name": "cancellation_reas",
     "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "batch_insert_ts",
-    "type": "TIMESTAMP"
   }
 ]


### PR DESCRIPTION
This PR changes the autodetect in `partner_pipeline_dag` to false to keep the operator running the function `read_local_schema`. The schema with the new `batch_insert_ts` field is not being used.