### PR TITLE
Update airflow resources and split out dbt tests and alerts

### DIFF
--- a/airflow_variables_dev.json
+++ b/airflow_variables_dev.json
@@ -284,21 +284,21 @@
   "public_project": "test-hubble-319619",
   "resources": {
     "dbt": {
-      "requests": {
+      "requests": {
         "cpu": "0.2",
         "ephemeral-storage": "500Mi",
         "memory": "250Mi"
       }
     },
     "default": {
-      "requests": {
+      "requests": {
         "cpu": "0.2",
         "ephemeral-storage": "500Mi",
         "memory": "250Mi"
       }
     },
     "stellar-etl": {
-      "requests": {
+      "requests": {
         "cpu": "0.2",
         "ephemeral-storage": "500Mi",
         "memory": "250Mi"

--- a/airflow_variables_dev.json
+++ b/airflow_variables_dev.json
@@ -283,21 +283,21 @@
   "public_dataset": "test_crypto_stellar",
   "public_project": "test-hubble-319619",
   "resources": {
-    "default": {
+    "dbt": {
       "requests": {
         "cpu": "0.2",
         "ephemeral-storage": "500Mi",
         "memory": "250Mi"
       }
     },
-    "stellar-etl": {
+    "default": {
       "requests": {
         "cpu": "0.2",
         "ephemeral-storage": "500Mi",
         "memory": "250Mi"
       }
     },
-    "dbt": {
+    "stellar-etl": {
       "requests": {
         "cpu": "0.2",
         "ephemeral-storage": "500Mi",

--- a/airflow_variables_dev.json
+++ b/airflow_variables_dev.json
@@ -285,24 +285,24 @@
   "resources": {
     "dbt": {
       "requests": {
-        "cpu": "0.2",
-        "ephemeral-storage": "500Mi",
-        "memory": "250Mi"
-      }
+        "cpu": "0.2",
+        "ephemeral-storage": "500Mi",
+        "memory": "250Mi"
+      }
     },
     "default": {
-      "requests": {
-        "cpu": "0.2",
-        "ephemeral-storage": "500Mi",
-        "memory": "250Mi"
-      }
+      "requests": {
+        "cpu": "0.2",
+        "ephemeral-storage": "500Mi",
+        "memory": "250Mi"
+      }
     },
     "stellar-etl": {
-      "requests": {
-        "cpu": "0.2",
-        "ephemeral-storage": "500Mi",
-        "memory": "250Mi"
-      }
+      "requests": {
+        "cpu": "0.2",
+        "ephemeral-storage": "500Mi",
+        "memory": "250Mi"
+      }
     }
   },
   "sandbox_dataset": "crypto_stellar_internal_sandbox",

--- a/airflow_variables_dev.json
+++ b/airflow_variables_dev.json
@@ -283,33 +283,26 @@
   "public_dataset": "test_crypto_stellar",
   "public_project": "test-hubble-319619",
   "resources": {
-    "cc": {
-      "requests": {
-        "cpu": "0.3",
-        "ephemeral-storage": "1Gi",
-        "memory": "900Mi"
-      }
-    },
     "default": {
-      "requests": {
-        "cpu": "0.3",
-        "ephemeral-storage": "1Gi",
-        "memory": "900Mi"
-      }
+      "requests": {
+        "cpu": "0.2",
+        "ephemeral-storage": "500Mi",
+        "memory": "250Mi"
+      }
     },
-    "state": {
+    "stellar-etl": {
       "requests": {
-        "cpu": "0.3",
-        "ephemeral-storage": "1Gi",
-        "memory": "900Mi"
-      }
+        "cpu": "0.2",
+        "ephemeral-storage": "500Mi",
+        "memory": "250Mi"
+      }
     },
-    "wocc": {
+    "dbt": {
       "requests": {
-        "cpu": "0.3",
-        "ephemeral-storage": "1Gi",
-        "memory": "900Mi"
-      }
+        "cpu": "0.2",
+        "ephemeral-storage": "500Mi",
+        "memory": "250Mi"
+      }
     }
   },
   "sandbox_dataset": "crypto_stellar_internal_sandbox",

--- a/airflow_variables_dev.json
+++ b/airflow_variables_dev.json
@@ -285,23 +285,23 @@
   "resources": {
     "dbt": {
       "requests": {
-        "cpu": "0.2",
+        "cpu": "1",
         "ephemeral-storage": "500Mi",
-        "memory": "250Mi"
+        "memory": "600Mi"
       }
     },
     "default": {
       "requests": {
-        "cpu": "0.2",
+        "cpu": "0.3",
         "ephemeral-storage": "500Mi",
-        "memory": "250Mi"
+        "memory": "600Mi"
       }
     },
     "stellaretl": {
       "requests": {
-        "cpu": "0.2",
+        "cpu": "0.3",
         "ephemeral-storage": "500Mi",
-        "memory": "250Mi"
+        "memory": "600Mi"
       }
     }
   },

--- a/airflow_variables_dev.json
+++ b/airflow_variables_dev.json
@@ -122,7 +122,7 @@
     "partnership_assets__account_holders_activity_fact": false,
     "partnership_assets__asset_activity_fact": false
   },
-  "dbt_image_name": "stellar/stellar-dbt:1a777f9",
+  "dbt_image_name": "stellar/stellar-dbt:5c7c924",
   "dbt_internal_source_db": "test-hubble-319619",
   "dbt_internal_source_schema": "test_crypto_stellar_internal",
   "dbt_job_execution_timeout_seconds": 300,
@@ -154,7 +154,7 @@
   },
   "gcs_exported_data_bucket_name": "us-central1-test-hubble-2-5f1f2dbf-bucket",
   "gcs_exported_object_prefix": "dag-exported",
-  "image_name": "stellar/stellar-etl:98bea9a",
+  "image_name": "stellar/stellar-etl:ab57fa4",
   "image_output_path": "/etl/exported_data/",
   "image_pull_policy": "IfNotPresent",
   "k8s_namespace": "hubble-composer",

--- a/airflow_variables_dev.json
+++ b/airflow_variables_dev.json
@@ -297,7 +297,7 @@
         "memory": "250Mi"
       }
     },
-    "stellar-etl": {
+    "stellaretl": {
       "requests": {
         "cpu": "0.2",
         "ephemeral-storage": "500Mi",

--- a/airflow_variables_prod.json
+++ b/airflow_variables_prod.json
@@ -283,7 +283,7 @@
   "resources": {
     "dbt": {
       "requests": {
-        "cpu": "0.5",
+        "cpu": "1",
         "ephemeral-storage": "1Gi",
         "memory": "1Gi"
       }

--- a/airflow_variables_prod.json
+++ b/airflow_variables_prod.json
@@ -295,7 +295,7 @@
         "memory": "1Gi"
       }
     },
-    "stellar-etl": {
+    "stellaretl": {
       "requests": {
         "cpu": "0.5",
         "ephemeral-storage": "1Gi",

--- a/airflow_variables_prod.json
+++ b/airflow_variables_prod.json
@@ -281,32 +281,25 @@
   "public_dataset": "crypto_stellar",
   "public_project": "crypto-stellar",
   "resources": {
-    "cc": {
-      "requests": {
-        "cpu": "3.5",
-        "ephemeral-storage": "10Gi",
-        "memory": "15Gi"
-      }
-    },
     "default": {
       "requests": {
-        "cpu": "3.5",
+        "cpu": "0.5",
         "ephemeral-storage": "1Gi",
-        "memory": "5Gi"
+        "memory": "1Gi"
       }
     },
-    "state": {
+    "stellar-etl": {
       "requests": {
-        "cpu": "3.5",
-        "ephemeral-storage": "12Gi",
-        "memory": "20Gi"
+        "cpu": "0.5",
+        "ephemeral-storage": "1Gi",
+        "memory": "1Gi"
       }
     },
-    "wocc": {
+    "dbt": {
       "requests": {
-        "cpu": "3.5",
-        "ephemeral-storage": "10Gi",
-        "memory": "15Gi"
+        "cpu": "0.5",
+        "ephemeral-storage": "1Gi",
+        "memory": "1Gi"
       }
     }
   },

--- a/airflow_variables_prod.json
+++ b/airflow_variables_prod.json
@@ -281,6 +281,13 @@
   "public_dataset": "crypto_stellar",
   "public_project": "crypto-stellar",
   "resources": {
+    "dbt": {
+      "requests": {
+        "cpu": "0.5",
+        "ephemeral-storage": "1Gi",
+        "memory": "1Gi"
+      }
+    },
     "default": {
       "requests": {
         "cpu": "0.5",
@@ -289,13 +296,6 @@
       }
     },
     "stellar-etl": {
-      "requests": {
-        "cpu": "0.5",
-        "ephemeral-storage": "1Gi",
-        "memory": "1Gi"
-      }
-    },
-    "dbt": {
       "requests": {
         "cpu": "0.5",
         "ephemeral-storage": "1Gi",

--- a/airflow_variables_prod.json
+++ b/airflow_variables_prod.json
@@ -123,7 +123,7 @@
     "partnership_assets__asset_activity_fact": false,
     "trade_agg": false
   },
-  "dbt_image_name": "stellar/stellar-dbt:1a777f9",
+  "dbt_image_name": "stellar/stellar-dbt:5c7c924",
   "dbt_internal_source_db": "hubble-261722",
   "dbt_internal_source_schema": "crypto_stellar_internal_2",
   "dbt_job_execution_timeout_seconds": 1800,
@@ -155,7 +155,7 @@
   },
   "gcs_exported_data_bucket_name": "us-central1-hubble-14c4ca64-bucket",
   "gcs_exported_object_prefix": "dag-exported",
-  "image_name": "stellar/stellar-etl:98bea9a",
+  "image_name": "stellar/stellar-etl:ab57fa4",
   "image_output_path": "/etl/exported_data/",
   "image_pull_policy": "IfNotPresent",
   "k8s_namespace": "hubble-composer",

--- a/dags/dbt_data_quality_alerts_dag.py
+++ b/dags/dbt_data_quality_alerts_dag.py
@@ -29,6 +29,6 @@ with DAG(
 ) as dag:
 
     # Trigger elementary
-    elementary_alerts = elementary_task(dag, "dbt_data_quality")
+    elementary_alerts = elementary_task(dag, "dbt_data_quality", resource_cfg="dbt")
 
     elementary_alerts

--- a/dags/dbt_data_quality_alerts_dag.py
+++ b/dags/dbt_data_quality_alerts_dag.py
@@ -18,7 +18,7 @@ with DAG(
     default_args=get_default_dag_args(),
     start_date=datetime(2024, 6, 25, 0, 0),
     description="This DAG runs dbt tests and Elementary alerts at a half-hourly cadence",
-    schedule="15,45 * * * *",  # Runs every 15th minute and every 45th minute
+    schedule="*/15 * * * *",  # Runs every 15 minutes
     user_defined_filters={
         "container_resources": lambda s: k8s.V1ResourceRequirements(requests=s),
     },

--- a/dags/dbt_singular_tests_dag.py
+++ b/dags/dbt_singular_tests_dag.py
@@ -33,6 +33,7 @@ with DAG(
         dag,
         command_type="test",
         tag="singular_test",
+        resource_cfg="dbt",
     )
 
     singular_tests

--- a/dags/dbt_singular_tests_dag.py
+++ b/dags/dbt_singular_tests_dag.py
@@ -14,21 +14,25 @@ from stellar_etl_airflow.default import (
 init_sentry()
 
 with DAG(
-    "dbt_data_quality_alerts",
+    "dbt_singular_tests",
     default_args=get_default_dag_args(),
     start_date=datetime(2024, 6, 25, 0, 0),
-    description="This DAG runs dbt tests and Elementary alerts at a half-hourly cadence",
-    schedule="15,45 * * * *",  # Runs every 15th minute and every 45th minute
+    description="This DAG runs non-model dbt tests half-hourly cadence",
+    schedule="*/30 * * * *",  # Runs every 30 minutes
     user_defined_filters={
         "container_resources": lambda s: k8s.V1ResourceRequirements(requests=s),
     },
     max_active_runs=1,
     catchup=False,
-    tags=["dbt-data-quality", "dbt-elementary-alerts"],
+    tags=["dbt-data-quality"],
     # sla_miss_callback=alert_sla_miss,
 ) as dag:
 
-    # Trigger elementary
-    elementary_alerts = elementary_task(dag, "dbt_data_quality")
+    # DBT tests to run
+    singular_tests = dbt_task(
+        dag,
+        command_type="test",
+        tag="singular_test",
+    )
 
-    elementary_alerts
+    singular_tests

--- a/dags/history_tables_dag.py
+++ b/dags/history_tables_dag.py
@@ -112,6 +112,7 @@ op_export_task = build_export_task(
     use_gcs=True,
     use_captive_core=use_captive_core,
     txmeta_datastore_path=txmeta_datastore_path,
+    resource_cfg="stellar-etl",
 )
 
 trade_export_task = build_export_task(
@@ -124,6 +125,7 @@ trade_export_task = build_export_task(
     use_gcs=True,
     use_captive_core=use_captive_core,
     txmeta_datastore_path=txmeta_datastore_path,
+    resource_cfg="stellar-etl",
 )
 
 effects_export_task = build_export_task(
@@ -136,6 +138,7 @@ effects_export_task = build_export_task(
     use_gcs=True,
     use_captive_core=use_captive_core,
     txmeta_datastore_path=txmeta_datastore_path,
+    resource_cfg="stellar-etl",
 )
 
 tx_export_task = build_export_task(
@@ -148,6 +151,7 @@ tx_export_task = build_export_task(
     use_gcs=True,
     use_captive_core=use_captive_core,
     txmeta_datastore_path=txmeta_datastore_path,
+    resource_cfg="stellar-etl",
 )
 
 ledger_export_task = build_export_task(
@@ -160,6 +164,7 @@ ledger_export_task = build_export_task(
     use_gcs=True,
     use_captive_core=use_captive_core,
     txmeta_datastore_path=txmeta_datastore_path,
+    resource_cfg="stellar-etl",
 )
 
 asset_export_task = build_export_task(
@@ -172,6 +177,7 @@ asset_export_task = build_export_task(
     use_gcs=True,
     use_captive_core=use_captive_core,
     txmeta_datastore_path=txmeta_datastore_path,
+    resource_cfg="stellar-etl",
 )
 
 contract_events_export_task = build_export_task(
@@ -184,6 +190,7 @@ contract_events_export_task = build_export_task(
     use_gcs=True,
     use_captive_core=use_captive_core,
     txmeta_datastore_path=txmeta_datastore_path,
+    resource_cfg="stellar-etl",
 )
 
 """

--- a/dags/history_tables_dag.py
+++ b/dags/history_tables_dag.py
@@ -112,7 +112,7 @@ op_export_task = build_export_task(
     use_gcs=True,
     use_captive_core=use_captive_core,
     txmeta_datastore_path=txmeta_datastore_path,
-    resource_cfg="stellar-etl",
+    resource_cfg="stellaretl",
 )
 
 trade_export_task = build_export_task(
@@ -125,7 +125,7 @@ trade_export_task = build_export_task(
     use_gcs=True,
     use_captive_core=use_captive_core,
     txmeta_datastore_path=txmeta_datastore_path,
-    resource_cfg="stellar-etl",
+    resource_cfg="stellaretl",
 )
 
 effects_export_task = build_export_task(
@@ -138,7 +138,7 @@ effects_export_task = build_export_task(
     use_gcs=True,
     use_captive_core=use_captive_core,
     txmeta_datastore_path=txmeta_datastore_path,
-    resource_cfg="stellar-etl",
+    resource_cfg="stellaretl",
 )
 
 tx_export_task = build_export_task(
@@ -151,7 +151,7 @@ tx_export_task = build_export_task(
     use_gcs=True,
     use_captive_core=use_captive_core,
     txmeta_datastore_path=txmeta_datastore_path,
-    resource_cfg="stellar-etl",
+    resource_cfg="stellaretl",
 )
 
 ledger_export_task = build_export_task(
@@ -164,7 +164,7 @@ ledger_export_task = build_export_task(
     use_gcs=True,
     use_captive_core=use_captive_core,
     txmeta_datastore_path=txmeta_datastore_path,
-    resource_cfg="stellar-etl",
+    resource_cfg="stellaretl",
 )
 
 asset_export_task = build_export_task(
@@ -177,7 +177,7 @@ asset_export_task = build_export_task(
     use_gcs=True,
     use_captive_core=use_captive_core,
     txmeta_datastore_path=txmeta_datastore_path,
-    resource_cfg="stellar-etl",
+    resource_cfg="stellaretl",
 )
 
 contract_events_export_task = build_export_task(
@@ -190,7 +190,7 @@ contract_events_export_task = build_export_task(
     use_gcs=True,
     use_captive_core=use_captive_core,
     txmeta_datastore_path=txmeta_datastore_path,
-    resource_cfg="stellar-etl",
+    resource_cfg="stellaretl",
 )
 
 """

--- a/dags/state_table_dag.py
+++ b/dags/state_table_dag.py
@@ -102,6 +102,7 @@ changes_task = build_export_task(
     use_gcs=True,
     use_captive_core=use_captive_core,
     txmeta_datastore_path=txmeta_datastore_path,
+    resource_cfg="stellar-etl",
 )
 
 """

--- a/dags/state_table_dag.py
+++ b/dags/state_table_dag.py
@@ -102,7 +102,7 @@ changes_task = build_export_task(
     use_gcs=True,
     use_captive_core=use_captive_core,
     txmeta_datastore_path=txmeta_datastore_path,
-    resource_cfg="stellar-etl",
+    resource_cfg="stellaretl",
 )
 
 """


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

- [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
- [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
      otherwise).
- [ ] This PR's title starts with the jira ticket associated with the PR.

### Thoroughness

- [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
- [ ] I've updated the README with the added features, breaking changes, new instructions on how to use the repository.

</details>

### What

Reducing airflow resources to reduce costs and splitting out tests from the elementary alert DAG

### Why

* Airflow resources were originally set for using captive core. Now that we have moved to CDP and observed the actual resources needed. We can greatly reduce the resources requested
* The elementary alert DAG has a dependency on a dbt test. If this test fails the elementary alerts won't actually fire. Separating them out should avoid this

### Known limitations

N/A
