### PR TITLE
Update Canvas sandbox dependencies

### DIFF
--- a/airflow_variables_dev.json
+++ b/airflow_variables_dev.json
@@ -257,7 +257,7 @@
     "liquidity_pools_current": "liquidity_pools_current",
     "offers_current": "offers_current",
     "trustlines_current": "trust_lines_current",
-    "ttl": "ttl_current"
+    "ttl_current": "ttl_current"
   },
   "use_testnet": "True",
   "sandbox_dataset": "crypto_stellar_internal_sandbox",

--- a/airflow_variables_dev.json
+++ b/airflow_variables_dev.json
@@ -257,7 +257,7 @@
     "liquidity_pools_current": "liquidity_pools_current",
     "offers_current": "offers_current",
     "trustlines_current": "trust_lines_current",
-    "ttl": "ttl"
+    "ttl": "ttl_current"
   },
   "use_testnet": "True",
   "sandbox_dataset": "crypto_stellar_internal_sandbox",

--- a/airflow_variables_dev.json
+++ b/airflow_variables_dev.json
@@ -235,8 +235,7 @@
     "contract_data": "contract_data",
     "contract_code": "contract_code",
     "config_settings": "config_settings",
-    "ttl": "ttl",
-    "diagnostic_events": "diagnostic_events"
+    "ttl": "ttl"
   },
   "task_timeout": {
     "build_batch_stats": 180,

--- a/airflow_variables_dev.json
+++ b/airflow_variables_dev.json
@@ -55,7 +55,7 @@
   "dbt_image_name": "stellar/stellar-dbt:6ee7342",
   "dbt_job_execution_timeout_seconds": 300,
   "dbt_job_retries": 1,
-  "dbt_mart_dataset": "test_sdf_marts",
+  "dbt_mart_dataset": "test_crypto_stellar_dbt",
   "dbt_maximum_bytes_billed": 250000000000,
   "dbt_project": "test-hubble-319619",
   "dbt_target": "test",
@@ -251,9 +251,13 @@
   "dbt_tables": {
     "signers_current": "account_signers_current",
     "accounts_current": "accounts_current",
+    "config_settings_current": "config_settings_current",
+    "contract_code_current": "contract_code_current",
+    "contract_data_current": "contract_data_current",
     "liquidity_pools_current": "liquidity_pools_current",
     "offers_current": "offers_current",
-    "trustlines_current": "trust_lines_current"
+    "trustlines_current": "trust_lines_current",
+    "ttl": "ttl"
   },
   "use_testnet": "True",
   "sandbox_dataset": "crypto_stellar_internal_sandbox",

--- a/airflow_variables_prod.json
+++ b/airflow_variables_prod.json
@@ -230,8 +230,7 @@
     "contract_data": "contract_data",
     "contract_code": "contract_code",
     "config_settings": "config_settings",
-    "ttl": "ttl",
-    "diagnostic_events": "diagnostic_events"
+    "ttl": "ttl"
   },
   "task_timeout": {
     "build_batch_stats": 180,

--- a/airflow_variables_prod.json
+++ b/airflow_variables_prod.json
@@ -252,7 +252,7 @@
     "liquidity_pools_current": "liquidity_pools_current",
     "offers_current": "offers_current",
     "trustlines_current": "trust_lines_current",
-    "ttl": "ttl_current"
+    "ttl_current": "ttl_current"
   },
   "use_testnet": "False",
   "sandbox_dataset": "crypto_stellar_internal_sandbox",

--- a/airflow_variables_prod.json
+++ b/airflow_variables_prod.json
@@ -60,7 +60,7 @@
   "dbt_image_name": "stellar/stellar-dbt:6ee7342",
   "dbt_job_execution_timeout_seconds": 1800,
   "dbt_job_retries": 1,
-  "dbt_mart_dataset": "sdf_marts",
+  "dbt_mart_dataset": "crypto_stellar_dbt",
   "dbt_maximum_bytes_billed": 100000000000000,
   "dbt_project": "hubble-261722",
   "dbt_target": "prod",
@@ -246,9 +246,13 @@
   "dbt_tables": {
     "signers_current": "account_signers_current",
     "accounts_current": "accounts_current",
+    "config_settings_current": "config_settings_current",
+    "contract_code_current": "contract_code_current",
+    "contract_data_current": "contract_data_current",
     "liquidity_pools_current": "liquidity_pools_current",
     "offers_current": "offers_current",
-    "trustlines_current": "trust_lines_current"
+    "trustlines_current": "trust_lines_current",
+    "ttl": "ttl"
   },
   "use_testnet": "False",
   "sandbox_dataset": "crypto_stellar_internal_sandbox",

--- a/airflow_variables_prod.json
+++ b/airflow_variables_prod.json
@@ -252,7 +252,7 @@
     "liquidity_pools_current": "liquidity_pools_current",
     "offers_current": "offers_current",
     "trustlines_current": "trust_lines_current",
-    "ttl": "ttl"
+    "ttl": "ttl_current"
   },
   "use_testnet": "False",
   "sandbox_dataset": "crypto_stellar_internal_sandbox",

--- a/dags/history_tables_dag.py
+++ b/dags/history_tables_dag.py
@@ -68,7 +68,7 @@ write_op_stats = build_batch_stats(dag, table_names["operations"])
 write_trade_stats = build_batch_stats(dag, table_names["trades"])
 write_effects_stats = build_batch_stats(dag, table_names["effects"])
 write_tx_stats = build_batch_stats(dag, table_names["transactions"])
-write_diagnostic_events_stats = build_batch_stats(dag, table_names["diagnostic_events"])
+write_diagnostic_events_stats = build_batch_stats(dag, "diagnostic_events")
 write_ledger_stats = build_batch_stats(dag, table_names["ledgers"])
 write_asset_stats = build_batch_stats(dag, table_names["assets"])
 

--- a/dags/queries/create_table.sql
+++ b/dags/queries/create_table.sql
@@ -3,6 +3,7 @@ partition by date_trunc(batch_run_date, day)
 options (partition_expiration_days = 180) as (
     select *
     from `{project_id}.{dataset_id}.{table_id}`
-    where batch_run_date >= date_sub(current_date(), interval 6 month)
-    and batch_run_date < date_sub(current_date())
+    where
+        batch_run_date >= date_sub(current_date(), interval 6 month)
+        and batch_run_date < date_sub(current_date())
 )

--- a/dags/queries/create_table.sql
+++ b/dags/queries/create_table.sql
@@ -5,5 +5,5 @@ options (partition_expiration_days = 180) as (
     from `{project_id}.{dataset_id}.{table_id}`
     where
         batch_run_date >= date_trunc(date_sub(current_date(), interval 6 month), day)
-        and batch_run_date < date_trunc((current_date(), day))
+        and batch_run_date < date_trunc(current_date(), day)
 )

--- a/dags/queries/create_table.sql
+++ b/dags/queries/create_table.sql
@@ -5,5 +5,5 @@ options (partition_expiration_days = 180) as (
     from `{project_id}.{dataset_id}.{table_id}`
     where
         batch_run_date >= date_trunc(date_sub(current_date(), interval 6 month), day)
-        and batch_run_date < date_trunc((current_date(), day)
+        and batch_run_date < date_trunc((current_date(), day))
 )

--- a/dags/queries/create_table.sql
+++ b/dags/queries/create_table.sql
@@ -4,6 +4,6 @@ options (partition_expiration_days = 180) as (
     select *
     from `{project_id}.{dataset_id}.{table_id}`
     where
-        batch_run_date >= date_sub(current_date(), interval 6 month)
-        and batch_run_date < date_sub(current_date())
+        batch_run_date >= date_trunc(date_sub(current_date(), interval 6 month), day)
+        and batch_run_date < date_trunc((current_date(), day)
 )

--- a/dags/queries/create_table.sql
+++ b/dags/queries/create_table.sql
@@ -4,4 +4,5 @@ options (partition_expiration_days = 180) as (
     select *
     from `{project_id}.{dataset_id}.{table_id}`
     where batch_run_date >= date_sub(current_date(), interval 6 month)
+    and batch_run_date < date_sub(current_date())
 )

--- a/dags/queries/update_table.sql
+++ b/dags/queries/update_table.sql
@@ -1,4 +1,4 @@
 insert into {project_id}.{target_dataset}.{table_id}
 select *
 from {project_id}.{dataset_id}.{table_id}
-where date_trunc(batch_run_date, day) = date_trunc({batch_run_date})
+where date_trunc(batch_run_date, day) = date_trunc('{batch_run_date}', day)

--- a/dags/queries/update_table.sql
+++ b/dags/queries/update_table.sql
@@ -1,4 +1,4 @@
 insert into {project_id}.{target_dataset}.{table_id}
 select *
 from {project_id}.{dataset_id}.{table_id}
-where date_trunc(batch_run_date, day) = date_trunc('{batch_run_date}', day)
+where date_trunc(batch_run_date, day) = date_trunc(cast('{batch_run_date}' as datetime), day)

--- a/dags/queries/update_table.sql
+++ b/dags/queries/update_table.sql
@@ -1,4 +1,4 @@
 insert into {project_id}.{target_dataset}.{table_id}
 select *
 from {project_id}.{dataset_id}.{table_id}
-where date_trunc(batch_run_date, day) = date_trunc(current_date() - interval 1 day, day)
+where date_trunc(batch_run_date, day) = date_trunc({batch_run_date})

--- a/dags/sandbox_create_dag.py
+++ b/dags/sandbox_create_dag.py
@@ -1,7 +1,6 @@
 """
 This DAG creates the sandbox dataset with transactions tables, state tables with history and views.
 """
-from datetime import datetime
 from json import loads
 
 from airflow import DAG

--- a/dags/sandbox_create_dag.py
+++ b/dags/sandbox_create_dag.py
@@ -23,7 +23,6 @@ init_sentry()
 with DAG(
     "sandbox_create_dag",
     default_args=get_default_dag_args(),
-    start_date=datetime(2023, 1, 1),
     description="This DAG creates a sandbox",
     schedule_interval="@once",
     params={"alias": "sandbox_dataset"},
@@ -32,8 +31,8 @@ with DAG(
     },
     catchup=False,
 ) as dag:
-    PROJECT = Variable.get("bq_project")
-    DATASET = Variable.get("bq_dataset")
+    PROJECT = Variable.get("public_project")
+    DATASET = Variable.get("public_dataset")
     SANDBOX_DATASET = Variable.get("sandbox_dataset")
     DBT_DATASET = Variable.get("dbt_mart_dataset")
     TABLES_ID = Variable.get("table_ids", deserialize_json=True)

--- a/dags/sandbox_update_dag.py
+++ b/dags/sandbox_update_dag.py
@@ -12,6 +12,7 @@ from stellar_etl_airflow.build_bq_insert_job_task import (
     file_to_string,
     get_query_filepath,
 )
+from stellar_etl_airflow import macros
 from stellar_etl_airflow.build_cross_dependency_task import build_cross_deps
 from stellar_etl_airflow.default import (
     alert_after_max_retries,
@@ -24,22 +25,28 @@ init_sentry()
 with DAG(
     "sandbox_update_dag",
     default_args=get_default_dag_args(),
-    start_date=datetime(2023, 1, 1),
+    start_date=datetime(2024, 4, 30),
     description="This DAG updates a sandbox",
     schedule_interval="0 1 * * *",
     params={"alias": "sandbox_dataset"},
     user_defined_filters={"fromjson": lambda s: loads(s)},
-    catchup=False,
+    catchup=True,
 ) as dag:
     TABLES_ID = Variable.get("table_ids", deserialize_json=True)
     PROJECT = Variable.get("bq_project")
     BQ_DATASET = Variable.get("bq_dataset")
     SANDBOX_DATASET = Variable.get("sandbox_dataset")
 
+    batch_run_date = "{{ batch_run_date_as_datetime_string(dag, data_interval_start) }}"
+
     start_tables_task = EmptyOperator(task_id="start_tables_task")
 
-    wait_on_dag = build_cross_deps(
-        dag, "wait_on_base_tables", "history_archive_with_captive_core_combined_export"
+    wait_on_history_dag = build_cross_deps(
+        dag, "wait_on_base_tables", "history_table_export"
+    )
+
+    wait_on_state_dag = build_cross_deps(
+        dag, "wait_on_base_tables", "state_table_export"
     )
 
     for table_id in TABLES_ID:
@@ -50,6 +57,7 @@ with DAG(
             "dataset_id": BQ_DATASET,
             "table_id": TABLES_ID[table_id],
             "target_dataset": SANDBOX_DATASET,
+            "batch_run_date": batch_run_date
         }
         query = query.format(**sql_params)
         tables_update_task = BigQueryInsertJobOperator(
@@ -63,4 +71,4 @@ with DAG(
             on_failure_callback=alert_after_max_retries,
         )
 
-        start_tables_task >> wait_on_dag >> tables_update_task
+        start_tables_task >> [wait_on_history_dag, wait_on_state_dag] >> tables_update_task

--- a/dags/sandbox_update_dag.py
+++ b/dags/sandbox_update_dag.py
@@ -38,8 +38,8 @@ with DAG(
     },
 ) as dag:
     TABLES_ID = Variable.get("table_ids", deserialize_json=True)
-    PROJECT = Variable.get("bq_project")
-    BQ_DATASET = Variable.get("bq_dataset")
+    PROJECT = Variable.get("public_project")
+    BQ_DATASET = Variable.get("public_dataset")
     SANDBOX_DATASET = Variable.get("sandbox_dataset")
 
     batch_run_date = "{{ batch_run_date_as_datetime_string(dag, data_interval_start) }}"

--- a/dags/sandbox_update_dag.py
+++ b/dags/sandbox_update_dag.py
@@ -30,19 +30,17 @@ with DAG(
     schedule_interval="0 1 * * *",
     params={"alias": "sandbox_dataset"},
     user_defined_filters={"fromjson": lambda s: loads(s)},
+    render_template_as_native_obj=True,
     catchup=True,
+    user_defined_macros={
+        "subtract_data_interval": macros.subtract_data_interval,
+        "batch_run_date_as_datetime_string": macros.batch_run_date_as_datetime_string,
+    },
 ) as dag:
     TABLES_ID = Variable.get("table_ids", deserialize_json=True)
     PROJECT = Variable.get("bq_project")
     BQ_DATASET = Variable.get("bq_dataset")
     SANDBOX_DATASET = Variable.get("sandbox_dataset")
-
-    user_defined_macros = (
-        {
-            "subtract_data_interval": macros.subtract_data_interval,
-            "batch_run_date_as_datetime_string": macros.batch_run_date_as_datetime_string,
-        },
-    )
 
     batch_run_date = "{{ batch_run_date_as_datetime_string(dag, data_interval_start) }}"
 

--- a/dags/sandbox_update_dag.py
+++ b/dags/sandbox_update_dag.py
@@ -37,6 +37,13 @@ with DAG(
     BQ_DATASET = Variable.get("bq_dataset")
     SANDBOX_DATASET = Variable.get("sandbox_dataset")
 
+    user_defined_macros = (
+        {
+            "subtract_data_interval": macros.subtract_data_interval,
+            "batch_run_date_as_datetime_string": macros.batch_run_date_as_datetime_string,
+        },
+    )
+
     batch_run_date = "{{ batch_run_date_as_datetime_string(dag, data_interval_start) }}"
 
     start_tables_task = EmptyOperator(task_id="start_tables_task")

--- a/dags/sandbox_update_dag.py
+++ b/dags/sandbox_update_dag.py
@@ -46,7 +46,7 @@ with DAG(
     )
 
     wait_on_state_dag = build_cross_deps(
-        dag, "wait_on_base_tables", "state_table_export"
+        dag, "wait_on_state_tables", "state_table_export"
     )
 
     for table_id in TABLES_ID:


### PR DESCRIPTION
The `sandbox_update` DAG broke because we changed the name of the upstream DAG that the workflow was dependent on. This PR addresses the name change and refactors the code to be less brittle.

- The DAG originally updated data based on `current_date()`. If the pipeline broke, backfilling missing data required manual intervention. The query is now date parameterized by `batch_start_date` and will backfill missing days because `catchup=True`.
- copy statements pointed to the internal dataset, `hubble-261722.crypto_stellar_internal_2`. Updated the statements to use `crypto-stellar.crypto_stellar`.
- Added the state table DAG as an additional dependency. We missed this

_Note:_ We will probably need to run the `sandbox_create` DAG because the column order on the public tables differ from internal. It'll be easier to just recreate the tables so that the schemas match.

Future considerations:

- add data quality checks 
- use a merge statement to ensure duplicate data is not inserted into the table (alternative is to delete/reinsert)
- utilize [table clone ](https://cloud.google.com/bigquery/docs/table-clones-intro)feature to copy data instead of manually inserting new data via SQL