### PR TITLE
Release new soroban fields

### DIFF
--- a/airflow_variables_dev.json
+++ b/airflow_variables_dev.json
@@ -121,7 +121,7 @@
     "partnership_assets__account_holders_activity_fact": false,
     "partnership_assets__asset_activity_fact": false
   },
-  "dbt_image_name": "stellar/stellar-dbt:cc28da9",
+  "dbt_image_name": "stellar/stellar-dbt:b621192",
   "dbt_job_execution_timeout_seconds": 300,
   "dbt_job_retries": 1,
   "dbt_mart_dataset": "test_sdf_marts",
@@ -131,7 +131,7 @@
   "dbt_threads": 12,
   "gcs_exported_data_bucket_name": "us-central1-hubble-1pt5-dev-7db0e004-bucket",
   "gcs_exported_object_prefix": "dag-exported",
-  "image_name": "stellar/stellar-etl:4874b6b",
+  "image_name": "stellar/stellar-etl:57becfe",
   "image_output_path": "/etl/exported_data/",
   "image_pull_policy": "IfNotPresent",
   "kube_config_location": "",

--- a/airflow_variables_dev.json
+++ b/airflow_variables_dev.json
@@ -131,7 +131,7 @@
   "dbt_threads": 12,
   "gcs_exported_data_bucket_name": "us-central1-hubble-1pt5-dev-7db0e004-bucket",
   "gcs_exported_object_prefix": "dag-exported",
-  "image_name": "stellar/stellar-etl:57becfe",
+  "image_name": "stellar/stellar-etl:70448cd",
   "image_output_path": "/etl/exported_data/",
   "image_pull_policy": "IfNotPresent",
   "kube_config_location": "",

--- a/airflow_variables_prod.json
+++ b/airflow_variables_prod.json
@@ -143,7 +143,7 @@
     "partnership_assets__asset_activity_fact": false,
     "trade_agg": false
   },
-  "dbt_image_name": "stellar/stellar-dbt:cc28da9",
+  "dbt_image_name": "stellar/stellar-dbt:b621192",
   "dbt_job_execution_timeout_seconds": 1800,
   "dbt_job_retries": 1,
   "dbt_mart_dataset": "sdf_marts",
@@ -153,7 +153,7 @@
   "dbt_threads": 12,
   "gcs_exported_data_bucket_name": "us-central1-hubble-2-d948d67b-bucket",
   "gcs_exported_object_prefix": "dag-exported",
-  "image_name": "stellar/stellar-etl:4874b6b",
+  "image_name": "stellar/stellar-etl:57becfe",
   "image_output_path": "/etl/exported_data/",
   "image_pull_policy": "IfNotPresent",
   "kube_config_location": "",

--- a/airflow_variables_prod.json
+++ b/airflow_variables_prod.json
@@ -153,7 +153,7 @@
   "dbt_threads": 12,
   "gcs_exported_data_bucket_name": "us-central1-hubble-2-d948d67b-bucket",
   "gcs_exported_object_prefix": "dag-exported",
-  "image_name": "stellar/stellar-etl:57becfe",
+  "image_name": "stellar/stellar-etl:70448cd",
   "image_output_path": "/etl/exported_data/",
   "image_pull_policy": "IfNotPresent",
   "kube_config_location": "",

--- a/dags/queries/enriched_history_operations.sql
+++ b/dags/queries/enriched_history_operations.sql
@@ -147,6 +147,12 @@ select
     , ht.soroban_resources_instructions
     , ht.soroban_resources_read_bytes
     , ht.soroban_resources_write_bytes
+    , ht.transaction_result_code
+    , ht.inclusion_fee_bid
+    , ht.inclusion_fee_charged
+    , ht.resource_fee_refund
+    , ho.operation_result_code
+    , ho.operation_trace_code
 from {project_id}.{dataset_id}.history_operations as ho
 join {project_id}.{dataset_id}.history_transactions as ht
     on ho.transaction_id = ht.id

--- a/schemas/enriched_history_operations_schema.json
+++ b/schemas/enriched_history_operations_schema.json
@@ -1320,5 +1320,35 @@
     "mode": "NULLABLE",
     "name": "soroban_resources_write_bytes",
     "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "transaction_result_code",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "inclusion_fee_bid",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "inclusion_fee_charged",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "resource_fee_refund",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "operation_result_code",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "operation_trace_code",
+    "type": "STRING"
   }
 ]


### PR DESCRIPTION
Add result codes, trace codes and fees to legacy `enriched_history_operations` table. Bump `stellar-dbt` and `stellar-etl` images