### PR TITLE
Update DBT image to reduce timeframe for claimable balance current model

### DIFF
--- a/airflow_variables_dev.json
+++ b/airflow_variables_dev.json
@@ -122,7 +122,7 @@
     "partnership_assets__account_holders_activity_fact": false,
     "partnership_assets__asset_activity_fact": false
   },
-  "dbt_image_name": "stellar/stellar-dbt:7356c7f",
+  "dbt_image_name": "stellar/stellar-dbt:fcf76b8",
   "dbt_internal_source_db": "test-hubble-319619",
   "dbt_internal_source_schema": "test_crypto_stellar_internal",
   "dbt_job_execution_timeout_seconds": 300,

--- a/airflow_variables_prod.json
+++ b/airflow_variables_prod.json
@@ -123,7 +123,7 @@
     "partnership_assets__asset_activity_fact": false,
     "trade_agg": false
   },
-  "dbt_image_name": "stellar/stellar-dbt:7356c7f",
+  "dbt_image_name": "stellar/stellar-dbt:fcf76b8",
   "dbt_internal_source_db": "hubble-261722",
   "dbt_internal_source_schema": "crypto_stellar_internal_2",
   "dbt_job_execution_timeout_seconds": 1800,


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

- [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
- [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
      otherwise).
- [ ] This PR's title starts with the jira ticket associated with the PR.

### Thoroughness

- [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
- [ ] I've updated the README with the added features, breaking changes, new instructions on how to use the repository.

</details>

### What

Ref: https://github.com/stellar/stellar-dbt-public/pull/69

### Why

The airflow run time has increased enormously high from ~18 min to ~30 min if we process last 7 days worth of data for claimable balances.

### Known limitations

None
