### PR TITLE
Hot Fix: Audit log Dag

### DIFF
--- a/README.md
+++ b/README.md
@@ -589,8 +589,8 @@ This section contains information about the Airflow setup. It includes our DAG d
 [This DAG](https://github.com/stellar/stellar-etl-airflow/blob/master/dags/cleanup_metadata_dag.py)
 
 - A maintenance workflow that you can deploy into Airflow to periodically clean
-out the DagRun, TaskInstance, Log, XCom, Job DB and SlaMiss entries to avoid
-having too much data in your Airflow MetaStore.
+  out the DagRun, TaskInstance, Log, XCom, Job DB and SlaMiss entries to avoid
+  having too much data in your Airflow MetaStore.
 
 ![Cleanup metadata DAG](documentation/images/cleanup_metadata_dag.png)
 

--- a/dags/stellar_etl_airflow/build_bq_insert_job_task.py
+++ b/dags/stellar_etl_airflow/build_bq_insert_job_task.py
@@ -74,7 +74,7 @@ def build_bq_insert_job(
     if create:
         configuration["query"]["createDisposition"] = "CREATE_IF_NEEDED"
     if write_disposition == "WRITE_APPEND":
-        configuration["query"]["schemaUpdateOptions"] = "ALLOW_FIELD_ADDITION"
+        configuration["query"]["schemaUpdateOptions"] = ["ALLOW_FIELD_ADDITION"]
 
     return BigQueryInsertJobOperator(
         task_id=f"insert_records_{table}_{dataset_type}",

--- a/dags/stellar_etl_airflow/build_bq_insert_job_task.py
+++ b/dags/stellar_etl_airflow/build_bq_insert_job_task.py
@@ -63,7 +63,6 @@ def build_bq_insert_job(
             },
             "useLegacySql": False,
             "writeDisposition": write_disposition,
-            "schemaUpdateOptions": ["ALLOW_FIELD_ADDITION"],
         }
     }
     if partition:
@@ -74,6 +73,8 @@ def build_bq_insert_job(
         configuration["query"]["clustering"] = {"fields": cluster_fields[table]}
     if create:
         configuration["query"]["createDisposition"] = "CREATE_IF_NEEDED"
+    if write_disposition == "WRITE_APPEND":
+        configuration["query"]["schemaUpdateOptions"] = "ALLOW_FIELD_ADDITION"
 
     return BigQueryInsertJobOperator(
         task_id=f"insert_records_{table}_{dataset_type}",


### PR DESCRIPTION
The insert job in BQ should only take the `schemaUpdateOptions` parameter if the write disposition is `WRITE_APPEND`. Moved the parameter to be optionally added to the query config.