### PR TITLE
Update BQ schema and bump airflow/dbt images

### DIFF
--- a/airflow_variables_dev.json
+++ b/airflow_variables_dev.json
@@ -154,7 +154,7 @@
   },
   "gcs_exported_data_bucket_name": "us-central1-test-hubble-2-5f1f2dbf-bucket",
   "gcs_exported_object_prefix": "dag-exported",
-  "image_name": "stellar/stellar-etl:98bea9a",
+  "image_name": "amishastellar/stellar-etl:pr-268",
   "image_output_path": "/etl/exported_data/",
   "image_pull_policy": "IfNotPresent",
   "k8s_namespace": "hubble-composer",

--- a/airflow_variables_dev.json
+++ b/airflow_variables_dev.json
@@ -122,7 +122,7 @@
     "partnership_assets__account_holders_activity_fact": false,
     "partnership_assets__asset_activity_fact": false
   },
-  "dbt_image_name": "stellar/stellar-dbt:3e34e0e",
+  "dbt_image_name": "stellar/stellar-dbt:c37ade6",
   "dbt_internal_source_db": "test-hubble-319619",
   "dbt_internal_source_schema": "test_crypto_stellar_internal",
   "dbt_job_execution_timeout_seconds": 300,
@@ -154,7 +154,7 @@
   },
   "gcs_exported_data_bucket_name": "us-central1-test-hubble-2-5f1f2dbf-bucket",
   "gcs_exported_object_prefix": "dag-exported",
-  "image_name": "amishastellar/stellar-etl:pr-268",
+  "image_name": "stellar/stellar-etl:741ee9b",
   "image_output_path": "/etl/exported_data/",
   "image_pull_policy": "IfNotPresent",
   "k8s_namespace": "hubble-composer",

--- a/airflow_variables_prod.json
+++ b/airflow_variables_prod.json
@@ -123,7 +123,7 @@
     "partnership_assets__asset_activity_fact": false,
     "trade_agg": false
   },
-  "dbt_image_name": "stellar/stellar-dbt:3e34e0e",
+  "dbt_image_name": "stellar/stellar-dbt:c37ade6",
   "dbt_internal_source_db": "hubble-261722",
   "dbt_internal_source_schema": "crypto_stellar_internal_2",
   "dbt_job_execution_timeout_seconds": 1800,
@@ -155,7 +155,7 @@
   },
   "gcs_exported_data_bucket_name": "us-central1-hubble-14c4ca64-bucket",
   "gcs_exported_object_prefix": "dag-exported",
-  "image_name": "stellar/stellar-etl:ab57fa4",
+  "image_name": "stellar/stellar-etl:741ee9b",
   "image_output_path": "/etl/exported_data/",
   "image_pull_policy": "IfNotPresent",
   "k8s_namespace": "hubble-composer",

--- a/schemas/trust_lines_schema.json
+++ b/schemas/trust_lines_schema.json
@@ -12,7 +12,7 @@
   {
     "mode": "NULLABLE",
     "name": "asset_type",
-    "type": "INTEGER"
+    "type": "STRING"
   },
   {
     "mode": "NULLABLE",


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

- [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
- [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
      otherwise).
- [ ] This PR's title starts with the jira ticket associated with the PR.

### Thoroughness

- [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
- [ ] I've updated the README with the added features, breaking changes, new instructions on how to use the repository.

</details>

### What

This PR updates etl image and DBT image so as to update the data type of AssetType for Trustlines tables from integer to string.
Related PRs:
- https://github.com/stellar/stellar-etl/pull/268
- https://github.com/stellar/stellar-dbt-public/pull/64

### Why

This is done to make AssetType consistent across all the schemas as it was mistakenly added as integer earlier.

### Known limitations

None. Deploy plan posted in Jira
