### PR TITLE
Add mgi_monthly_usd_balance table in mgi_transform_dag

### DIFF
--- a/airflow_variables_dev.json
+++ b/airflow_variables_dev.json
@@ -299,5 +299,5 @@
   },
   "currency_bucket": "currencies_ohlc",
   "max_db_entry_age_in_days": 90,
-  "public_dbt_image_name": "stellar/stellar-dbt:671afb6"
+  "public_dbt_image_name": "stellar/stellar-dbt:18a84a3"
 }

--- a/airflow_variables_dev.json
+++ b/airflow_variables_dev.json
@@ -299,5 +299,5 @@
   },
   "currency_bucket": "currencies_ohlc",
   "max_db_entry_age_in_days": 90,
-  "public_dbt_image_name": "stellar/stellar-dbt:18a84a3"
+  "public_dbt_image_name": "stellar/stellar-dbt:dbf348d"
 }

--- a/airflow_variables_prod.json
+++ b/airflow_variables_prod.json
@@ -319,5 +319,5 @@
   },
   "currency_bucket": "ext-asset-pricing",
   "max_db_entry_age_in_days": 180,
-  "public_dbt_image_name": "stellar/stellar-dbt:671afb6"
+  "public_dbt_image_name": "stellar/stellar-dbt:dbf348d"
 }

--- a/dags/mgi_transforms_dag.py
+++ b/dags/mgi_transforms_dag.py
@@ -32,9 +32,6 @@ snapshot_raw_mgi_stellar_transactions = build_dbt_task(
 stg_mgi_transactions_snap = build_dbt_task(dag, "stg_mgi_transactions_snapshot")
 stg_mgi_transactions_null_id = build_dbt_task(dag, "stg_mgi_transactions_null_id")
 stg_country_code = build_dbt_task(dag, "stg_country_code")
-stg_history_ledgers_dev = build_dbt_task(dag, "stg_history_ledgers_dev")
-stg_accounts_dev = build_dbt_task(dag, "stg_accounts_dev")
-stg_trust_lines_dev = build_dbt_task(dag, "stg_trust_lines_dev")
 stg_partnership_assets_prices = build_dbt_task(dag, "stg_partnership_assets_prices")
 # tasks for fct_mgi_cashflow
 int_mgi_transactions_transformed = build_dbt_task(
@@ -63,10 +60,7 @@ wait_on__mgi_dag >> snapshot_raw_mgi_stellar_transactions
     >> stg_mgi_transactions_snap
     >> stg_mgi_transactions_null_id
     >> stg_country_code
-    >> stg_history_ledgers_dev
-    >> stg_accounts_dev
     >> stg_partnership_assets_prices
-    >> stg_trust_lines_dev
     >> int_mgi_transactions_transformed
     >> int_mgi_transactions_null_id
     >> dim_dates

--- a/dags/mgi_transforms_dag.py
+++ b/dags/mgi_transforms_dag.py
@@ -32,6 +32,10 @@ snapshot_raw_mgi_stellar_transactions = build_dbt_task(
 stg_mgi_transactions_snap = build_dbt_task(dag, "stg_mgi_transactions_snapshot")
 stg_mgi_transactions_null_id = build_dbt_task(dag, "stg_mgi_transactions_null_id")
 stg_country_code = build_dbt_task(dag, "stg_country_code")
+stg_history_ledgers_dev = build_dbt_task(dag, "stg_history_ledgers_dev")
+stg_accounts_dev = build_dbt_task(dag, "stg_accounts_dev")
+stg_trust_lines_dev = build_dbt_task(dag, "stg_trust_lines_dev")
+stg_partnership_assets_prices = build_dbt_task(dag, "stg_partnership_assets_prices")
 # tasks for fct_mgi_cashflow
 int_mgi_transactions_transformed = build_dbt_task(
     dag, "int_mgi_transactions_transformed"
@@ -45,6 +49,9 @@ dim_mgi_wallets = build_dbt_task(dag, "dim_mgi_wallets")
 # task for dim dates
 dim_dates = build_dbt_task(dag, "dim_dates")
 
+# tasks for mgi monthly usd balance
+mgi_monthly_usd_balance = build_dbt_task(dag, "mgi_monthly_usd_balance")
+
 # tasks for network stats
 enriched_history_mgi_operations = build_dbt_task(dag, "enriched_history_mgi_operations")
 mgi_network_stats_agg = build_dbt_task(dag, "mgi_network_stats_agg")
@@ -56,6 +63,10 @@ wait_on__mgi_dag >> snapshot_raw_mgi_stellar_transactions
     >> stg_mgi_transactions_snap
     >> stg_mgi_transactions_null_id
     >> stg_country_code
+    >> stg_history_ledgers_dev
+    >> stg_accounts_dev
+    >> stg_partnership_assets_prices
+    >> stg_trust_lines_dev
     >> int_mgi_transactions_transformed
     >> int_mgi_transactions_null_id
     >> dim_dates
@@ -67,3 +78,4 @@ wait_on__mgi_dag >> snapshot_raw_mgi_stellar_transactions
     >> enriched_history_mgi_operations
     >> mgi_network_stats_agg
 )
+(dim_dates >> mgi_monthly_usd_balance)


### PR DESCRIPTION
This PR updates the Dbt image from `671afb6` to `18a84a3` and adds a `mgi_monthly_usd_balance` table in `mgi_transform_dag` and all upstream tables that `mgi_monthly_usd_balance` need to run.
`stg_history_ledgers_dev` 
`stg_accounts_dev`
`stg_trust_lines_dev`
`stg_partnership_assets_prices`