### PR TITLE
Add dag for update stellar-base.min.js

### DIFF
--- a/airflow_variables_dev.json
+++ b/airflow_variables_dev.json
@@ -299,5 +299,9 @@
   },
   "currency_bucket": "currencies_ohlc",
   "max_db_entry_age_in_days": 90,
-  "public_dbt_image_name": "stellar/stellar-dbt:dbf348d"
+  "public_dbt_image_name": "stellar/stellar-dbt:dbf348d",
+  "stellar_base_js_repositoy_name": "bower-js-stellar-base",
+  "stellar_base_js_repository_url": "https://raw.githubusercontent.com/stellar/bower-js-stellar-base/master/stellar-base.min.js",
+  "package_js_bucket_name": "stellar-etl-cli",
+  "package_js_object_name": "stellar-base.min.js"
 }

--- a/airflow_variables_prod.json
+++ b/airflow_variables_prod.json
@@ -319,5 +319,8 @@
   },
   "currency_bucket": "ext-asset-pricing",
   "max_db_entry_age_in_days": 180,
-  "public_dbt_image_name": "stellar/stellar-dbt:dbf348d"
+  "public_dbt_image_name": "stellar/stellar-dbt:dbf348d",
+  "stellar_base_js_repositoy_name": "bower-js-stellar-base",
+  "stellar_base_js_repository_url": "https://raw.githubusercontent.com/stellar/bower-js-stellar-base/master/stellar-base.min.js",
+  "package_js_object_name": "stellar-base.min.js"
 }

--- a/dags/js_library_update_dag.py
+++ b/dags/js_library_update_dag.py
@@ -1,0 +1,70 @@
+from datetime import datetime
+from json import loads
+
+from airflow import DAG
+from airflow.operators.empty import EmptyOperator
+from airflow.operators.python import BranchPythonOperator
+from airflow.operators.python_operator import PythonOperator
+from stellar_etl_airflow.build_check_latest_tag_task import is_new_tag
+from stellar_etl_airflow.build_get_update_library_task import (
+    check_file_upload_date,
+    send_library_to_gcs,
+)
+from stellar_etl_airflow.default import get_default_dag_args, init_sentry
+
+init_sentry()
+
+dag = DAG(
+    "js_library_update_dag",
+    default_args=get_default_dag_args(),
+    start_date=datetime(2015, 9, 30),
+    description="This DAG updates the js library from bower-js-stellar-base repo.",
+    schedule_interval="0 17 * * *",  # Daily 11 AM UTC
+    render_template_as_native_obj=True,
+    params={
+        "alias": "js_library",
+    },
+    user_defined_filters={"fromjson": lambda s: loads(s)},
+    catchup=True,
+    max_active_runs=1,
+)
+
+repo = "{{ var.value.stellar_base_js_repositoy_name }}"
+file_url = "{{ var.value.stellar_base_js_repository_url }}"
+bucket_name = "{{ var.value.package_js_bucket_name }}"
+destination_blob_name = "{{ var.value.package_js_object_name }}"
+
+check_last_update = PythonOperator(
+    task_id="check_last_update_task",
+    python_callable=check_file_upload_date,
+    op_kwargs={"bucket_name": bucket_name, "file_name": destination_blob_name},
+    dag=dag,
+)
+
+check_tag = BranchPythonOperator(
+    task_id="check_tag_task",
+    python_callable=is_new_tag,
+    op_kwargs={
+        "repo": repo,
+        "last_known_tag_date": "{{ ti.xcom_pull(task_ids='check_last_update_task') }}",
+    },
+    dag=dag,
+)
+
+update_library = PythonOperator(
+    task_id="update_library_task",
+    python_callable=send_library_to_gcs,
+    op_kwargs={
+        "file_url": file_url,
+        "bucket_name": bucket_name,
+        "destination_blob_name": destination_blob_name,
+    },
+    dag=dag,
+)
+
+task_aready_up_to_date = EmptyOperator(
+    task_id="task_aready_up_to_date_task",
+    dag=dag,
+)
+
+check_last_update >> check_tag >> [update_library, task_aready_up_to_date]

--- a/dags/js_library_update_dag.py
+++ b/dags/js_library_update_dag.py
@@ -45,7 +45,7 @@ check_tag = BranchPythonOperator(
     python_callable=is_new_tag,
     op_kwargs={
         "repo": repo,
-        "last_known_tag_date": "{{ ti.xcom_pull(task_ids='check_last_update_task') }}",
+        "last_known_tag_date": "{{ ti.xcom_pull(key='last_update_date',task_ids='check_last_update_task') }}",
     },
     dag=dag,
 )

--- a/dags/js_library_update_dag.py
+++ b/dags/js_library_update_dag.py
@@ -61,9 +61,9 @@ update_library = PythonOperator(
     dag=dag,
 )
 
-task_aready_up_to_date = EmptyOperator(
-    task_id="task_aready_up_to_date_task",
+task_already_up_to_date = EmptyOperator(
+    task_id="task_already_up_to_date_task",
     dag=dag,
 )
 
-check_last_update >> check_tag >> [update_library, task_aready_up_to_date]
+check_last_update >> check_tag >> [update_library, task_already_up_to_date]

--- a/dags/js_library_update_dag.py
+++ b/dags/js_library_update_dag.py
@@ -1,7 +1,9 @@
+from ast import literal_eval
 from datetime import datetime
 from json import loads
 
 from airflow import DAG
+from airflow.models import Variable
 from airflow.operators.empty import EmptyOperator
 from airflow.operators.python import BranchPythonOperator
 from airflow.operators.python_operator import PythonOperator
@@ -19,8 +21,9 @@ dag = DAG(
     default_args=get_default_dag_args(),
     start_date=datetime(2023, 1, 1),
     description="This DAG updates the js library from bower-js-stellar-base repo.",
-    schedule_interval="0 17 * * *",  # Daily 11 AM UTC
+    schedule_interval="0 17 * * *",  # Daily at 17:00 UTC
     render_template_as_native_obj=True,
+    is_paused_upon_creation=literal_eval(Variable.get("use_testnet")),
     params={
         "alias": "js_library",
     },

--- a/dags/js_library_update_dag.py
+++ b/dags/js_library_update_dag.py
@@ -17,7 +17,7 @@ init_sentry()
 dag = DAG(
     "js_library_update_dag",
     default_args=get_default_dag_args(),
-    start_date=datetime(2015, 9, 30),
+    start_date=datetime(2023, 1, 1),
     description="This DAG updates the js library from bower-js-stellar-base repo.",
     schedule_interval="0 17 * * *",  # Daily 11 AM UTC
     render_template_as_native_obj=True,
@@ -25,8 +25,7 @@ dag = DAG(
         "alias": "js_library",
     },
     user_defined_filters={"fromjson": lambda s: loads(s)},
-    catchup=True,
-    max_active_runs=1,
+    catchup=False,
 )
 
 repo = "{{ var.value.stellar_base_js_repositoy_name }}"

--- a/dags/stellar_etl_airflow/build_check_latest_tag_task.py
+++ b/dags/stellar_etl_airflow/build_check_latest_tag_task.py
@@ -1,0 +1,53 @@
+import logging
+
+import requests
+
+
+def get_commit_details(owner, repo, commit_sha):
+    url = f"https://api.github.com/repos/{owner}/{repo}/commits/{commit_sha}"
+    response = requests.get(url)
+    if response.status_code == 200:
+        try:
+            commit_details = response.json()
+            commit_date = commit_details["commit"]["committer"]["date"]
+            return commit_date
+        except ValueError:
+            raise Exception("Error parsing response from GitHub API")
+    else:
+        raise Exception(
+            f"Error fetching commit details from GitHub API: {response.status_code}"
+        )
+
+
+def get_latest_tag_from_github(owner, repo):
+    url = f"https://api.github.com/repos/{owner}/{repo}/tags"
+    response = requests.get(url)
+    if response.status_code == 200:
+        try:
+            tags = response.json()
+            for tag in tags:
+                if "beta" not in tag["name"]:
+                    if "alpha" not in tag["name"]:
+                        logging.info(f"Tag: {tag['name']}")
+                        commit_sha = tag["commit"]["sha"]
+                        commit_date = get_commit_details(owner, repo, commit_sha)
+                        tag["commit_date"] = commit_date
+                        return tag
+            return None
+        except ValueError:
+            raise Exception("Error parsing response from GitHub API")
+    else:
+        raise Exception(f"Error fetching tags from GitHub API: {response.status_code}")
+
+
+def is_new_tag(repo, last_known_tag_date):
+    repository_owner = "stellar"
+    latest_tag = get_latest_tag_from_github(repository_owner, repo)
+    if latest_tag:
+        logging.info(f"Latest tag date: {latest_tag['commit_date']}")
+        if latest_tag["commit_date"] > last_known_tag_date:
+            logging.info("New tag found!")
+            return True
+        else:
+            logging.info("No new tags found")
+            return "task_aready_up_to_date_task"

--- a/dags/stellar_etl_airflow/build_check_latest_tag_task.py
+++ b/dags/stellar_etl_airflow/build_check_latest_tag_task.py
@@ -51,3 +51,6 @@ def is_new_tag(repo, last_known_tag_date):
         else:
             logging.info("No new tags found")
             return "task_aready_up_to_date_task"
+
+
+is_new_tag("js-stellar-base", "2021-09-01T17:00:00Z")

--- a/dags/stellar_etl_airflow/build_check_latest_tag_task.py
+++ b/dags/stellar_etl_airflow/build_check_latest_tag_task.py
@@ -47,10 +47,7 @@ def is_new_tag(repo, last_known_tag_date):
         logging.info(f"Latest tag date: {latest_tag['commit_date']}")
         if latest_tag["commit_date"] > last_known_tag_date:
             logging.info("New tag found!")
-            return True
+            return "update_library_task"
         else:
             logging.info("No new tags found")
             return "task_aready_up_to_date_task"
-
-
-is_new_tag("js-stellar-base", "2021-09-01T17:00:00Z")

--- a/dags/stellar_etl_airflow/build_check_latest_tag_task.py
+++ b/dags/stellar_etl_airflow/build_check_latest_tag_task.py
@@ -52,4 +52,4 @@ def is_new_tag(repo, last_known_tag_date):
             return "update_library_task"
         else:
             logging.info("No new tags found")
-            return "task_aready_up_to_date_task"
+            return "task_already_up_to_date_task"

--- a/dags/stellar_etl_airflow/build_check_latest_tag_task.py
+++ b/dags/stellar_etl_airflow/build_check_latest_tag_task.py
@@ -43,6 +43,8 @@ def get_latest_tag_from_github(owner, repo):
 def is_new_tag(repo, last_known_tag_date):
     repository_owner = "stellar"
     latest_tag = get_latest_tag_from_github(repository_owner, repo)
+    latest_tag["commit_date"] = latest_tag["commit_date"].split("T")[0]
+    last_known_tag_date = str(last_known_tag_date)
     if latest_tag:
         logging.info(f"Latest tag date: {latest_tag['commit_date']}")
         if latest_tag["commit_date"] > last_known_tag_date:

--- a/dags/stellar_etl_airflow/build_get_update_library_task.py
+++ b/dags/stellar_etl_airflow/build_get_update_library_task.py
@@ -41,4 +41,5 @@ def send_library_to_gcs(file_url, bucket_name, destination_blob_name):
 
 def check_file_upload_date(bucket_name, file_name):
     blob = create_gcs_blob(bucket_name, file_name)
-    return blob.update()
+    last_update_date = blob.update()
+    return last_update_date

--- a/dags/stellar_etl_airflow/build_get_update_library_task.py
+++ b/dags/stellar_etl_airflow/build_get_update_library_task.py
@@ -4,12 +4,6 @@ import requests
 from google.cloud import storage
 
 
-def create_gcs_blob(bucket_name, destination_blob_name):
-    storage_client = storage.Client()
-    bucket = storage_client.bucket(bucket_name)
-    return bucket.blob(destination_blob_name)
-
-
 def download_file(url):
     response = requests.get(url)
     if response.status_code == 200:
@@ -19,7 +13,9 @@ def download_file(url):
 
 
 def upload_to_gcs(bucket_name, destination_blob_name, content):
-    blob = create_gcs_blob(bucket_name, destination_blob_name)
+    storage_client = storage.Client()
+    bucket = storage_client.bucket(bucket_name)
+    blob = bucket.blob(destination_blob_name)
     blob.upload_from_string(content)
 
 
@@ -40,6 +36,8 @@ def send_library_to_gcs(file_url, bucket_name, destination_blob_name):
 
 
 def check_file_upload_date(bucket_name, file_name):
-    blob = create_gcs_blob(bucket_name, file_name)
-    last_update_date = blob.update()
+    client = storage.Client()
+    bucket = client.get_bucket(bucket_name)
+    blob = bucket.get_blob(file_name)
+    last_update_date = blob.updated
     return last_update_date

--- a/dags/stellar_etl_airflow/build_get_update_library_task.py
+++ b/dags/stellar_etl_airflow/build_get_update_library_task.py
@@ -40,4 +40,5 @@ def check_file_upload_date(bucket_name, file_name):
     bucket = client.get_bucket(bucket_name)
     blob = bucket.get_blob(file_name)
     last_update_date = blob.updated
+    last_update_date = {"last_update_date": last_update_date}
     return last_update_date

--- a/dags/stellar_etl_airflow/build_get_update_library_task.py
+++ b/dags/stellar_etl_airflow/build_get_update_library_task.py
@@ -1,0 +1,44 @@
+import logging
+
+import requests
+from google.cloud import storage
+
+
+def create_gcs_blob(bucket_name, destination_blob_name):
+    storage_client = storage.Client()
+    bucket = storage_client.bucket(bucket_name)
+    return bucket.blob(destination_blob_name)
+
+
+def download_file(url):
+    response = requests.get(url)
+    if response.status_code == 200:
+        return response.content
+    else:
+        raise Exception(f"Error downloading file: {response.status_code}")
+
+
+def upload_to_gcs(bucket_name, destination_blob_name, content):
+    blob = create_gcs_blob(bucket_name, destination_blob_name)
+    blob.upload_from_string(content)
+
+
+def send_library_to_gcs(file_url, bucket_name, destination_blob_name):
+    try:
+        file_content = download_file(file_url)
+        upload_to_gcs(
+            bucket_name,
+            destination_blob_name,
+            file_content,
+            content_type="application/javascript",
+        )
+        logging.info(
+            f"File {destination_blob_name} loaded successfully to {bucket_name}."
+        )
+    except Exception as e:
+        logging.error(f"Error: {e}")
+
+
+def check_file_upload_date(bucket_name, file_name):
+    blob = create_gcs_blob(bucket_name, file_name)
+    return blob.time_created

--- a/dags/stellar_etl_airflow/build_get_update_library_task.py
+++ b/dags/stellar_etl_airflow/build_get_update_library_task.py
@@ -41,4 +41,4 @@ def send_library_to_gcs(file_url, bucket_name, destination_blob_name):
 
 def check_file_upload_date(bucket_name, file_name):
     blob = create_gcs_blob(bucket_name, file_name)
-    return blob.time_created
+    return blob.update()

--- a/dags/stellar_etl_airflow/build_get_update_library_task.py
+++ b/dags/stellar_etl_airflow/build_get_update_library_task.py
@@ -12,11 +12,11 @@ def download_file(url):
         raise Exception(f"Error downloading file: {response.status_code}")
 
 
-def upload_to_gcs(bucket_name, destination_blob_name, content):
+def upload_to_gcs(bucket_name, destination_blob_name, content, content_type=None):
     storage_client = storage.Client()
     bucket = storage_client.bucket(bucket_name)
     blob = bucket.blob(destination_blob_name)
-    blob.upload_from_string(content)
+    blob.upload_from_string(content, content_type=content_type)
 
 
 def send_library_to_gcs(file_url, bucket_name, destination_blob_name):

--- a/dags/stellar_etl_airflow/build_get_update_library_task.py
+++ b/dags/stellar_etl_airflow/build_get_update_library_task.py
@@ -40,5 +40,5 @@ def check_file_upload_date(bucket_name, file_name):
     bucket = client.get_bucket(bucket_name)
     blob = bucket.get_blob(file_name)
     last_update_date = blob.updated
-    last_update_date = {"last_update_date": last_update_date}
+    last_update_date = last_update_date.strftime("%Y-%m-%d")
     return last_update_date


### PR DESCRIPTION
With the need to automate `stellar-base.min.js` to use as a package for Dbt, we created a dag to automatically download this library.

This dag does a check to verify the file's upload date in GCS and checks the date of the last tag that is not beta or alpha in the repository. If this date is greater than that of GCS, the file is downloaded and replaced in GCS.