### PR TITLE
Refactor dags to delete internal sources

### DIFF
--- a/airflow_variables_dev.json
+++ b/airflow_variables_dev.json
@@ -52,7 +52,7 @@
     "partnership_assets__account_holders_activity_fact": false,
     "partnership_assets__asset_activity_fact": false
   },
-  "dbt_image_name": "stellar/stellar-dbt:6ee7342",
+  "dbt_image_name": "stellar/stellar-dbt:f360f91",
   "dbt_job_execution_timeout_seconds": 300,
   "dbt_job_retries": 1,
   "dbt_mart_dataset": "test_crypto_stellar_dbt",

--- a/airflow_variables_prod.json
+++ b/airflow_variables_prod.json
@@ -57,7 +57,7 @@
     "partnership_assets__asset_activity_fact": false,
     "trade_agg": false
   },
-  "dbt_image_name": "stellar/stellar-dbt:6ee7342",
+  "dbt_image_name": "stellar/stellar-dbt:f360f91",
   "dbt_job_execution_timeout_seconds": 1800,
   "dbt_job_retries": 1,
   "dbt_mart_dataset": "crypto_stellar_dbt",

--- a/dags/history_tables_dag.py
+++ b/dags/history_tables_dag.py
@@ -6,7 +6,6 @@ from ast import literal_eval
 from datetime import datetime
 from json import loads
 
-
 from airflow import DAG
 from airflow.models.variable import Variable
 from kubernetes.client import models as k8s
@@ -20,30 +19,29 @@ from stellar_etl_airflow.build_gcs_to_bq_task import build_gcs_to_bq_task
 from stellar_etl_airflow.build_time_task import build_time_task
 from stellar_etl_airflow.default import get_default_dag_args, init_sentry
 
-
 init_sentry()
 
 
 dag = DAG(
-   "history_table_export",
-   default_args=get_default_dag_args(),
-   start_date=datetime(2024, 4, 23, 15, 0),
-   catchup=True,
-   description="This DAG exports trades and operations from the history archive using CaptiveCore. This supports parsing sponsorship and AMMs.",
-   schedule_interval="*/10 * * * *",
-   params={
-       "alias": "cc",
-   },
-   render_template_as_native_obj=True,
-   user_defined_filters={
-       "fromjson": lambda s: loads(s),
-       "container_resources": lambda s: k8s.V1ResourceRequirements(requests=s),
-       "literal_eval": lambda e: literal_eval(e),
-   },
-   user_defined_macros={
-       "subtract_data_interval": macros.subtract_data_interval,
-       "batch_run_date_as_datetime_string": macros.batch_run_date_as_datetime_string,
-   },
+    "history_table_export",
+    default_args=get_default_dag_args(),
+    start_date=datetime(2024, 4, 23, 15, 0),
+    catchup=True,
+    description="This DAG exports trades and operations from the history archive using CaptiveCore. This supports parsing sponsorship and AMMs.",
+    schedule_interval="*/10 * * * *",
+    params={
+        "alias": "cc",
+    },
+    render_template_as_native_obj=True,
+    user_defined_filters={
+        "fromjson": lambda s: loads(s),
+        "container_resources": lambda s: k8s.V1ResourceRequirements(requests=s),
+        "literal_eval": lambda e: literal_eval(e),
+    },
+    user_defined_macros={
+        "subtract_data_interval": macros.subtract_data_interval,
+        "batch_run_date_as_datetime_string": macros.batch_run_date_as_datetime_string,
+    },
 )
 
 
@@ -90,81 +88,81 @@ script time to copy the file over to the correct directory. If there is no sleep
 starts prematurely and will not load data.
 """
 op_export_task = build_export_task(
-   dag,
-   "archive",
-   "export_operations",
-   "{{ var.json.output_file_names.operations }}",
-   use_testnet=use_testnet,
-   use_futurenet=use_futurenet,
-   use_gcs=True,
-   use_captive_core=use_captive_core,
-   txmeta_datastore_url=txmeta_datastore_url,
+    dag,
+    "archive",
+    "export_operations",
+    "{{ var.json.output_file_names.operations }}",
+    use_testnet=use_testnet,
+    use_futurenet=use_futurenet,
+    use_gcs=True,
+    use_captive_core=use_captive_core,
+    txmeta_datastore_url=txmeta_datastore_url,
 )
 trade_export_task = build_export_task(
-   dag,
-   "archive",
-   "export_trades",
-   "{{ var.json.output_file_names.trades }}",
-   use_testnet=use_testnet,
-   use_futurenet=use_futurenet,
-   use_gcs=True,
-   use_captive_core=use_captive_core,
-   txmeta_datastore_url=txmeta_datastore_url,
+    dag,
+    "archive",
+    "export_trades",
+    "{{ var.json.output_file_names.trades }}",
+    use_testnet=use_testnet,
+    use_futurenet=use_futurenet,
+    use_gcs=True,
+    use_captive_core=use_captive_core,
+    txmeta_datastore_url=txmeta_datastore_url,
 )
 effects_export_task = build_export_task(
-   dag,
-   "archive",
-   "export_effects",
-   "effects.txt",
-   use_testnet=use_testnet,
-   use_futurenet=use_futurenet,
-   use_gcs=True,
-   use_captive_core=use_captive_core,
-   txmeta_datastore_url=txmeta_datastore_url,
+    dag,
+    "archive",
+    "export_effects",
+    "effects.txt",
+    use_testnet=use_testnet,
+    use_futurenet=use_futurenet,
+    use_gcs=True,
+    use_captive_core=use_captive_core,
+    txmeta_datastore_url=txmeta_datastore_url,
 )
 tx_export_task = build_export_task(
-   dag,
-   "archive",
-   "export_transactions",
-   "{{ var.json.output_file_names.transactions }}",
-   use_testnet=use_testnet,
-   use_futurenet=use_futurenet,
-   use_gcs=True,
-   use_captive_core=use_captive_core,
-   txmeta_datastore_url=txmeta_datastore_url,
+    dag,
+    "archive",
+    "export_transactions",
+    "{{ var.json.output_file_names.transactions }}",
+    use_testnet=use_testnet,
+    use_futurenet=use_futurenet,
+    use_gcs=True,
+    use_captive_core=use_captive_core,
+    txmeta_datastore_url=txmeta_datastore_url,
 )
 diagnostic_events_export_task = build_export_task(
-   dag,
-   "archive",
-   "export_diagnostic_events",
-   "{{ var.json.output_file_names.diagnostic_events }}",
-   use_testnet=use_testnet,
-   use_futurenet=use_futurenet,
-   use_gcs=True,
-   use_captive_core=use_captive_core,
-   txmeta_datastore_url=txmeta_datastore_url,
+    dag,
+    "archive",
+    "export_diagnostic_events",
+    "{{ var.json.output_file_names.diagnostic_events }}",
+    use_testnet=use_testnet,
+    use_futurenet=use_futurenet,
+    use_gcs=True,
+    use_captive_core=use_captive_core,
+    txmeta_datastore_url=txmeta_datastore_url,
 )
 ledger_export_task = build_export_task(
-   dag,
-   "archive",
-   "export_ledgers",
-   "{{ var.json.output_file_names.ledgers }}",
-   use_testnet=use_testnet,
-   use_futurenet=use_futurenet,
-   use_gcs=True,
-   use_captive_core=use_captive_core,
-   txmeta_datastore_url=txmeta_datastore_url,
+    dag,
+    "archive",
+    "export_ledgers",
+    "{{ var.json.output_file_names.ledgers }}",
+    use_testnet=use_testnet,
+    use_futurenet=use_futurenet,
+    use_gcs=True,
+    use_captive_core=use_captive_core,
+    txmeta_datastore_url=txmeta_datastore_url,
 )
 asset_export_task = build_export_task(
-   dag,
-   "archive",
-   "export_assets",
-   "{{ var.json.output_file_names.assets }}",
-   use_testnet=use_testnet,
-   use_futurenet=use_futurenet,
-   use_gcs=True,
-   use_captive_core=use_captive_core,
-   txmeta_datastore_url=txmeta_datastore_url,
+    dag,
+    "archive",
+    "export_assets",
+    "{{ var.json.output_file_names.assets }}",
+    use_testnet=use_testnet,
+    use_futurenet=use_futurenet,
+    use_gcs=True,
+    use_captive_core=use_captive_core,
+    txmeta_datastore_url=txmeta_datastore_url,
 )
 
 
@@ -175,42 +173,42 @@ Bigquery. If it does, the records are deleted prior to reinserting the batch.
 
 
 delete_old_op_pub_task = build_delete_data_task(
-   dag, public_project, public_dataset, table_names["operations"], "pub"
+    dag, public_project, public_dataset, table_names["operations"], "pub"
 )
 
 
 delete_old_trade_pub_task = build_delete_data_task(
-   dag, public_project, public_dataset, table_names["trades"], "pub"
+    dag, public_project, public_dataset, table_names["trades"], "pub"
 )
 
 
 delete_enrich_op_pub_task = build_delete_data_task(
-   dag,
-   public_project,
-   public_dataset,
-   "enriched_history_operations",
-   "pub",
+    dag,
+    public_project,
+    public_dataset,
+    "enriched_history_operations",
+    "pub",
 )
 
 
 delete_old_effects_pub_task = build_delete_data_task(
-   dag, public_project, public_dataset, table_names["effects"], "pub"
+    dag, public_project, public_dataset, table_names["effects"], "pub"
 )
 
 
 delete_old_tx_pub_task = build_delete_data_task(
-   dag, public_project, public_dataset, table_names["transactions"], "pub"
+    dag, public_project, public_dataset, table_names["transactions"], "pub"
 )
 
 
 delete_old_ledger_pub_task = build_delete_data_task(
-   dag, public_project, public_dataset, table_names["ledgers"], "pub"
+    dag, public_project, public_dataset, table_names["ledgers"], "pub"
 )
 delete_old_asset_task = build_delete_data_task(
-   dag, internal_project, internal_dataset, table_names["assets"]
+    dag, internal_project, internal_dataset, table_names["assets"]
 )
 delete_old_asset_pub_task = build_delete_data_task(
-   dag, public_project, public_dataset, table_names["assets"], "pub"
+    dag, public_project, public_dataset, table_names["assets"], "pub"
 )
 
 
@@ -219,14 +217,14 @@ The send tasks receive the location of the file in Google Cloud storage through 
 Then, the task merges the unique entries in the file into the corresponding table in BigQuery.
 """
 send_assets_to_bq_task = build_gcs_to_bq_task(
-   dag,
-   asset_export_task.task_id,
-   internal_project,
-   internal_dataset,
-   table_names["assets"],
-   "",
-   partition=True,
-   cluster=True,
+    dag,
+    asset_export_task.task_id,
+    internal_project,
+    internal_dataset,
+    table_names["assets"],
+    "",
+    partition=True,
+    cluster=True,
 )
 
 
@@ -234,167 +232,167 @@ send_assets_to_bq_task = build_gcs_to_bq_task(
 Load final public dataset, crypto-stellar
 """
 send_ops_to_pub_task = build_gcs_to_bq_task(
-   dag,
-   op_export_task.task_id,
-   public_project,
-   public_dataset,
-   table_names["operations"],
-   "",
-   partition=True,
-   cluster=True,
-   dataset_type="pub",
+    dag,
+    op_export_task.task_id,
+    public_project,
+    public_dataset,
+    table_names["operations"],
+    "",
+    partition=True,
+    cluster=True,
+    dataset_type="pub",
 )
 send_trades_to_pub_task = build_gcs_to_bq_task(
-   dag,
-   trade_export_task.task_id,
-   public_project,
-   public_dataset,
-   table_names["trades"],
-   "",
-   partition=True,
-   cluster=True,
-   dataset_type="pub",
+    dag,
+    trade_export_task.task_id,
+    public_project,
+    public_dataset,
+    table_names["trades"],
+    "",
+    partition=True,
+    cluster=True,
+    dataset_type="pub",
 )
 send_effects_to_pub_task = build_gcs_to_bq_task(
-   dag,
-   effects_export_task.task_id,
-   public_project,
-   public_dataset,
-   table_names["effects"],
-   "",
-   partition=True,
-   cluster=True,
-   dataset_type="pub",
+    dag,
+    effects_export_task.task_id,
+    public_project,
+    public_dataset,
+    table_names["effects"],
+    "",
+    partition=True,
+    cluster=True,
+    dataset_type="pub",
 )
 send_txs_to_pub_task = build_gcs_to_bq_task(
-   dag,
-   tx_export_task.task_id,
-   public_project,
-   public_dataset,
-   table_names["transactions"],
-   "",
-   partition=True,
-   cluster=True,
-   dataset_type="pub",
+    dag,
+    tx_export_task.task_id,
+    public_project,
+    public_dataset,
+    table_names["transactions"],
+    "",
+    partition=True,
+    cluster=True,
+    dataset_type="pub",
 )
 send_ledgers_to_pub_task = build_gcs_to_bq_task(
-   dag,
-   ledger_export_task.task_id,
-   public_project,
-   public_dataset,
-   table_names["ledgers"],
-   "",
-   partition=True,
-   cluster=True,
-   dataset_type="pub",
+    dag,
+    ledger_export_task.task_id,
+    public_project,
+    public_dataset,
+    table_names["ledgers"],
+    "",
+    partition=True,
+    cluster=True,
+    dataset_type="pub",
 )
 
 
 send_assets_to_pub_task = build_gcs_to_bq_task(
-   dag,
-   asset_export_task.task_id,
-   public_project,
-   public_dataset,
-   table_names["assets"],
-   "",
-   partition=True,
-   cluster=True,
-   dataset_type="pub",
+    dag,
+    asset_export_task.task_id,
+    public_project,
+    public_dataset,
+    table_names["assets"],
+    "",
+    partition=True,
+    cluster=True,
+    dataset_type="pub",
 )
 
 
 insert_enriched_hist_pub_task = build_bq_insert_job(
-   dag,
-   public_project,
-   public_dataset,
-   "enriched_history_operations",
-   partition=True,
-   cluster=True,
-   dataset_type="pub",
+    dag,
+    public_project,
+    public_dataset,
+    "enriched_history_operations",
+    partition=True,
+    cluster=True,
+    dataset_type="pub",
 )
 
 
 (
-   time_task
-   >> write_op_stats
-   >> op_export_task
-   >> delete_old_op_pub_task
-   >> send_ops_to_pub_task
-   >> delete_enrich_op_pub_task
-   >> insert_enriched_hist_pub_task
+    time_task
+    >> write_op_stats
+    >> op_export_task
+    >> delete_old_op_pub_task
+    >> send_ops_to_pub_task
+    >> delete_enrich_op_pub_task
+    >> insert_enriched_hist_pub_task
 )
 
 
 (
-   time_task
-   >> write_trade_stats
-   >> trade_export_task
-   >> delete_old_trade_pub_task
-   >> send_trades_to_pub_task
+    time_task
+    >> write_trade_stats
+    >> trade_export_task
+    >> delete_old_trade_pub_task
+    >> send_trades_to_pub_task
 )
 
 
 (
-   time_task
-   >> write_effects_stats
-   >> effects_export_task
-   >> delete_old_effects_pub_task
-   >> send_effects_to_pub_task
+    time_task
+    >> write_effects_stats
+    >> effects_export_task
+    >> delete_old_effects_pub_task
+    >> send_effects_to_pub_task
 )
 
 
 (
-   time_task
-   >> write_tx_stats
-   >> tx_export_task
-   >> delete_old_tx_pub_task
-   >> send_txs_to_pub_task
-   >> delete_enrich_op_pub_task
+    time_task
+    >> write_tx_stats
+    >> tx_export_task
+    >> delete_old_tx_pub_task
+    >> send_txs_to_pub_task
+    >> delete_enrich_op_pub_task
 )
 (time_task >> write_diagnostic_events_stats >> diagnostic_events_export_task)
 (
-   [
-       insert_enriched_hist_pub_task,
-   ]
+    [
+        insert_enriched_hist_pub_task,
+    ]
 )
 dedup_assets_bq_task = build_bq_insert_job(
-   dag,
-   internal_project,
-   internal_dataset,
-   table_names["assets"],
-   partition=True,
-   cluster=True,
-   create=True,
+    dag,
+    internal_project,
+    internal_dataset,
+    table_names["assets"],
+    partition=True,
+    cluster=True,
+    create=True,
 )
 dedup_assets_pub_task = build_bq_insert_job(
-   dag,
-   public_project,
-   public_dataset,
-   table_names["assets"],
-   partition=True,
-   cluster=True,
-   create=True,
-   dataset_type="pub",
+    dag,
+    public_project,
+    public_dataset,
+    table_names["assets"],
+    partition=True,
+    cluster=True,
+    create=True,
+    dataset_type="pub",
 )
 (
-   time_task
-   >> write_ledger_stats
-   >> ledger_export_task
-   >> delete_old_ledger_pub_task
-   >> send_ledgers_to_pub_task
-   >> delete_enrich_op_pub_task
+    time_task
+    >> write_ledger_stats
+    >> ledger_export_task
+    >> delete_old_ledger_pub_task
+    >> send_ledgers_to_pub_task
+    >> delete_enrich_op_pub_task
 )
 (
-   time_task
-   >> write_asset_stats
-   >> asset_export_task
-   >> delete_old_asset_task
-   >> send_assets_to_bq_task
-   >> dedup_assets_bq_task
+    time_task
+    >> write_asset_stats
+    >> asset_export_task
+    >> delete_old_asset_task
+    >> send_assets_to_bq_task
+    >> dedup_assets_bq_task
 )
 (
-   asset_export_task
-   >> delete_old_asset_pub_task
-   >> send_assets_to_pub_task
-   >> dedup_assets_pub_task
+    asset_export_task
+    >> delete_old_asset_pub_task
+    >> send_assets_to_pub_task
+    >> dedup_assets_pub_task
 )

--- a/dags/history_tables_dag.py
+++ b/dags/history_tables_dag.py
@@ -6,6 +6,7 @@ from ast import literal_eval
 from datetime import datetime
 from json import loads
 
+
 from airflow import DAG
 from airflow.models.variable import Variable
 from kubernetes.client import models as k8s
@@ -19,29 +20,32 @@ from stellar_etl_airflow.build_gcs_to_bq_task import build_gcs_to_bq_task
 from stellar_etl_airflow.build_time_task import build_time_task
 from stellar_etl_airflow.default import get_default_dag_args, init_sentry
 
+
 init_sentry()
 
+
 dag = DAG(
-    "history_table_export",
-    default_args=get_default_dag_args(),
-    start_date=datetime(2024, 4, 23, 15, 0),
-    catchup=True,
-    description="This DAG exports trades and operations from the history archive using CaptiveCore. This supports parsing sponsorship and AMMs.",
-    schedule_interval="*/10 * * * *",
-    params={
-        "alias": "cc",
-    },
-    render_template_as_native_obj=True,
-    user_defined_filters={
-        "fromjson": lambda s: loads(s),
-        "container_resources": lambda s: k8s.V1ResourceRequirements(requests=s),
-        "literal_eval": lambda e: literal_eval(e),
-    },
-    user_defined_macros={
-        "subtract_data_interval": macros.subtract_data_interval,
-        "batch_run_date_as_datetime_string": macros.batch_run_date_as_datetime_string,
-    },
+   "history_table_export",
+   default_args=get_default_dag_args(),
+   start_date=datetime(2024, 4, 23, 15, 0),
+   catchup=True,
+   description="This DAG exports trades and operations from the history archive using CaptiveCore. This supports parsing sponsorship and AMMs.",
+   schedule_interval="*/10 * * * *",
+   params={
+       "alias": "cc",
+   },
+   render_template_as_native_obj=True,
+   user_defined_filters={
+       "fromjson": lambda s: loads(s),
+       "container_resources": lambda s: k8s.V1ResourceRequirements(requests=s),
+       "literal_eval": lambda e: literal_eval(e),
+   },
+   user_defined_macros={
+       "subtract_data_interval": macros.subtract_data_interval,
+       "batch_run_date_as_datetime_string": macros.batch_run_date_as_datetime_string,
+   },
 )
+
 
 table_names = Variable.get("table_ids", deserialize_json=True)
 internal_project = "{{ var.value.bq_project }}"
@@ -53,11 +57,13 @@ use_futurenet = literal_eval(Variable.get("use_futurenet"))
 use_captive_core = literal_eval(Variable.get("use_captive_core"))
 txmeta_datastore_url = "{{ var.value.txmeta_datastore_url }}"
 
+
 """
 The time task reads in the execution time of the current run, as well as the next
 execution time. It converts these two times into ledger ranges.
 """
 time_task = build_time_task(dag, use_testnet=use_testnet, use_futurenet=use_futurenet)
+
 
 """
 The write batch stats task will take a snapshot of the DAG run_id, execution date,
@@ -72,206 +78,155 @@ write_diagnostic_events_stats = build_batch_stats(dag, "diagnostic_events")
 write_ledger_stats = build_batch_stats(dag, table_names["ledgers"])
 write_asset_stats = build_batch_stats(dag, table_names["assets"])
 
+
 """
 The export tasks call export commands on the Stellar ETL using the ledger range from the time task.
 The results of the command are stored in a file. There is one task for each of the data types that
 can be exported from the history archives.
+
 
 The DAG sleeps for 30 seconds after the export_task writes to the file to give the poststart.sh
 script time to copy the file over to the correct directory. If there is no sleep, the load task
 starts prematurely and will not load data.
 """
 op_export_task = build_export_task(
-    dag,
-    "archive",
-    "export_operations",
-    "{{ var.json.output_file_names.operations }}",
-    use_testnet=use_testnet,
-    use_futurenet=use_futurenet,
-    use_gcs=True,
-    use_captive_core=use_captive_core,
-    txmeta_datastore_url=txmeta_datastore_url,
+   dag,
+   "archive",
+   "export_operations",
+   "{{ var.json.output_file_names.operations }}",
+   use_testnet=use_testnet,
+   use_futurenet=use_futurenet,
+   use_gcs=True,
+   use_captive_core=use_captive_core,
+   txmeta_datastore_url=txmeta_datastore_url,
 )
 trade_export_task = build_export_task(
-    dag,
-    "archive",
-    "export_trades",
-    "{{ var.json.output_file_names.trades }}",
-    use_testnet=use_testnet,
-    use_futurenet=use_futurenet,
-    use_gcs=True,
-    use_captive_core=use_captive_core,
-    txmeta_datastore_url=txmeta_datastore_url,
+   dag,
+   "archive",
+   "export_trades",
+   "{{ var.json.output_file_names.trades }}",
+   use_testnet=use_testnet,
+   use_futurenet=use_futurenet,
+   use_gcs=True,
+   use_captive_core=use_captive_core,
+   txmeta_datastore_url=txmeta_datastore_url,
 )
 effects_export_task = build_export_task(
-    dag,
-    "archive",
-    "export_effects",
-    "effects.txt",
-    use_testnet=use_testnet,
-    use_futurenet=use_futurenet,
-    use_gcs=True,
-    use_captive_core=use_captive_core,
-    txmeta_datastore_url=txmeta_datastore_url,
+   dag,
+   "archive",
+   "export_effects",
+   "effects.txt",
+   use_testnet=use_testnet,
+   use_futurenet=use_futurenet,
+   use_gcs=True,
+   use_captive_core=use_captive_core,
+   txmeta_datastore_url=txmeta_datastore_url,
 )
 tx_export_task = build_export_task(
-    dag,
-    "archive",
-    "export_transactions",
-    "{{ var.json.output_file_names.transactions }}",
-    use_testnet=use_testnet,
-    use_futurenet=use_futurenet,
-    use_gcs=True,
-    use_captive_core=use_captive_core,
-    txmeta_datastore_url=txmeta_datastore_url,
+   dag,
+   "archive",
+   "export_transactions",
+   "{{ var.json.output_file_names.transactions }}",
+   use_testnet=use_testnet,
+   use_futurenet=use_futurenet,
+   use_gcs=True,
+   use_captive_core=use_captive_core,
+   txmeta_datastore_url=txmeta_datastore_url,
 )
 diagnostic_events_export_task = build_export_task(
-    dag,
-    "archive",
-    "export_diagnostic_events",
-    "{{ var.json.output_file_names.diagnostic_events }}",
-    use_testnet=use_testnet,
-    use_futurenet=use_futurenet,
-    use_gcs=True,
-    use_captive_core=use_captive_core,
-    txmeta_datastore_url=txmeta_datastore_url,
+   dag,
+   "archive",
+   "export_diagnostic_events",
+   "{{ var.json.output_file_names.diagnostic_events }}",
+   use_testnet=use_testnet,
+   use_futurenet=use_futurenet,
+   use_gcs=True,
+   use_captive_core=use_captive_core,
+   txmeta_datastore_url=txmeta_datastore_url,
 )
 ledger_export_task = build_export_task(
-    dag,
-    "archive",
-    "export_ledgers",
-    "{{ var.json.output_file_names.ledgers }}",
-    use_testnet=use_testnet,
-    use_futurenet=use_futurenet,
-    use_gcs=True,
-    use_captive_core=use_captive_core,
-    txmeta_datastore_url=txmeta_datastore_url,
+   dag,
+   "archive",
+   "export_ledgers",
+   "{{ var.json.output_file_names.ledgers }}",
+   use_testnet=use_testnet,
+   use_futurenet=use_futurenet,
+   use_gcs=True,
+   use_captive_core=use_captive_core,
+   txmeta_datastore_url=txmeta_datastore_url,
 )
 asset_export_task = build_export_task(
-    dag,
-    "archive",
-    "export_assets",
-    "{{ var.json.output_file_names.assets }}",
-    use_testnet=use_testnet,
-    use_futurenet=use_futurenet,
-    use_gcs=True,
-    use_captive_core=use_captive_core,
-    txmeta_datastore_url=txmeta_datastore_url,
+   dag,
+   "archive",
+   "export_assets",
+   "{{ var.json.output_file_names.assets }}",
+   use_testnet=use_testnet,
+   use_futurenet=use_futurenet,
+   use_gcs=True,
+   use_captive_core=use_captive_core,
+   txmeta_datastore_url=txmeta_datastore_url,
 )
+
 
 """
 The delete partition task checks to see if the given partition/batch id exists in
 Bigquery. If it does, the records are deleted prior to reinserting the batch.
 """
-delete_old_op_task = build_delete_data_task(
-    dag, internal_project, internal_dataset, table_names["operations"]
-)
+
+
 delete_old_op_pub_task = build_delete_data_task(
-    dag, public_project, public_dataset, table_names["operations"], "pub"
+   dag, public_project, public_dataset, table_names["operations"], "pub"
 )
-delete_old_trade_task = build_delete_data_task(
-    dag, internal_project, internal_dataset, table_names["trades"]
-)
+
+
 delete_old_trade_pub_task = build_delete_data_task(
-    dag, public_project, public_dataset, table_names["trades"], "pub"
+   dag, public_project, public_dataset, table_names["trades"], "pub"
 )
-delete_enrich_op_task = build_delete_data_task(
-    dag, internal_project, internal_dataset, "enriched_history_operations"
-)
+
+
 delete_enrich_op_pub_task = build_delete_data_task(
-    dag, public_project, public_dataset, "enriched_history_operations", "pub"
+   dag,
+   public_project,
+   public_dataset,
+   "enriched_history_operations",
+   "pub",
 )
-delete_enrich_ma_op_task = build_delete_data_task(
-    dag, internal_project, internal_dataset, "enriched_meaningful_history_operations"
-)
-delete_old_effects_task = build_delete_data_task(
-    dag, internal_project, internal_dataset, table_names["effects"]
-)
+
+
 delete_old_effects_pub_task = build_delete_data_task(
-    dag, public_project, public_dataset, table_names["effects"], "pub"
+   dag, public_project, public_dataset, table_names["effects"], "pub"
 )
-delete_old_tx_task = build_delete_data_task(
-    dag, internal_project, internal_dataset, table_names["transactions"]
-)
+
+
 delete_old_tx_pub_task = build_delete_data_task(
-    dag, public_project, public_dataset, table_names["transactions"], "pub"
+   dag, public_project, public_dataset, table_names["transactions"], "pub"
 )
-delete_old_ledger_task = build_delete_data_task(
-    dag, internal_project, internal_dataset, table_names["ledgers"]
-)
+
+
 delete_old_ledger_pub_task = build_delete_data_task(
-    dag, public_project, public_dataset, table_names["ledgers"], "pub"
+   dag, public_project, public_dataset, table_names["ledgers"], "pub"
 )
 delete_old_asset_task = build_delete_data_task(
-    dag, internal_project, internal_dataset, table_names["assets"]
+   dag, internal_project, internal_dataset, table_names["assets"]
 )
 delete_old_asset_pub_task = build_delete_data_task(
-    dag, public_project, public_dataset, table_names["assets"], "pub"
+   dag, public_project, public_dataset, table_names["assets"], "pub"
 )
+
 
 """
 The send tasks receive the location of the file in Google Cloud storage through Airflow's XCOM system.
 Then, the task merges the unique entries in the file into the corresponding table in BigQuery.
 """
-send_ops_to_bq_task = build_gcs_to_bq_task(
-    dag,
-    op_export_task.task_id,
-    internal_project,
-    internal_dataset,
-    table_names["operations"],
-    "",
-    partition=True,
-    cluster=True,
-)
-send_trades_to_bq_task = build_gcs_to_bq_task(
-    dag,
-    trade_export_task.task_id,
-    internal_project,
-    internal_dataset,
-    table_names["trades"],
-    "",
-    partition=True,
-    cluster=True,
-)
-send_effects_to_bq_task = build_gcs_to_bq_task(
-    dag,
-    effects_export_task.task_id,
-    internal_project,
-    internal_dataset,
-    table_names["effects"],
-    "",
-    partition=True,
-    cluster=True,
-)
-send_txs_to_bq_task = build_gcs_to_bq_task(
-    dag,
-    tx_export_task.task_id,
-    internal_project,
-    internal_dataset,
-    table_names["transactions"],
-    "",
-    partition=True,
-    cluster=True,
-)
-send_ledgers_to_bq_task = build_gcs_to_bq_task(
-    dag,
-    ledger_export_task.task_id,
-    internal_project,
-    internal_dataset,
-    table_names["ledgers"],
-    "",
-    partition=True,
-    cluster=True,
-)
 send_assets_to_bq_task = build_gcs_to_bq_task(
-    dag,
-    asset_export_task.task_id,
-    internal_project,
-    internal_dataset,
-    table_names["assets"],
-    "",
-    partition=True,
-    cluster=True,
+   dag,
+   asset_export_task.task_id,
+   internal_project,
+   internal_dataset,
+   table_names["assets"],
+   "",
+   partition=True,
+   cluster=True,
 )
 
 
@@ -279,201 +234,167 @@ send_assets_to_bq_task = build_gcs_to_bq_task(
 Load final public dataset, crypto-stellar
 """
 send_ops_to_pub_task = build_gcs_to_bq_task(
-    dag,
-    op_export_task.task_id,
-    public_project,
-    public_dataset,
-    table_names["operations"],
-    "",
-    partition=True,
-    cluster=True,
-    dataset_type="pub",
+   dag,
+   op_export_task.task_id,
+   public_project,
+   public_dataset,
+   table_names["operations"],
+   "",
+   partition=True,
+   cluster=True,
+   dataset_type="pub",
 )
 send_trades_to_pub_task = build_gcs_to_bq_task(
-    dag,
-    trade_export_task.task_id,
-    public_project,
-    public_dataset,
-    table_names["trades"],
-    "",
-    partition=True,
-    cluster=True,
-    dataset_type="pub",
+   dag,
+   trade_export_task.task_id,
+   public_project,
+   public_dataset,
+   table_names["trades"],
+   "",
+   partition=True,
+   cluster=True,
+   dataset_type="pub",
 )
 send_effects_to_pub_task = build_gcs_to_bq_task(
-    dag,
-    effects_export_task.task_id,
-    public_project,
-    public_dataset,
-    table_names["effects"],
-    "",
-    partition=True,
-    cluster=True,
-    dataset_type="pub",
+   dag,
+   effects_export_task.task_id,
+   public_project,
+   public_dataset,
+   table_names["effects"],
+   "",
+   partition=True,
+   cluster=True,
+   dataset_type="pub",
 )
 send_txs_to_pub_task = build_gcs_to_bq_task(
-    dag,
-    tx_export_task.task_id,
-    public_project,
-    public_dataset,
-    table_names["transactions"],
-    "",
-    partition=True,
-    cluster=True,
-    dataset_type="pub",
+   dag,
+   tx_export_task.task_id,
+   public_project,
+   public_dataset,
+   table_names["transactions"],
+   "",
+   partition=True,
+   cluster=True,
+   dataset_type="pub",
 )
 send_ledgers_to_pub_task = build_gcs_to_bq_task(
-    dag,
-    ledger_export_task.task_id,
-    public_project,
-    public_dataset,
-    table_names["ledgers"],
-    "",
-    partition=True,
-    cluster=True,
-    dataset_type="pub",
+   dag,
+   ledger_export_task.task_id,
+   public_project,
+   public_dataset,
+   table_names["ledgers"],
+   "",
+   partition=True,
+   cluster=True,
+   dataset_type="pub",
 )
+
+
 send_assets_to_pub_task = build_gcs_to_bq_task(
-    dag,
-    asset_export_task.task_id,
-    public_project,
-    public_dataset,
-    table_names["assets"],
-    "",
-    partition=True,
-    cluster=True,
-    dataset_type="pub",
+   dag,
+   asset_export_task.task_id,
+   public_project,
+   public_dataset,
+   table_names["assets"],
+   "",
+   partition=True,
+   cluster=True,
+   dataset_type="pub",
 )
 
-insert_enriched_hist_task = build_bq_insert_job(
-    dag,
-    internal_project,
-    internal_dataset,
-    "enriched_history_operations",
-    partition=True,
-    cluster=True,
-)
+
 insert_enriched_hist_pub_task = build_bq_insert_job(
-    dag,
-    public_project,
-    public_dataset,
-    "enriched_history_operations",
-    partition=True,
-    cluster=True,
-    dataset_type="pub",
-)
-insert_enriched_ma_hist_task = build_bq_insert_job(
-    dag,
-    internal_project,
-    internal_dataset,
-    "enriched_meaningful_history_operations",
-    partition=True,
-    cluster=True,
+   dag,
+   public_project,
+   public_dataset,
+   "enriched_history_operations",
+   partition=True,
+   cluster=True,
+   dataset_type="pub",
 )
 
+
 (
-    time_task
-    >> write_op_stats
-    >> op_export_task
-    >> delete_old_op_task
-    >> send_ops_to_bq_task
-    >> delete_enrich_op_task
+   time_task
+   >> write_op_stats
+   >> op_export_task
+   >> delete_old_op_pub_task
+   >> send_ops_to_pub_task
+   >> delete_enrich_op_pub_task
+   >> insert_enriched_hist_pub_task
 )
+
+
 (
-    delete_enrich_op_task
-    >> insert_enriched_hist_task
-    >> delete_enrich_ma_op_task
-    >> insert_enriched_ma_hist_task
+   time_task
+   >> write_trade_stats
+   >> trade_export_task
+   >> delete_old_trade_pub_task
+   >> send_trades_to_pub_task
 )
+
+
 (
-    op_export_task
-    >> delete_old_op_pub_task
-    >> send_ops_to_pub_task
-    >> delete_enrich_op_pub_task
-    >> insert_enriched_hist_pub_task
+   time_task
+   >> write_effects_stats
+   >> effects_export_task
+   >> delete_old_effects_pub_task
+   >> send_effects_to_pub_task
 )
+
+
 (
-    time_task
-    >> write_trade_stats
-    >> trade_export_task
-    >> delete_old_trade_task
-    >> send_trades_to_bq_task
-)
-trade_export_task >> delete_old_trade_pub_task >> send_trades_to_pub_task
-(
-    time_task
-    >> write_effects_stats
-    >> effects_export_task
-    >> delete_old_effects_task
-    >> send_effects_to_bq_task
-)
-effects_export_task >> delete_old_effects_pub_task >> send_effects_to_pub_task
-(
-    time_task
-    >> write_tx_stats
-    >> tx_export_task
-    >> delete_old_tx_task
-    >> send_txs_to_bq_task
-    >> delete_enrich_op_task
-)
-(
-    tx_export_task
-    >> delete_old_tx_pub_task
-    >> send_txs_to_pub_task
-    >> delete_enrich_op_pub_task
+   time_task
+   >> write_tx_stats
+   >> tx_export_task
+   >> delete_old_tx_pub_task
+   >> send_txs_to_pub_task
+   >> delete_enrich_op_pub_task
 )
 (time_task >> write_diagnostic_events_stats >> diagnostic_events_export_task)
 (
-    [
-        insert_enriched_hist_pub_task,
-        insert_enriched_hist_task,
-    ]
+   [
+       insert_enriched_hist_pub_task,
+   ]
 )
 dedup_assets_bq_task = build_bq_insert_job(
-    dag,
-    internal_project,
-    internal_dataset,
-    table_names["assets"],
-    partition=True,
-    cluster=True,
-    create=True,
+   dag,
+   internal_project,
+   internal_dataset,
+   table_names["assets"],
+   partition=True,
+   cluster=True,
+   create=True,
 )
 dedup_assets_pub_task = build_bq_insert_job(
-    dag,
-    public_project,
-    public_dataset,
-    table_names["assets"],
-    partition=True,
-    cluster=True,
-    create=True,
-    dataset_type="pub",
-)
-
-(
-    time_task
-    >> write_ledger_stats
-    >> ledger_export_task
-    >> delete_old_ledger_task
-    >> send_ledgers_to_bq_task
-    >> delete_enrich_op_task
+   dag,
+   public_project,
+   public_dataset,
+   table_names["assets"],
+   partition=True,
+   cluster=True,
+   create=True,
+   dataset_type="pub",
 )
 (
-    ledger_export_task
-    >> delete_old_ledger_pub_task
-    >> send_ledgers_to_pub_task
-    >> delete_enrich_op_pub_task
+   time_task
+   >> write_ledger_stats
+   >> ledger_export_task
+   >> delete_old_ledger_pub_task
+   >> send_ledgers_to_pub_task
+   >> delete_enrich_op_pub_task
 )
 (
-    time_task
-    >> write_asset_stats
-    >> asset_export_task
-    >> delete_old_asset_task
-    >> send_assets_to_bq_task
-    >> dedup_assets_bq_task
+   time_task
+   >> write_asset_stats
+   >> asset_export_task
+   >> delete_old_asset_task
+   >> send_assets_to_bq_task
+   >> dedup_assets_bq_task
 )
 (
-    asset_export_task
-    >> delete_old_asset_pub_task
-    >> send_assets_to_pub_task
-    >> dedup_assets_pub_task
+   asset_export_task
+   >> delete_old_asset_pub_task
+   >> send_assets_to_pub_task
+   >> dedup_assets_pub_task
 )

--- a/dags/state_table_dag.py
+++ b/dags/state_table_dag.py
@@ -6,6 +6,7 @@ from ast import literal_eval
 from datetime import datetime
 from json import loads
 
+
 from airflow import DAG
 from airflow.models import Variable
 from kubernetes.client import models as k8s
@@ -17,29 +18,32 @@ from stellar_etl_airflow.build_gcs_to_bq_task import build_gcs_to_bq_task
 from stellar_etl_airflow.build_time_task import build_time_task
 from stellar_etl_airflow.default import get_default_dag_args, init_sentry
 
+
 init_sentry()
 
+
 dag = DAG(
-    "state_table_export",
-    default_args=get_default_dag_args(),
-    start_date=datetime(2024, 4, 23, 15, 0),
-    description="This DAG runs a bounded stellar-core instance, which allows it to export accounts, offers, liquidity pools, and trustlines to BigQuery.",
-    schedule_interval="*/10 * * * *",
-    params={
-        "alias": "state",
-    },
-    render_template_as_native_obj=True,
-    user_defined_filters={
-        "fromjson": lambda s: loads(s),
-        "container_resources": lambda s: k8s.V1ResourceRequirements(requests=s),
-        "literal_eval": lambda e: literal_eval(e),
-    },
-    user_defined_macros={
-        "subtract_data_interval": macros.subtract_data_interval,
-        "batch_run_date_as_datetime_string": macros.batch_run_date_as_datetime_string,
-    },
-    catchup=True,
+   "state_table_export",
+   default_args=get_default_dag_args(),
+   start_date=datetime(2024, 4, 23, 15, 0),
+   description="This DAG runs a bounded stellar-core instance, which allows it to export accounts, offers, liquidity pools, and trustlines to BigQuery.",
+   schedule_interval="*/10 * * * *",
+   params={
+       "alias": "state",
+   },
+   render_template_as_native_obj=True,
+   user_defined_filters={
+       "fromjson": lambda s: loads(s),
+       "container_resources": lambda s: k8s.V1ResourceRequirements(requests=s),
+       "literal_eval": lambda e: literal_eval(e),
+   },
+   user_defined_macros={
+       "subtract_data_interval": macros.subtract_data_interval,
+       "batch_run_date_as_datetime_string": macros.batch_run_date_as_datetime_string,
+   },
+   catchup=True,
 )
+
 
 table_names = Variable.get("table_ids", deserialize_json=True)
 internal_project = "{{ var.value.bq_project }}"
@@ -51,18 +55,20 @@ use_futurenet = literal_eval(Variable.get("use_futurenet"))
 use_captive_core = literal_eval(Variable.get("use_captive_core"))
 txmeta_datastore_url = "{{ var.value.txmeta_datastore_url }}"
 
+
 date_task = build_time_task(dag, use_testnet=use_testnet, use_futurenet=use_futurenet)
 changes_task = build_export_task(
-    dag,
-    "bounded-core",
-    "export_ledger_entry_changes",
-    "{{ var.json.output_file_names.changes }}",
-    use_testnet=use_testnet,
-    use_futurenet=use_futurenet,
-    use_gcs=True,
-    use_captive_core=use_captive_core,
-    txmeta_datastore_url=txmeta_datastore_url,
+   dag,
+   "bounded-core",
+   "export_ledger_entry_changes",
+   "{{ var.json.output_file_names.changes }}",
+   use_testnet=use_testnet,
+   use_futurenet=use_futurenet,
+   use_gcs=True,
+   use_captive_core=use_captive_core,
+   txmeta_datastore_url=txmeta_datastore_url,
 )
+
 
 """
 The write batch stats task will take a snapshot of the DAG run_id, execution date,
@@ -80,298 +86,243 @@ write_contract_code_stats = build_batch_stats(dag, table_names["contract_code"])
 write_config_settings_stats = build_batch_stats(dag, table_names["config_settings"])
 write_ttl_stats = build_batch_stats(dag, table_names["ttl"])
 
+
 """
 The delete partition task checks to see if the given partition/batch id exists in
 Bigquery. If it does, the records are deleted prior to reinserting the batch.
 """
-delete_acc_task = build_delete_data_task(
-    dag, internal_project, internal_dataset, table_names["accounts"]
-)
 delete_acc_pub_task = build_delete_data_task(
-    dag, public_project, public_dataset, table_names["accounts"], "pub"
-)
-delete_bal_task = build_delete_data_task(
-    dag, internal_project, internal_dataset, table_names["claimable_balances"]
+   dag, public_project, public_dataset, table_names["accounts"], "pub"
 )
 delete_bal_pub_task = build_delete_data_task(
-    dag,
-    public_project,
-    public_dataset,
-    table_names["claimable_balances"],
-    "pub",
-)
-delete_off_task = build_delete_data_task(
-    dag, internal_project, internal_dataset, table_names["offers"]
+   dag,
+   public_project,
+   public_dataset,
+   table_names["claimable_balances"],
+   "pub",
 )
 delete_off_pub_task = build_delete_data_task(
-    dag, public_project, public_dataset, table_names["offers"], "pub"
-)
-delete_pool_task = build_delete_data_task(
-    dag, internal_project, internal_dataset, table_names["liquidity_pools"]
+   dag, public_project, public_dataset, table_names["offers"], "pub"
 )
 delete_pool_pub_task = build_delete_data_task(
-    dag, public_project, public_dataset, table_names["liquidity_pools"], "pub"
-)
-delete_sign_task = build_delete_data_task(
-    dag, internal_project, internal_dataset, table_names["signers"]
+   dag, public_project, public_dataset, table_names["liquidity_pools"], "pub"
 )
 delete_sign_pub_task = build_delete_data_task(
-    dag, public_project, public_dataset, table_names["signers"], "pub"
-)
-delete_trust_task = build_delete_data_task(
-    dag, internal_project, internal_dataset, table_names["trustlines"]
+   dag, public_project, public_dataset, table_names["signers"], "pub"
 )
 delete_trust_pub_task = build_delete_data_task(
-    dag, public_project, public_dataset, table_names["trustlines"], "pub"
+   dag, public_project, public_dataset, table_names["trustlines"], "pub"
 )
 delete_contract_data_task = build_delete_data_task(
-    dag, public_project, public_dataset, table_names["contract_data"], "pub"
+   dag, public_project, public_dataset, table_names["contract_data"], "pub"
 )
 delete_contract_code_task = build_delete_data_task(
-    dag, public_project, public_dataset, table_names["contract_code"], "pub"
+   dag, public_project, public_dataset, table_names["contract_code"], "pub"
 )
 delete_config_settings_task = build_delete_data_task(
-    dag, public_project, public_dataset, table_names["config_settings"], "pub"
+   dag, public_project, public_dataset, table_names["config_settings"], "pub"
 )
 delete_ttl_task = build_delete_data_task(
-    dag, public_project, public_dataset, table_names["ttl"], "pub"
+   dag, public_project, public_dataset, table_names["ttl"], "pub"
 )
+
 
 """
 The apply tasks receive the location of the file in Google Cloud storage through Airflow's XCOM system.
-Then, the task merges the entries in the file with the entries in the corresponding table in BigQuery.
+Then, the task merges the entries in the file with the entries in the corresponding table in the public dataset.
 Entries are updated, deleted, or inserted as needed.
 """
-send_acc_to_bq_task = build_gcs_to_bq_task(
-    dag,
-    changes_task.task_id,
-    internal_project,
-    internal_dataset,
-    table_names["accounts"],
-    "/*-accounts.txt",
-    partition=True,
-    cluster=True,
-)
-send_bal_to_bq_task = build_gcs_to_bq_task(
-    dag,
-    changes_task.task_id,
-    internal_project,
-    internal_dataset,
-    table_names["claimable_balances"],
-    "/*-claimable_balances.txt",
-    partition=True,
-    cluster=True,
-)
-send_off_to_bq_task = build_gcs_to_bq_task(
-    dag,
-    changes_task.task_id,
-    internal_project,
-    internal_dataset,
-    table_names["offers"],
-    "/*-offers.txt",
-    partition=True,
-    cluster=True,
-)
-send_pool_to_bq_task = build_gcs_to_bq_task(
-    dag,
-    changes_task.task_id,
-    internal_project,
-    internal_dataset,
-    table_names["liquidity_pools"],
-    "/*-liquidity_pools.txt",
-    partition=True,
-    cluster=True,
-)
-send_sign_to_bq_task = build_gcs_to_bq_task(
-    dag,
-    changes_task.task_id,
-    internal_project,
-    internal_dataset,
-    table_names["signers"],
-    "/*-signers.txt",
-    partition=True,
-    cluster=True,
-)
-send_trust_to_bq_task = build_gcs_to_bq_task(
-    dag,
-    changes_task.task_id,
-    internal_project,
-    internal_dataset,
-    table_names["trustlines"],
-    "/*-trustlines.txt",
-    partition=True,
-    cluster=True,
-)
-
-"""
-    Send to public dataset
-"""
 send_acc_to_pub_task = build_gcs_to_bq_task(
-    dag,
-    changes_task.task_id,
-    public_project,
-    public_dataset,
-    table_names["accounts"],
-    "/*-accounts.txt",
-    partition=True,
-    cluster=True,
-    dataset_type="pub",
+   dag,
+   changes_task.task_id,
+   public_project,
+   public_dataset,
+   table_names["accounts"],
+   "/*-accounts.txt",
+   partition=True,
+   cluster=True,
+   dataset_type="pub",
 )
 send_bal_to_pub_task = build_gcs_to_bq_task(
-    dag,
-    changes_task.task_id,
-    public_project,
-    public_dataset,
-    table_names["claimable_balances"],
-    "/*-claimable_balances.txt",
-    partition=True,
-    cluster=True,
-    dataset_type="pub",
+   dag,
+   changes_task.task_id,
+   public_project,
+   public_dataset,
+   table_names["claimable_balances"],
+   "/*-claimable_balances.txt",
+   partition=True,
+   cluster=True,
+   dataset_type="pub",
 )
 send_off_to_pub_task = build_gcs_to_bq_task(
-    dag,
-    changes_task.task_id,
-    public_project,
-    public_dataset,
-    table_names["offers"],
-    "/*-offers.txt",
-    partition=True,
-    cluster=True,
-    dataset_type="pub",
+   dag,
+   changes_task.task_id,
+   public_project,
+   public_dataset,
+   table_names["offers"],
+   "/*-offers.txt",
+   partition=True,
+   cluster=True,
+   dataset_type="pub",
 )
 send_pool_to_pub_task = build_gcs_to_bq_task(
-    dag,
-    changes_task.task_id,
-    public_project,
-    public_dataset,
-    table_names["liquidity_pools"],
-    "/*-liquidity_pools.txt",
-    partition=True,
-    cluster=True,
-    dataset_type="pub",
+   dag,
+   changes_task.task_id,
+   public_project,
+   public_dataset,
+   table_names["liquidity_pools"],
+   "/*-liquidity_pools.txt",
+   partition=True,
+   cluster=True,
+   dataset_type="pub",
 )
 send_sign_to_pub_task = build_gcs_to_bq_task(
-    dag,
-    changes_task.task_id,
-    public_project,
-    public_dataset,
-    table_names["signers"],
-    "/*-signers.txt",
-    partition=True,
-    cluster=True,
-    dataset_type="pub",
+   dag,
+   changes_task.task_id,
+   public_project,
+   public_dataset,
+   table_names["signers"],
+   "/*-signers.txt",
+   partition=True,
+   cluster=True,
+   dataset_type="pub",
 )
 send_trust_to_pub_task = build_gcs_to_bq_task(
-    dag,
-    changes_task.task_id,
-    public_project,
-    public_dataset,
-    table_names["trustlines"],
-    "/*-trustlines.txt",
-    partition=True,
-    cluster=True,
-    dataset_type="pub",
+   dag,
+   changes_task.task_id,
+   public_project,
+   public_dataset,
+   table_names["trustlines"],
+   "/*-trustlines.txt",
+   partition=True,
+   cluster=True,
+   dataset_type="pub",
 )
 send_contract_data_to_pub_task = build_gcs_to_bq_task(
-    dag,
-    changes_task.task_id,
-    public_project,
-    public_dataset,
-    table_names["contract_data"],
-    "/*-contract_data.txt",
-    partition=True,
-    cluster=True,
-    dataset_type="pub",
+   dag,
+   changes_task.task_id,
+   public_project,
+   public_dataset,
+   table_names["contract_data"],
+   "/*-contract_data.txt",
+   partition=True,
+   cluster=True,
+   dataset_type="pub",
 )
 send_contract_code_to_pub_task = build_gcs_to_bq_task(
-    dag,
-    changes_task.task_id,
-    public_project,
-    public_dataset,
-    table_names["contract_code"],
-    "/*-contract_code.txt",
-    partition=True,
-    cluster=True,
-    dataset_type="pub",
+   dag,
+   changes_task.task_id,
+   public_project,
+   public_dataset,
+   table_names["contract_code"],
+   "/*-contract_code.txt",
+   partition=True,
+   cluster=True,
+   dataset_type="pub",
 )
 send_config_settings_to_pub_task = build_gcs_to_bq_task(
-    dag,
-    changes_task.task_id,
-    public_project,
-    public_dataset,
-    table_names["config_settings"],
-    "/*-config_settings.txt",
-    partition=True,
-    cluster=True,
-    dataset_type="pub",
+   dag,
+   changes_task.task_id,
+   public_project,
+   public_dataset,
+   table_names["config_settings"],
+   "/*-config_settings.txt",
+   partition=True,
+   cluster=True,
+   dataset_type="pub",
 )
 send_ttl_to_pub_task = build_gcs_to_bq_task(
-    dag,
-    changes_task.task_id,
-    public_project,
-    public_dataset,
-    table_names["ttl"],
-    "/*-ttl.txt",
-    partition=True,
-    cluster=True,
-    dataset_type="pub",
+   dag,
+   changes_task.task_id,
+   public_project,
+   public_dataset,
+   table_names["ttl"],
+   "/*-ttl.txt",
+   partition=True,
+   cluster=True,
+   dataset_type="pub",
 )
 
-date_task >> changes_task >> write_acc_stats >> delete_acc_task >> send_acc_to_bq_task
-write_acc_stats >> delete_acc_pub_task >> send_acc_to_pub_task
-date_task >> changes_task >> write_bal_stats >> delete_bal_task >> send_bal_to_bq_task
-write_bal_stats >> delete_bal_pub_task >> send_bal_to_pub_task
-date_task >> changes_task >> write_off_stats >> delete_off_task >> send_off_to_bq_task
-write_off_stats >> delete_off_pub_task >> send_off_to_pub_task
+
+
+
 (
-    date_task
-    >> changes_task
-    >> write_pool_stats
-    >> delete_pool_task
-    >> send_pool_to_bq_task
+   date_task
+   >> changes_task
+   >> write_acc_stats
+   >> delete_acc_pub_task
+   >> send_acc_to_pub_task
 )
-write_pool_stats >> delete_pool_pub_task >> send_pool_to_pub_task
+
+
 (
-    date_task
-    >> changes_task
-    >> write_sign_stats
-    >> delete_sign_task
-    >> send_sign_to_bq_task
+   date_task
+   >> changes_task
+   >> write_bal_stats
+   >> delete_bal_pub_task
+   >> send_bal_to_pub_task
 )
-write_sign_stats >> delete_sign_pub_task >> send_sign_to_pub_task
+
+
 (
-    date_task
-    >> changes_task
-    >> write_trust_stats
-    >> delete_trust_task
-    >> send_trust_to_bq_task
+   date_task
+   >> changes_task
+   >> write_off_stats
+   >> delete_off_pub_task
+   >> send_off_to_pub_task
 )
-write_trust_stats >> delete_trust_pub_task >> send_trust_to_pub_task
+
+
 (
-    date_task
-    >> changes_task
-    >> write_contract_data_stats
-    >> delete_contract_data_task
-    >> send_contract_data_to_pub_task
+   date_task
+   >> changes_task
+   >> write_pool_stats
+   >> delete_pool_pub_task
+   >> send_pool_to_pub_task
+)
+
+
+(
+   date_task
+   >> changes_task
+   >> write_sign_stats
+   >> delete_sign_pub_task
+   >> send_sign_to_pub_task
+)
+
+
+(
+   date_task
+   >> changes_task
+   >> write_trust_stats
+   >> delete_trust_pub_task
+   >> send_trust_to_pub_task
 )
 (
-    date_task
-    >> changes_task
-    >> write_contract_code_stats
-    >> delete_contract_code_task
-    >> send_contract_code_to_pub_task
+   date_task
+   >> changes_task
+   >> write_contract_data_stats
+   >> delete_contract_data_task
+   >> send_contract_data_to_pub_task
 )
 (
-    date_task
-    >> changes_task
-    >> write_config_settings_stats
-    >> delete_config_settings_task
-    >> send_config_settings_to_pub_task
+   date_task
+   >> changes_task
+   >> write_contract_code_stats
+   >> delete_contract_code_task
+   >> send_contract_code_to_pub_task
 )
 (
-    date_task
-    >> changes_task
-    >> write_ttl_stats
-    >> delete_ttl_task
-    >> send_ttl_to_pub_task
+   date_task
+   >> changes_task
+   >> write_config_settings_stats
+   >> delete_config_settings_task
+   >> send_config_settings_to_pub_task
+)
+(
+   date_task
+   >> changes_task
+   >> write_ttl_stats
+   >> delete_ttl_task
+   >> send_ttl_to_pub_task
 )

--- a/dags/state_table_dag.py
+++ b/dags/state_table_dag.py
@@ -6,7 +6,6 @@ from ast import literal_eval
 from datetime import datetime
 from json import loads
 
-
 from airflow import DAG
 from airflow.models import Variable
 from kubernetes.client import models as k8s
@@ -18,30 +17,29 @@ from stellar_etl_airflow.build_gcs_to_bq_task import build_gcs_to_bq_task
 from stellar_etl_airflow.build_time_task import build_time_task
 from stellar_etl_airflow.default import get_default_dag_args, init_sentry
 
-
 init_sentry()
 
 
 dag = DAG(
-   "state_table_export",
-   default_args=get_default_dag_args(),
-   start_date=datetime(2024, 4, 23, 15, 0),
-   description="This DAG runs a bounded stellar-core instance, which allows it to export accounts, offers, liquidity pools, and trustlines to BigQuery.",
-   schedule_interval="*/10 * * * *",
-   params={
-       "alias": "state",
-   },
-   render_template_as_native_obj=True,
-   user_defined_filters={
-       "fromjson": lambda s: loads(s),
-       "container_resources": lambda s: k8s.V1ResourceRequirements(requests=s),
-       "literal_eval": lambda e: literal_eval(e),
-   },
-   user_defined_macros={
-       "subtract_data_interval": macros.subtract_data_interval,
-       "batch_run_date_as_datetime_string": macros.batch_run_date_as_datetime_string,
-   },
-   catchup=True,
+    "state_table_export",
+    default_args=get_default_dag_args(),
+    start_date=datetime(2024, 4, 23, 15, 0),
+    description="This DAG runs a bounded stellar-core instance, which allows it to export accounts, offers, liquidity pools, and trustlines to BigQuery.",
+    schedule_interval="*/10 * * * *",
+    params={
+        "alias": "state",
+    },
+    render_template_as_native_obj=True,
+    user_defined_filters={
+        "fromjson": lambda s: loads(s),
+        "container_resources": lambda s: k8s.V1ResourceRequirements(requests=s),
+        "literal_eval": lambda e: literal_eval(e),
+    },
+    user_defined_macros={
+        "subtract_data_interval": macros.subtract_data_interval,
+        "batch_run_date_as_datetime_string": macros.batch_run_date_as_datetime_string,
+    },
+    catchup=True,
 )
 
 
@@ -58,15 +56,15 @@ txmeta_datastore_url = "{{ var.value.txmeta_datastore_url }}"
 
 date_task = build_time_task(dag, use_testnet=use_testnet, use_futurenet=use_futurenet)
 changes_task = build_export_task(
-   dag,
-   "bounded-core",
-   "export_ledger_entry_changes",
-   "{{ var.json.output_file_names.changes }}",
-   use_testnet=use_testnet,
-   use_futurenet=use_futurenet,
-   use_gcs=True,
-   use_captive_core=use_captive_core,
-   txmeta_datastore_url=txmeta_datastore_url,
+    dag,
+    "bounded-core",
+    "export_ledger_entry_changes",
+    "{{ var.json.output_file_names.changes }}",
+    use_testnet=use_testnet,
+    use_futurenet=use_futurenet,
+    use_gcs=True,
+    use_captive_core=use_captive_core,
+    txmeta_datastore_url=txmeta_datastore_url,
 )
 
 
@@ -92,38 +90,38 @@ The delete partition task checks to see if the given partition/batch id exists i
 Bigquery. If it does, the records are deleted prior to reinserting the batch.
 """
 delete_acc_pub_task = build_delete_data_task(
-   dag, public_project, public_dataset, table_names["accounts"], "pub"
+    dag, public_project, public_dataset, table_names["accounts"], "pub"
 )
 delete_bal_pub_task = build_delete_data_task(
-   dag,
-   public_project,
-   public_dataset,
-   table_names["claimable_balances"],
-   "pub",
+    dag,
+    public_project,
+    public_dataset,
+    table_names["claimable_balances"],
+    "pub",
 )
 delete_off_pub_task = build_delete_data_task(
-   dag, public_project, public_dataset, table_names["offers"], "pub"
+    dag, public_project, public_dataset, table_names["offers"], "pub"
 )
 delete_pool_pub_task = build_delete_data_task(
-   dag, public_project, public_dataset, table_names["liquidity_pools"], "pub"
+    dag, public_project, public_dataset, table_names["liquidity_pools"], "pub"
 )
 delete_sign_pub_task = build_delete_data_task(
-   dag, public_project, public_dataset, table_names["signers"], "pub"
+    dag, public_project, public_dataset, table_names["signers"], "pub"
 )
 delete_trust_pub_task = build_delete_data_task(
-   dag, public_project, public_dataset, table_names["trustlines"], "pub"
+    dag, public_project, public_dataset, table_names["trustlines"], "pub"
 )
 delete_contract_data_task = build_delete_data_task(
-   dag, public_project, public_dataset, table_names["contract_data"], "pub"
+    dag, public_project, public_dataset, table_names["contract_data"], "pub"
 )
 delete_contract_code_task = build_delete_data_task(
-   dag, public_project, public_dataset, table_names["contract_code"], "pub"
+    dag, public_project, public_dataset, table_names["contract_code"], "pub"
 )
 delete_config_settings_task = build_delete_data_task(
-   dag, public_project, public_dataset, table_names["config_settings"], "pub"
+    dag, public_project, public_dataset, table_names["config_settings"], "pub"
 )
 delete_ttl_task = build_delete_data_task(
-   dag, public_project, public_dataset, table_names["ttl"], "pub"
+    dag, public_project, public_dataset, table_names["ttl"], "pub"
 )
 
 
@@ -133,196 +131,193 @@ Then, the task merges the entries in the file with the entries in the correspond
 Entries are updated, deleted, or inserted as needed.
 """
 send_acc_to_pub_task = build_gcs_to_bq_task(
-   dag,
-   changes_task.task_id,
-   public_project,
-   public_dataset,
-   table_names["accounts"],
-   "/*-accounts.txt",
-   partition=True,
-   cluster=True,
-   dataset_type="pub",
+    dag,
+    changes_task.task_id,
+    public_project,
+    public_dataset,
+    table_names["accounts"],
+    "/*-accounts.txt",
+    partition=True,
+    cluster=True,
+    dataset_type="pub",
 )
 send_bal_to_pub_task = build_gcs_to_bq_task(
-   dag,
-   changes_task.task_id,
-   public_project,
-   public_dataset,
-   table_names["claimable_balances"],
-   "/*-claimable_balances.txt",
-   partition=True,
-   cluster=True,
-   dataset_type="pub",
+    dag,
+    changes_task.task_id,
+    public_project,
+    public_dataset,
+    table_names["claimable_balances"],
+    "/*-claimable_balances.txt",
+    partition=True,
+    cluster=True,
+    dataset_type="pub",
 )
 send_off_to_pub_task = build_gcs_to_bq_task(
-   dag,
-   changes_task.task_id,
-   public_project,
-   public_dataset,
-   table_names["offers"],
-   "/*-offers.txt",
-   partition=True,
-   cluster=True,
-   dataset_type="pub",
+    dag,
+    changes_task.task_id,
+    public_project,
+    public_dataset,
+    table_names["offers"],
+    "/*-offers.txt",
+    partition=True,
+    cluster=True,
+    dataset_type="pub",
 )
 send_pool_to_pub_task = build_gcs_to_bq_task(
-   dag,
-   changes_task.task_id,
-   public_project,
-   public_dataset,
-   table_names["liquidity_pools"],
-   "/*-liquidity_pools.txt",
-   partition=True,
-   cluster=True,
-   dataset_type="pub",
+    dag,
+    changes_task.task_id,
+    public_project,
+    public_dataset,
+    table_names["liquidity_pools"],
+    "/*-liquidity_pools.txt",
+    partition=True,
+    cluster=True,
+    dataset_type="pub",
 )
 send_sign_to_pub_task = build_gcs_to_bq_task(
-   dag,
-   changes_task.task_id,
-   public_project,
-   public_dataset,
-   table_names["signers"],
-   "/*-signers.txt",
-   partition=True,
-   cluster=True,
-   dataset_type="pub",
+    dag,
+    changes_task.task_id,
+    public_project,
+    public_dataset,
+    table_names["signers"],
+    "/*-signers.txt",
+    partition=True,
+    cluster=True,
+    dataset_type="pub",
 )
 send_trust_to_pub_task = build_gcs_to_bq_task(
-   dag,
-   changes_task.task_id,
-   public_project,
-   public_dataset,
-   table_names["trustlines"],
-   "/*-trustlines.txt",
-   partition=True,
-   cluster=True,
-   dataset_type="pub",
+    dag,
+    changes_task.task_id,
+    public_project,
+    public_dataset,
+    table_names["trustlines"],
+    "/*-trustlines.txt",
+    partition=True,
+    cluster=True,
+    dataset_type="pub",
 )
 send_contract_data_to_pub_task = build_gcs_to_bq_task(
-   dag,
-   changes_task.task_id,
-   public_project,
-   public_dataset,
-   table_names["contract_data"],
-   "/*-contract_data.txt",
-   partition=True,
-   cluster=True,
-   dataset_type="pub",
+    dag,
+    changes_task.task_id,
+    public_project,
+    public_dataset,
+    table_names["contract_data"],
+    "/*-contract_data.txt",
+    partition=True,
+    cluster=True,
+    dataset_type="pub",
 )
 send_contract_code_to_pub_task = build_gcs_to_bq_task(
-   dag,
-   changes_task.task_id,
-   public_project,
-   public_dataset,
-   table_names["contract_code"],
-   "/*-contract_code.txt",
-   partition=True,
-   cluster=True,
-   dataset_type="pub",
+    dag,
+    changes_task.task_id,
+    public_project,
+    public_dataset,
+    table_names["contract_code"],
+    "/*-contract_code.txt",
+    partition=True,
+    cluster=True,
+    dataset_type="pub",
 )
 send_config_settings_to_pub_task = build_gcs_to_bq_task(
-   dag,
-   changes_task.task_id,
-   public_project,
-   public_dataset,
-   table_names["config_settings"],
-   "/*-config_settings.txt",
-   partition=True,
-   cluster=True,
-   dataset_type="pub",
+    dag,
+    changes_task.task_id,
+    public_project,
+    public_dataset,
+    table_names["config_settings"],
+    "/*-config_settings.txt",
+    partition=True,
+    cluster=True,
+    dataset_type="pub",
 )
 send_ttl_to_pub_task = build_gcs_to_bq_task(
-   dag,
-   changes_task.task_id,
-   public_project,
-   public_dataset,
-   table_names["ttl"],
-   "/*-ttl.txt",
-   partition=True,
-   cluster=True,
-   dataset_type="pub",
+    dag,
+    changes_task.task_id,
+    public_project,
+    public_dataset,
+    table_names["ttl"],
+    "/*-ttl.txt",
+    partition=True,
+    cluster=True,
+    dataset_type="pub",
 )
 
-
-
-
 (
-   date_task
-   >> changes_task
-   >> write_acc_stats
-   >> delete_acc_pub_task
-   >> send_acc_to_pub_task
-)
-
-
-(
-   date_task
-   >> changes_task
-   >> write_bal_stats
-   >> delete_bal_pub_task
-   >> send_bal_to_pub_task
+    date_task
+    >> changes_task
+    >> write_acc_stats
+    >> delete_acc_pub_task
+    >> send_acc_to_pub_task
 )
 
 
 (
-   date_task
-   >> changes_task
-   >> write_off_stats
-   >> delete_off_pub_task
-   >> send_off_to_pub_task
+    date_task
+    >> changes_task
+    >> write_bal_stats
+    >> delete_bal_pub_task
+    >> send_bal_to_pub_task
 )
 
 
 (
-   date_task
-   >> changes_task
-   >> write_pool_stats
-   >> delete_pool_pub_task
-   >> send_pool_to_pub_task
+    date_task
+    >> changes_task
+    >> write_off_stats
+    >> delete_off_pub_task
+    >> send_off_to_pub_task
 )
 
 
 (
-   date_task
-   >> changes_task
-   >> write_sign_stats
-   >> delete_sign_pub_task
-   >> send_sign_to_pub_task
+    date_task
+    >> changes_task
+    >> write_pool_stats
+    >> delete_pool_pub_task
+    >> send_pool_to_pub_task
 )
 
 
 (
-   date_task
-   >> changes_task
-   >> write_trust_stats
-   >> delete_trust_pub_task
-   >> send_trust_to_pub_task
+    date_task
+    >> changes_task
+    >> write_sign_stats
+    >> delete_sign_pub_task
+    >> send_sign_to_pub_task
+)
+
+
+(
+    date_task
+    >> changes_task
+    >> write_trust_stats
+    >> delete_trust_pub_task
+    >> send_trust_to_pub_task
 )
 (
-   date_task
-   >> changes_task
-   >> write_contract_data_stats
-   >> delete_contract_data_task
-   >> send_contract_data_to_pub_task
+    date_task
+    >> changes_task
+    >> write_contract_data_stats
+    >> delete_contract_data_task
+    >> send_contract_data_to_pub_task
 )
 (
-   date_task
-   >> changes_task
-   >> write_contract_code_stats
-   >> delete_contract_code_task
-   >> send_contract_code_to_pub_task
+    date_task
+    >> changes_task
+    >> write_contract_code_stats
+    >> delete_contract_code_task
+    >> send_contract_code_to_pub_task
 )
 (
-   date_task
-   >> changes_task
-   >> write_config_settings_stats
-   >> delete_config_settings_task
-   >> send_config_settings_to_pub_task
+    date_task
+    >> changes_task
+    >> write_config_settings_stats
+    >> delete_config_settings_task
+    >> send_config_settings_to_pub_task
 )
 (
-   date_task
-   >> changes_task
-   >> write_ttl_stats
-   >> delete_ttl_task
-   >> send_ttl_to_pub_task
+    date_task
+    >> changes_task
+    >> write_ttl_stats
+    >> delete_ttl_task
+    >> send_ttl_to_pub_task
 )


### PR DESCRIPTION
Deleted from internal: account_signers, accounts, claimable_balances, history_effects, history_ledgers, history_operations, history_trades, history_transactions, trustlines, offers, liquidity_pools, history_assets.

Added new stellar-dbt image to dev and prod: "stellar/stellar-dbt:f360f91"

Along with it, it was deleted from bigQuery the views related to the sources that are not being used anymore
![image](https://github.com/stellar/stellar-etl-airflow/assets/46203330/a9c9ea77-f5bb-43b6-9868-93f60053bd93)


