### PR TITLE
Unify dbt sdf marts in one dbt task

### DIFF
--- a/airflow_variables_dev.json
+++ b/airflow_variables_dev.json
@@ -354,7 +354,8 @@
       "asset_stats",
       "network_stats",
       "partnership_assets",
-      "history_assets"
+      "history_assets",
+      "soroban"
     ]
   }
 }

--- a/airflow_variables_dev.json
+++ b/airflow_variables_dev.json
@@ -342,5 +342,19 @@
   "internal_source_db": "test-hubble-319619",
   "internal_source_schema": "test_crypto_stellar_internal",
   "public_source_db": "test-hubble-319619",
-  "public_source_schema": "test_crypto_stellar"
+  "public_source_schema": "test_crypto_stellar",
+  "dbt_tags": {
+    "sdf_marts": [
+      "ohlc",
+      "liquidity_pool_trade_volume",
+      "mgi",
+      "liquidity_providers",
+      "trade_agg",
+      "fee_stats",
+      "asset_stats",
+      "network_stats",
+      "partnership_assets",
+      "history_assets"
+    ]
+  }
 }

--- a/airflow_variables_prod.json
+++ b/airflow_variables_prod.json
@@ -374,7 +374,8 @@
       "asset_stats",
       "network_stats",
       "partnership_assets",
-      "history_assets"
+      "history_assets",
+      "soroban"
     ]
   }
 }

--- a/airflow_variables_prod.json
+++ b/airflow_variables_prod.json
@@ -362,5 +362,19 @@
   "internal_source_db": "hubble-261722",
   "internal_source_schema": "crypto_stellar_internal_2",
   "public_source_db": "crypto-stellar",
-  "public_source_schema": "crypto_stellar"
+  "public_source_schema": "crypto_stellar",
+  "dbt_tags": {
+    "sdf_marts": [
+      "ohlc",
+      "liquidity_pool_trade_volume",
+      "mgi",
+      "liquidity_providers",
+      "trade_agg",
+      "fee_stats",
+      "asset_stats",
+      "network_stats",
+      "partnership_assets",
+      "history_assets"
+    ]
+  }
 }

--- a/dags/stellar_etl_airflow/build_dbt_task.py
+++ b/dags/stellar_etl_airflow/build_dbt_task.py
@@ -98,7 +98,7 @@ def dbt_task(
         models.append(f"{operator}{model_name}")
     if len(models) > 1:
         task_name = "multiple_models"
-        args.append(",".join(models))
+        args.append(" ".join(models))
     else:
         args.append(models[0])
 

--- a/dags/stellar_etl_airflow/build_dbt_task.py
+++ b/dags/stellar_etl_airflow/build_dbt_task.py
@@ -87,9 +87,12 @@ def dbt_task(
     args = [command_type, f"--{flag}"]
 
     models = []
-    if tag:
+    if isinstance(tag, str):
         task_name = tag
         models.append(f"{operator}tag:{tag}")
+    if isinstance(tag, list):
+        task_name = "multiple_tags"
+        models.extend([f"{operator}tag:{t}" for t in tag])
     if model_name:
         task_name = model_name
         models.append(f"{operator}{model_name}")


### PR DESCRIPTION
This PR adds an if statement that allows you to insert more than one tag for the `dbt_task` function, with this we can run all the tags in the same run to prevent errors about concurrent updates mentioned in the HUBBLE-301 ticket.