### PR TITLE
Update schema for history_effects table

### DIFF
--- a/airflow_variables_dev.json
+++ b/airflow_variables_dev.json
@@ -148,7 +148,7 @@
   "dbt_threads": 12,
   "gcs_exported_data_bucket_name": "us-central1-test-hubble-2-5f1f2dbf-bucket",
   "gcs_exported_object_prefix": "dag-exported",
-  "image_name": "stellar/stellar-etl:b3fb467",
+  "image_name": "stellar/stellar-etl:e6a47f9",
   "image_output_path": "/etl/exported_data/",
   "image_pull_policy": "IfNotPresent",
   "k8s_namespace": "hubble-composer",

--- a/airflow_variables_prod.json
+++ b/airflow_variables_prod.json
@@ -149,7 +149,7 @@
   "dbt_threads": 12,
   "gcs_exported_data_bucket_name": "us-central1-hubble-14c4ca64-bucket",
   "gcs_exported_object_prefix": "dag-exported",
-  "image_name": "stellar/stellar-etl:b3fb467",
+  "image_name": "stellar/stellar-etl:e6a47f9",
   "image_output_path": "/etl/exported_data/",
   "image_pull_policy": "IfNotPresent",
   "k8s_namespace": "hubble-composer",

--- a/schemas/history_effects_schema.json
+++ b/schemas/history_effects_schema.json
@@ -27,7 +27,7 @@
   {
     "mode": "NULLABLE",
     "name": "index",
-    "type": "STRING"
+    "type": "INTEGER"
   },
   {
     "mode": "NULLABLE",

--- a/schemas/history_effects_schema.json
+++ b/schemas/history_effects_schema.json
@@ -25,16 +25,6 @@
     "type": "STRING"
   },
   {
-    "mode": "NULLABLE",
-    "name": "index",
-    "type": "INTEGER"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "id",
-    "type": "STRING"
-  },
-  {
     "fields": [
       {
         "fields": [
@@ -874,5 +864,15 @@
     "mode": "NULLABLE",
     "name": "ledger_sequence",
     "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "index",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "id",
+    "type": "STRING"
   }
 ]

--- a/schemas/history_effects_schema.json
+++ b/schemas/history_effects_schema.json
@@ -25,6 +25,16 @@
     "type": "STRING"
   },
   {
+    "mode": "NULLABLE",
+    "name": "index",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "id",
+    "type": "STRING"
+  },
+  {
     "fields": [
       {
         "fields": [


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

- [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
- [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
      otherwise).
- [ ] This PR's title starts with the jira ticket associated with the PR.

### Thoroughness

- [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
- [ ] I've updated the README with the added features, breaking changes, new instructions on how to use the repository.

</details>

### What

See context in https://stellarorg.atlassian.net/browse/HUBBLE-460
Related PR https://github.com/stellar/stellar-etl/pull/264

This PR updates bigquery schema for `history_effects` table to export `id` and `index` fields.

### Why

To have data parity between Horizon and Hubble

### Known limitations

N/A