### PR TITLE
Fixes bug in elementary target definition

### DIFF
--- a/airflow_variables_dev.json
+++ b/airflow_variables_dev.json
@@ -117,6 +117,7 @@
   },
   "dbt_dataset_for_test": "test",
   "dbt_elementary_dataset": "test_elementary",
+  "dbt_elementary_target": "elementary",
   "dbt_elementary_secret": "slack-token-elementary",
   "dbt_full_refresh_models": {
     "partnership_assets__account_holders_activity_fact": false,

--- a/airflow_variables_dev.json
+++ b/airflow_variables_dev.json
@@ -117,8 +117,8 @@
   },
   "dbt_dataset_for_test": "test",
   "dbt_elementary_dataset": "test_elementary",
-  "dbt_elementary_target": "elementary",
   "dbt_elementary_secret": "slack-token-elementary",
+  "dbt_elementary_target": "elementary",
   "dbt_full_refresh_models": {
     "partnership_assets__account_holders_activity_fact": false,
     "partnership_assets__asset_activity_fact": false

--- a/airflow_variables_prod.json
+++ b/airflow_variables_prod.json
@@ -109,6 +109,7 @@
   },
   "dbt_dataset_for_test": "placeholder_value",
   "dbt_elementary_dataset": "elementary",
+  "dbt_elementary_target": "elementary",
   "dbt_elementary_secret": "slack-token-elementary",
   "dbt_full_refresh_models": {
     "history_assets": false,

--- a/airflow_variables_prod.json
+++ b/airflow_variables_prod.json
@@ -109,8 +109,8 @@
   },
   "dbt_dataset_for_test": "placeholder_value",
   "dbt_elementary_dataset": "elementary",
-  "dbt_elementary_target": "elementary",
   "dbt_elementary_secret": "slack-token-elementary",
+  "dbt_elementary_target": "elementary",
   "dbt_full_refresh_models": {
     "history_assets": false,
     "int_partnership_assets__account_holders_activity": false,

--- a/dags/stellar_etl_airflow/build_elementary_slack_alert_task.py
+++ b/dags/stellar_etl_airflow/build_elementary_slack_alert_task.py
@@ -62,7 +62,7 @@ def elementary_task(
         env_vars={
             "DBT_USE_COLORS": "0",
             "DBT_DATASET": "{{ var.value.dbt_elementary_dataset }}",
-            "DBT_TARGET": "{{ var.value.dbt_target }}",
+            "DBT_TARGET": "{{ var.value.dbt_elementary_target }}",
             "DBT_MAX_BYTES_BILLED": "{{ var.value.dbt_maximum_bytes_billed }}",
             "DBT_JOB_TIMEOUT": "{{ var.value.dbt_job_execution_timeout_seconds }}",
             "DBT_THREADS": "{{ var.value.dbt_threads }}",


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

- [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
- [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
      otherwise).
- [ ] This PR's title starts with the jira ticket associated with the PR.

### Thoroughness

- [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
- [ ] I've updated the README with the added features, breaking changes, new instructions on how to use the repository.

</details>

### What

Fixes bug in dbt_data_quality_alert Dag, which was throwing following error post upgrading to version 1.8

```
[2024-08-16 15:30:38.931554+00:00] {pod_manager.py:468} INFO - [base] 2024-08-16 15:30:38 — INFO —
[2024-08-16 15:30:38.931842+00:00] {pod_manager.py:468} INFO - [base] 2024-08-16 15:30:38 — INFO — Updates available for packages: ['dbt-labs/dbt_utils', 'elementary-data/elementary']
[2024-08-16 15:30:42.439841+00:00] {pod_manager.py:468} INFO - [base] Update your versions in packages.yml, then run dbt deps
[2024-08-16 15:30:42.440148+00:00] {pod_manager.py:468} INFO - [base] [31;20m2024-08-16 15:30:42 — ERROR — Unable to get the latest invocation: Failed to run dbt command.
[2024-08-16 15:30:42.440419+00:00] {pod_manager.py:468} INFO - [base] Encountered an error:
[2024-08-16 15:30:42.440656+00:00] {pod_manager.py:468} INFO - [base] Runtime Error
[2024-08-16 15:30:42.440851+00:00] {pod_manager.py:468} INFO - [base]   The profile 'elementary' does not have a target named 'test'. The valid target names for this profile are:
[2024-08-16 15:30:48.720775+00:00] {pod_manager.py:468} INFO - [base]    - elementary[0m
[2024-08-16 15:30:48.721224+00:00] {pod_manager.py:468} INFO - [base] [31;20m2024-08-16 15:30:48 — ERROR — Failed to parse Elementary's database and schema.[0m
```

### Why

I am unsure why we did not have this error before. But looks like with new version, dbt has enforced target validation. 
Earlier we were passing `dbt_target` as `prod` and still the DAG will pick `elementary` as target since that's the only target `elementary` profile contains.
However, it now complains that you are passing `dbt_target` as `prod` and only targets which are available are `elementary`.

Therefore, I made change in this PR to explicitly pass `dbt_target` for elementary task as `elementary`. For context, following is the code for elementary profile.

```
elementary:
  target: "elementary"
  outputs:
    elementary:
      dataset: "{{ env_var('DBT_DATASET') }}"
      project: "{{ env_var('DBT_PROJECT') }}"
      maximum_bytes_billed: "{{ env_var('DBT_MAX_BYTES_BILLED') | as_number }}"
      job_execution_timeout_seconds: "{{ env_var('DBT_JOB_TIMEOUT') | int }}"
      threads: "{{ env_var('DBT_THREADS') | int }}"
      job_retries: "{{ env_var('DBT_JOB_RETRIES') | int }}"
      priority: interactive
      location: us
      method: oauth
      type: bigquery
```

### Known limitations
None

### Testing

I tested it on test-hubble and confirmed the patch resolves the issue
