### PR TITLE
Remove elementary model from `dbt run`

### DIFF
--- a/dags/stellar_etl_airflow/build_dbt_task.py
+++ b/dags/stellar_etl_airflow/build_dbt_task.py
@@ -91,7 +91,6 @@ def build_dbt_task(
                 command_type,
                 "--select",
                 model_name,
-                "elementary",
                 dbt_full_refresh,
             ]
         )

--- a/dags/stellar_etl_airflow/build_dbt_task.py
+++ b/dags/stellar_etl_airflow/build_dbt_task.py
@@ -58,7 +58,7 @@ elementary:
 
 
 def build_dbt_task(
-    dag, model_name, command_type="run", resource_cfg="default", project="prod"
+    dag, model_name, command_type="build", resource_cfg="default", project="prod"
 ):
     """Create a task to run dbt on a selected model.
 


### PR DESCRIPTION
This PR removes the `elementary` model from the `dbt run` (`build_dbt_task()`) so that it doesn't truncate the tables.

This also changes the default dbt command from `run` to `build` that is more complete.