### PR TITLE
Update schemas

### DIFF
--- a/schemas/claimable_balances_schema.json
+++ b/schemas/claimable_balances_schema.json
@@ -103,7 +103,34 @@
                     "mode": "NULLABLE",
                     "name": "abs_before_epoch",
                     "type": "INTEGER"
-                  }
+                  },
+                  {
+                    "fields": [
+                      {
+                        "mode": "NULLABLE",
+                        "name": "abs_before",
+                        "type": "STRING"
+                      },
+                      {
+                        "mode": "NULLABLE",
+                        "name": "rel_before",
+                        "type": "INTEGER"
+                      },
+                      {
+                        "mode": "NULLABLE",
+                        "name": "unconditional",
+                        "type": "BOOLEAN"
+                      },
+                      {
+                        "mode": "NULLABLE",
+                        "name": "abs_before_epoch",
+                        "type": "INTEGER"
+                      }
+                    ],
+                    "mode": "REPEATED",
+                    "name": "or",
+                    "type": "RECORD"
+                  }    
                 ],
                 "mode": "REPEATED",
                 "name": "or",

--- a/schemas/claimable_balances_schema.json
+++ b/schemas/claimable_balances_schema.json
@@ -130,7 +130,7 @@
                     "mode": "REPEATED",
                     "name": "or",
                     "type": "RECORD"
-                  }    
+                  }
                 ],
                 "mode": "REPEATED",
                 "name": "or",

--- a/schemas/history_effects_schema.json
+++ b/schemas/history_effects_schema.json
@@ -492,6 +492,33 @@
                     "mode": "NULLABLE",
                     "name": "abs_before_epoch",
                     "type": "INTEGER"
+                  },
+                  {
+                    "fields": [
+                      {
+                        "mode": "NULLABLE",
+                        "name": "abs_before",
+                        "type": "STRING"
+                      },
+                      {
+                        "mode": "NULLABLE",
+                        "name": "rel_before",
+                        "type": "INTEGER"
+                      },
+                      {
+                        "mode": "NULLABLE",
+                        "name": "unconditional",
+                        "type": "BOOLEAN"
+                      },
+                      {
+                        "mode": "NULLABLE",
+                        "name": "abs_before_epoch",
+                        "type": "INTEGER"
+                      }
+                    ],
+                    "mode": "REPEATED",
+                    "name": "or",
+                    "type": "RECORD"
                   }
                 ],
                 "mode": "REPEATED",

--- a/schemas/history_operations_schema.json
+++ b/schemas/history_operations_schema.json
@@ -200,6 +200,33 @@
                         "mode": "NULLABLE",
                         "name": "abs_before_epoch",
                         "type": "INTEGER"
+                      },
+                      {
+                        "fields": [
+                          {
+                            "mode": "NULLABLE",
+                            "name": "abs_before",
+                            "type": "STRING"
+                          },
+                          {
+                            "mode": "NULLABLE",
+                            "name": "rel_before",
+                            "type": "INTEGER"
+                          },
+                          {
+                            "mode": "NULLABLE",
+                            "name": "unconditional",
+                            "type": "BOOLEAN"
+                          },
+                          {
+                            "mode": "NULLABLE",
+                            "name": "abs_before_epoch",
+                            "type": "INTEGER"
+                          }
+                        ],
+                        "mode": "REPEATED",
+                        "name": "or",
+                        "type": "RECORD"
                       }
                     ],
                     "mode": "REPEATED",


### PR DESCRIPTION
There is a new predicate depth added in one of the recent operations that caused errors in the airflow insert tasks
https://stellarfoundation.slack.com/archives/C02GQ9ZGNDU/p1720235944089819

Added the new `or` level to resolve this issue