### PR TITLE
Remove all references to old public dataset

### DIFF
--- a/airflow_variables_dev.json
+++ b/airflow_variables_dev.json
@@ -253,8 +253,7 @@
     }
   },
   "partners_bucket": "partners_data",
-  "public_dataset": "test_crypto_stellar_old",
-  "public_dataset_new": "test_crypto_stellar",
+  "public_dataset": "test_crypto_stellar",
   "public_project": "test-hubble-319619",
   "resources": {
     "default": {

--- a/airflow_variables_prod.json
+++ b/airflow_variables_prod.json
@@ -264,8 +264,7 @@
       "type": "MONTH"
     }
   },
-  "public_dataset": "crypto_stellar_2",
-  "public_dataset_new": "crypto_stellar",
+  "public_dataset": "crypto_stellar",
   "public_project": "crypto-stellar",
   "bq_dataset_audit_log": "audit_log",
   "resources": {

--- a/dags/bucket_list_dag.py
+++ b/dags/bucket_list_dag.py
@@ -48,7 +48,6 @@ internal_project = "{{ var.value.bq_project }}"
 internal_dataset = "{{ var.value.bq_dataset }}"
 public_project = "{{ var.value.public_project }}"
 public_dataset = "{{ var.value.public_dataset }}"
-public_dataset_new = "{{ var.value.public_dataset_new }}"
 use_testnet = literal_eval(Variable.get("use_testnet"))
 use_futurenet = literal_eval(Variable.get("use_futurenet"))
 """

--- a/dags/history_archive_with_captive_core_dag.py
+++ b/dags/history_archive_with_captive_core_dag.py
@@ -48,7 +48,6 @@ internal_project = "{{ var.value.bq_project }}"
 internal_dataset = "{{ var.value.bq_dataset }}"
 public_project = "{{ var.value.public_project }}"
 public_dataset = "{{ var.value.public_dataset }}"
-public_dataset_new = "{{ var.value.public_dataset_new }}"
 use_testnet = literal_eval(Variable.get("use_testnet"))
 use_futurenet = literal_eval(Variable.get("use_futurenet"))
 
@@ -139,17 +138,11 @@ delete_old_op_task = build_delete_data_task(
 delete_old_op_pub_task = build_delete_data_task(
     dag, public_project, public_dataset, table_names["operations"], "pub"
 )
-delete_old_op_pub_new_task = build_delete_data_task(
-    dag, public_project, public_dataset_new, table_names["operations"], "pub_new"
-)
 delete_old_trade_task = build_delete_data_task(
     dag, internal_project, internal_dataset, table_names["trades"]
 )
 delete_old_trade_pub_task = build_delete_data_task(
     dag, public_project, public_dataset, table_names["trades"], "pub"
-)
-delete_old_trade_pub_new_task = build_delete_data_task(
-    dag, public_project, public_dataset_new, table_names["trades"], "pub_new"
 )
 delete_enrich_op_task = build_delete_data_task(
     dag, internal_project, internal_dataset, "enriched_history_operations"
@@ -157,26 +150,20 @@ delete_enrich_op_task = build_delete_data_task(
 delete_enrich_op_pub_task = build_delete_data_task(
     dag, public_project, public_dataset, "enriched_history_operations", "pub"
 )
-delete_enrich_op_pub_new_task = build_delete_data_task(
-    dag, public_project, public_dataset_new, "enriched_history_operations", "pub_new"
-)
 delete_enrich_ma_op_task = build_delete_data_task(
     dag, internal_project, internal_dataset, "enriched_meaningful_history_operations"
 )
 delete_old_effects_task = build_delete_data_task(
     dag, internal_project, internal_dataset, table_names["effects"]
 )
-delete_old_effects_pub_new_task = build_delete_data_task(
-    dag, public_project, public_dataset_new, table_names["effects"], "pub_new"
+delete_old_effects_pub_task = build_delete_data_task(
+    dag, public_project, public_dataset, table_names["effects"], "pub"
 )
 delete_old_tx_task = build_delete_data_task(
     dag, internal_project, internal_dataset, table_names["transactions"]
 )
 delete_old_tx_pub_task = build_delete_data_task(
     dag, public_project, public_dataset, table_names["transactions"], "pub"
-)
-delete_old_tx_pub_new_task = build_delete_data_task(
-    dag, public_project, public_dataset_new, table_names["transactions"], "pub_new"
 )
 
 """
@@ -224,9 +211,9 @@ send_txs_to_bq_task = build_gcs_to_bq_task(
     cluster=True,
 )
 
+
 """
-The send tasks receive the location of the file in Google Cloud storage through Airflow's XCOM system.
-Then, the task merges the unique entries in the file into the corresponding table in BigQuery.
+Load final public dataset, crypto-stellar
 """
 send_ops_to_pub_task = build_gcs_to_bq_task(
     dag,
@@ -250,6 +237,17 @@ send_trades_to_pub_task = build_gcs_to_bq_task(
     cluster=True,
     dataset_type="pub",
 )
+send_effects_to_pub_task = build_gcs_to_bq_task(
+    dag,
+    effects_export_task.task_id,
+    public_project,
+    public_dataset,
+    table_names["effects"],
+    "",
+    partition=True,
+    cluster=True,
+    dataset_type="pub",
+)
 send_txs_to_pub_task = build_gcs_to_bq_task(
     dag,
     tx_export_task.task_id,
@@ -260,54 +258,6 @@ send_txs_to_pub_task = build_gcs_to_bq_task(
     partition=True,
     cluster=True,
     dataset_type="pub",
-)
-
-"""
-Load final public dataset, crypto-stellar
-"""
-send_ops_to_pub_new_task = build_gcs_to_bq_task(
-    dag,
-    op_export_task.task_id,
-    public_project,
-    public_dataset_new,
-    table_names["operations"],
-    "",
-    partition=True,
-    cluster=True,
-    dataset_type="pub_new",
-)
-send_trades_to_pub_new_task = build_gcs_to_bq_task(
-    dag,
-    trade_export_task.task_id,
-    public_project,
-    public_dataset_new,
-    table_names["trades"],
-    "",
-    partition=True,
-    cluster=True,
-    dataset_type="pub_new",
-)
-send_effects_to_pub_new_task = build_gcs_to_bq_task(
-    dag,
-    effects_export_task.task_id,
-    public_project,
-    public_dataset_new,
-    table_names["effects"],
-    "",
-    partition=True,
-    cluster=True,
-    dataset_type="pub_new",
-)
-send_txs_to_pub_new_task = build_gcs_to_bq_task(
-    dag,
-    tx_export_task.task_id,
-    public_project,
-    public_dataset_new,
-    table_names["transactions"],
-    "",
-    partition=True,
-    cluster=True,
-    dataset_type="pub_new",
 )
 
 """
@@ -334,15 +284,6 @@ insert_enriched_hist_pub_task = build_bq_insert_job(
     partition=True,
     cluster=True,
     dataset_type="pub",
-)
-insert_enriched_hist_pub_new_task = build_bq_insert_job(
-    dag,
-    public_project,
-    public_dataset_new,
-    "enriched_history_operations",
-    partition=True,
-    cluster=True,
-    dataset_type="pub_new",
 )
 insert_enriched_ma_hist_task = build_bq_insert_job(
     dag,
@@ -377,14 +318,6 @@ insert_enriched_ma_hist_task = build_bq_insert_job(
     >> insert_enriched_hist_pub_task
 )
 (
-    op_export_task
-    >> delete_old_op_pub_new_task
-    >> send_ops_to_pub_new_task
-    >> wait_on_dag
-    >> delete_enrich_op_pub_new_task
-    >> insert_enriched_hist_pub_new_task
-)
-(
     time_task
     >> write_trade_stats
     >> trade_export_task
@@ -392,7 +325,6 @@ insert_enriched_ma_hist_task = build_bq_insert_job(
     >> send_trades_to_bq_task
 )
 trade_export_task >> delete_old_trade_pub_task >> send_trades_to_pub_task
-trade_export_task >> delete_old_trade_pub_new_task >> send_trades_to_pub_new_task
 (
     time_task
     >> write_effects_stats
@@ -400,7 +332,7 @@ trade_export_task >> delete_old_trade_pub_new_task >> send_trades_to_pub_new_tas
     >> delete_old_effects_task
     >> send_effects_to_bq_task
 )
-effects_export_task >> delete_old_effects_pub_new_task >> send_effects_to_pub_new_task
+effects_export_task >> delete_old_effects_pub_task >> send_effects_to_pub_task
 (
     time_task
     >> write_tx_stats
@@ -410,5 +342,4 @@ effects_export_task >> delete_old_effects_pub_new_task >> send_effects_to_pub_ne
     >> wait_on_dag
 )
 tx_export_task >> delete_old_tx_pub_task >> send_txs_to_pub_task >> wait_on_dag
-tx_export_task >> delete_old_tx_pub_new_task >> send_txs_to_pub_new_task >> wait_on_dag
 (time_task >> write_diagnostic_events_stats >> diagnostic_events_export_task)

--- a/dags/history_archive_without_captive_core_dag.py
+++ b/dags/history_archive_without_captive_core_dag.py
@@ -47,7 +47,6 @@ internal_project = "{{ var.value.bq_project }}"
 internal_dataset = "{{ var.value.bq_dataset }}"
 public_project = "{{ var.value.public_project }}"
 public_dataset = "{{ var.value.public_dataset }}"
-public_dataset_new = "{{ var.value.public_dataset_new }}"
 use_testnet = literal_eval(Variable.get("use_testnet"))
 use_futurenet = literal_eval(Variable.get("use_futurenet"))
 
@@ -105,14 +104,11 @@ delete_old_ledger_task = build_delete_data_task(
 delete_old_ledger_pub_task = build_delete_data_task(
     dag, public_project, public_dataset, table_names["ledgers"], "pub"
 )
-delete_old_ledger_pub_new_task = build_delete_data_task(
-    dag, public_project, public_dataset_new, table_names["ledgers"], "pub_new"
-)
 delete_old_asset_task = build_delete_data_task(
     dag, internal_project, internal_dataset, table_names["assets"]
 )
-delete_old_asset_pub_new_task = build_delete_data_task(
-    dag, public_project, public_dataset_new, table_names["assets"], "pub_new"
+delete_old_asset_pub_task = build_delete_data_task(
+    dag, public_project, public_dataset, table_names["assets"], "pub"
 )
 
 """
@@ -144,17 +140,6 @@ send_assets_to_bq_task = build_gcs_to_bq_task(
 The send tasks receive the location of the file in Google Cloud storage through Airflow's XCOM system.
 Then, the task merges the unique entries in the file into the corresponding table in BigQuery.
 """
-send_ledgers_to_pub_new_task = build_gcs_to_bq_task(
-    dag,
-    ledger_export_task.task_id,
-    public_project,
-    public_dataset_new,
-    table_names["ledgers"],
-    "",
-    partition=True,
-    cluster=True,
-    dataset_type="pub_new",
-)
 send_ledgers_to_pub_task = build_gcs_to_bq_task(
     dag,
     ledger_export_task.task_id,
@@ -166,16 +151,16 @@ send_ledgers_to_pub_task = build_gcs_to_bq_task(
     cluster=True,
     dataset_type="pub",
 )
-send_assets_to_pub_new_task = build_gcs_to_bq_task(
+send_assets_to_pub_task = build_gcs_to_bq_task(
     dag,
     asset_export_task.task_id,
     public_project,
-    public_dataset_new,
+    public_dataset,
     table_names["assets"],
     "",
     partition=True,
     cluster=True,
-    dataset_type="pub_new",
+    dataset_type="pub",
 )
 
 """
@@ -191,15 +176,15 @@ dedup_assets_bq_task = build_bq_insert_job(
     cluster=True,
     create=True,
 )
-dedup_assets_pub_new_task = build_bq_insert_job(
+dedup_assets_pub_task = build_bq_insert_job(
     dag,
     public_project,
-    public_dataset_new,
+    public_dataset,
     table_names["assets"],
     partition=True,
     cluster=True,
     create=True,
-    dataset_type="pub_new",
+    dataset_type="pub",
 )
 
 (
@@ -209,7 +194,6 @@ dedup_assets_pub_new_task = build_bq_insert_job(
     >> delete_old_ledger_task
     >> send_ledgers_to_bq_task
 )
-ledger_export_task >> delete_old_ledger_pub_new_task >> send_ledgers_to_pub_new_task
 ledger_export_task >> delete_old_ledger_pub_task >> send_ledgers_to_pub_task
 (
     time_task
@@ -221,7 +205,7 @@ ledger_export_task >> delete_old_ledger_pub_task >> send_ledgers_to_pub_task
 )
 (
     asset_export_task
-    >> delete_old_asset_pub_new_task
-    >> send_assets_to_pub_new_task
-    >> dedup_assets_pub_new_task
+    >> delete_old_asset_pub_task
+    >> send_assets_to_pub_task
+    >> dedup_assets_pub_task
 )

--- a/dags/ledger_current_state_dag.py
+++ b/dags/ledger_current_state_dag.py
@@ -25,7 +25,7 @@ dag = DAG(
 internal_project = Variable.get("bq_project")
 internal_dataset = Variable.get("dbt_mart_dataset")
 public_project = Variable.get("public_project")
-public_dataset = Variable.get("public_dataset_new")
+public_dataset = Variable.get("public_dataset")
 
 # tasks for staging tables for ledger_current_state tables
 stg_account_signers = build_dbt_task(dag, "stg_account_signers")

--- a/dags/state_table_dag.py
+++ b/dags/state_table_dag.py
@@ -46,7 +46,6 @@ internal_project = "{{ var.value.bq_project }}"
 internal_dataset = "{{ var.value.bq_dataset }}"
 public_project = "{{ var.value.public_project }}"
 public_dataset = "{{ var.value.public_dataset }}"
-public_dataset_new = "{{ var.value.public_dataset_new }}"
 use_testnet = literal_eval(Variable.get("use_testnet"))
 use_futurenet = literal_eval(Variable.get("use_futurenet"))
 
@@ -85,57 +84,54 @@ Bigquery. If it does, the records are deleted prior to reinserting the batch.
 delete_acc_task = build_delete_data_task(
     dag, internal_project, internal_dataset, table_names["accounts"]
 )
-delete_acc_pub_new_task = build_delete_data_task(
-    dag, public_project, public_dataset_new, table_names["accounts"], "pub_new"
+delete_acc_pub_task = build_delete_data_task(
+    dag, public_project, public_dataset, table_names["accounts"], "pub"
 )
 delete_bal_task = build_delete_data_task(
     dag, internal_project, internal_dataset, table_names["claimable_balances"]
 )
 delete_bal_pub_task = build_delete_data_task(
-    dag, public_project, public_dataset, table_names["claimable_balances"], "pub"
-)
-delete_bal_pub_new_task = build_delete_data_task(
     dag,
     public_project,
-    public_dataset_new,
+    public_dataset,
     table_names["claimable_balances"],
-    "pub_new",
+    "pub",
 )
 delete_off_task = build_delete_data_task(
     dag, internal_project, internal_dataset, table_names["offers"]
 )
-delete_off_pub_new_task = build_delete_data_task(
-    dag, public_project, public_dataset_new, table_names["offers"], "pub_new"
+delete_off_pub_task = build_delete_data_task(
+    dag, public_project, public_dataset, table_names["offers"], "pub"
 )
 delete_pool_task = build_delete_data_task(
     dag, internal_project, internal_dataset, table_names["liquidity_pools"]
 )
-delete_pool_pub_new_task = build_delete_data_task(
-    dag, public_project, public_dataset_new, table_names["liquidity_pools"], "pub_new"
+delete_pool_pub_task = build_delete_data_task(
+    dag, public_project, public_dataset, table_names["liquidity_pools"], "pub"
 )
 delete_sign_task = build_delete_data_task(
     dag, internal_project, internal_dataset, table_names["signers"]
 )
-delete_sign_pub_new_task = build_delete_data_task(
-    dag, public_project, public_dataset_new, table_names["signers"], "pub_new"
+delete_sign_pub_task = build_delete_data_task(
+    dag, public_project, public_dataset, table_names["signers"], "pub"
 )
 delete_trust_task = build_delete_data_task(
     dag, internal_project, internal_dataset, table_names["trustlines"]
 )
-delete_trust_pub_new_task = build_delete_data_task(
-    dag, public_project, public_dataset_new, table_names["trustlines"], "pub_new"
+delete_trust_pub_task = build_delete_data_task(
+    dag, public_project, public_dataset, table_names["trustlines"], "pub"
 )
 delete_contract_data_task = build_delete_data_task(
-    dag, public_project, public_dataset_new, table_names["contract_data"], "pub_new"
+    dag, public_project, public_dataset, table_names["contract_data"], "pub"
 )
 delete_contract_code_task = build_delete_data_task(
-    dag, public_project, public_dataset_new, table_names["contract_code"], "pub_new"
+    dag, public_project, public_dataset, table_names["contract_code"], "pub"
 )
 delete_config_settings_task = build_delete_data_task(
-    dag, public_project, public_dataset_new, table_names["config_settings"], "pub_new"
+    dag, public_project, public_dataset, table_names["config_settings"], "pub"
 )
 delete_ttl_task = build_delete_data_task(
-    dag, public_project, public_dataset_new, table_names["ttl"], "pub_new"
+    dag, public_project, public_dataset, table_names["ttl"], "pub"
 )
 
 """
@@ -205,10 +201,19 @@ send_trust_to_bq_task = build_gcs_to_bq_task(
 )
 
 """
-The apply tasks receive the location of the file in Google Cloud storage through Airflow's XCOM system.
-Then, the task merges the entries in the file with the entries in the corresponding table in BigQuery.
-Entries are updated, deleted, or inserted as needed.
+    Send to public dataset
 """
+send_acc_to_pub_task = build_gcs_to_bq_task(
+    dag,
+    changes_task.task_id,
+    public_project,
+    public_dataset,
+    table_names["accounts"],
+    "/*-accounts.txt",
+    partition=True,
+    cluster=True,
+    dataset_type="pub",
+)
 send_bal_to_pub_task = build_gcs_to_bq_task(
     dag,
     changes_task.task_id,
@@ -220,128 +225,101 @@ send_bal_to_pub_task = build_gcs_to_bq_task(
     cluster=True,
     dataset_type="pub",
 )
-
-"""
-    Send to new public dataset
-"""
-send_acc_to_pub_new_task = build_gcs_to_bq_task(
+send_off_to_pub_task = build_gcs_to_bq_task(
     dag,
     changes_task.task_id,
     public_project,
-    public_dataset_new,
-    table_names["accounts"],
-    "/*-accounts.txt",
-    partition=True,
-    cluster=True,
-    dataset_type="pub_new",
-)
-send_bal_to_pub_new_task = build_gcs_to_bq_task(
-    dag,
-    changes_task.task_id,
-    public_project,
-    public_dataset_new,
-    table_names["claimable_balances"],
-    "/*-claimable_balances.txt",
-    partition=True,
-    cluster=True,
-    dataset_type="pub_new",
-)
-send_off_to_pub_new_task = build_gcs_to_bq_task(
-    dag,
-    changes_task.task_id,
-    public_project,
-    public_dataset_new,
+    public_dataset,
     table_names["offers"],
     "/*-offers.txt",
     partition=True,
     cluster=True,
-    dataset_type="pub_new",
+    dataset_type="pub",
 )
-send_pool_to_pub_new_task = build_gcs_to_bq_task(
+send_pool_to_pub_task = build_gcs_to_bq_task(
     dag,
     changes_task.task_id,
     public_project,
-    public_dataset_new,
+    public_dataset,
     table_names["liquidity_pools"],
     "/*-liquidity_pools.txt",
     partition=True,
     cluster=True,
-    dataset_type="pub_new",
+    dataset_type="pub",
 )
-send_sign_to_pub_new_task = build_gcs_to_bq_task(
+send_sign_to_pub_task = build_gcs_to_bq_task(
     dag,
     changes_task.task_id,
     public_project,
-    public_dataset_new,
+    public_dataset,
     table_names["signers"],
     "/*-signers.txt",
     partition=True,
     cluster=True,
-    dataset_type="pub_new",
+    dataset_type="pub",
 )
-send_trust_to_pub_new_task = build_gcs_to_bq_task(
+send_trust_to_pub_task = build_gcs_to_bq_task(
     dag,
     changes_task.task_id,
     public_project,
-    public_dataset_new,
+    public_dataset,
     table_names["trustlines"],
     "/*-trustlines.txt",
     partition=True,
     cluster=True,
-    dataset_type="pub_new",
+    dataset_type="pub",
 )
 send_contract_data_to_pub_task = build_gcs_to_bq_task(
     dag,
     changes_task.task_id,
     public_project,
-    public_dataset_new,
+    public_dataset,
     table_names["contract_data"],
     "/*-contract_data.txt",
     partition=True,
     cluster=True,
-    dataset_type="pub_new",
+    dataset_type="pub",
 )
 send_contract_code_to_pub_task = build_gcs_to_bq_task(
     dag,
     changes_task.task_id,
     public_project,
-    public_dataset_new,
+    public_dataset,
     table_names["contract_code"],
     "/*-contract_code.txt",
     partition=True,
     cluster=True,
-    dataset_type="pub_new",
+    dataset_type="pub",
 )
 send_config_settings_to_pub_task = build_gcs_to_bq_task(
     dag,
     changes_task.task_id,
     public_project,
-    public_dataset_new,
+    public_dataset,
     table_names["config_settings"],
     "/*-config_settings.txt",
     partition=True,
     cluster=True,
-    dataset_type="pub_new",
+    dataset_type="pub",
 )
 send_ttl_to_pub_task = build_gcs_to_bq_task(
     dag,
     changes_task.task_id,
     public_project,
-    public_dataset_new,
+    public_dataset,
     table_names["ttl"],
     "/*-ttl.txt",
     partition=True,
     cluster=True,
-    dataset_type="pub_new",
+    dataset_type="pub",
 )
 
 date_task >> changes_task >> write_acc_stats >> delete_acc_task >> send_acc_to_bq_task
-write_acc_stats >> delete_acc_pub_new_task >> send_acc_to_pub_new_task
+write_acc_stats >> delete_acc_pub_task >> send_acc_to_pub_task
 date_task >> changes_task >> write_bal_stats >> delete_bal_task >> send_bal_to_bq_task
 write_bal_stats >> delete_bal_pub_task >> send_bal_to_pub_task
-write_bal_stats >> delete_bal_pub_new_task >> send_bal_to_pub_new_task
 date_task >> changes_task >> write_off_stats >> delete_off_task >> send_off_to_bq_task
-write_off_stats >> delete_off_pub_new_task >> send_off_to_pub_new_task
+write_off_stats >> delete_off_pub_task >> send_off_to_pub_task
 (
     date_task
     >> changes_task
@@ -349,7 +327,7 @@ write_off_stats >> delete_off_pub_new_task >> send_off_to_pub_new_task
     >> delete_pool_task
     >> send_pool_to_bq_task
 )
-write_pool_stats >> delete_pool_pub_new_task >> send_pool_to_pub_new_task
+write_pool_stats >> delete_pool_pub_task >> send_pool_to_pub_task
 (
     date_task
     >> changes_task
@@ -357,7 +335,7 @@ write_pool_stats >> delete_pool_pub_new_task >> send_pool_to_pub_new_task
     >> delete_sign_task
     >> send_sign_to_bq_task
 )
-write_sign_stats >> delete_sign_pub_new_task >> send_sign_to_pub_new_task
+write_sign_stats >> delete_sign_pub_task >> send_sign_to_pub_task
 (
     date_task
     >> changes_task
@@ -365,7 +343,7 @@ write_sign_stats >> delete_sign_pub_new_task >> send_sign_to_pub_new_task
     >> delete_trust_task
     >> send_trust_to_bq_task
 )
-write_trust_stats >> delete_trust_pub_new_task >> send_trust_to_pub_new_task
+write_trust_stats >> delete_trust_pub_task >> send_trust_to_pub_task
 (
     date_task
     >> changes_task

--- a/dags/stellar_etl_airflow/build_bq_insert_job_task.py
+++ b/dags/stellar_etl_airflow/build_bq_insert_job_task.py
@@ -63,6 +63,7 @@ def build_bq_insert_job(
             },
             "useLegacySql": False,
             "writeDisposition": write_disposition,
+            "schemaUpdateOptions": ["ALLOW_FIELD_ADDITION"],
         }
     }
     if partition:


### PR DESCRIPTION
Hubble DAGs were published raw data in two public datasets, `crypto-stellar` and `crypto-stellar-2`. All dependencies have been migrated off of `crypto-stellar-2` and the datasets should be deleted.

The rollout of this change will be phased: 
1. Deploy to test and monitor both `test_crypto_stellar` and `test_crypto_stellar_old`. The old dataset should stop updating completely. The normal dataset should not be impacted.
2. Monitor for 24 hours
3. Deploy to production and monitor the same behavior across `crypto_stellar` and `crypto_stellar_2`
4. Wait 7 days
5. Delete the dataset `crypto_stellar_2`