### PR TITLE
Add Sentry failure callback to custom python operator

### DIFF
--- a/dags/stellar_etl_airflow/build_del_ins_operator.py
+++ b/dags/stellar_etl_airflow/build_del_ins_operator.py
@@ -1,5 +1,5 @@
 from airflow.operators.python import PythonOperator
-
+from stellar_etl_airflow.default import alert_after_max_retries
 
 def initialize_task_vars(
     table_id,
@@ -70,5 +70,6 @@ def create_del_ins_task(dag, task_vars, del_ins_callable):
         python_callable=del_ins_callable,
         op_kwargs=task_vars,
         provide_context=True,
+        on_failure_callback=alert_after_max_retries,
         dag=dag,
     )

--- a/dags/stellar_etl_airflow/build_del_ins_operator.py
+++ b/dags/stellar_etl_airflow/build_del_ins_operator.py
@@ -1,6 +1,7 @@
 from airflow.operators.python import PythonOperator
 from stellar_etl_airflow.default import alert_after_max_retries
 
+
 def initialize_task_vars(
     table_id,
     table_name,


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

- [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
- [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
      otherwise).
- [ ] This PR's title starts with the jira ticket associated with the PR.

### Thoroughness

- [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
- [ ] I've updated the README with the added features, breaking changes, new instructions on how to use the repository.

</details>

### What

Airflow was not passing failed task status to Sentry correctly for `del_ins_` tasks in the `history_table_export` DAG. The team was not getting notified when the task would fail, requiring manual inspection in Airflow to know if such tasks failed.

### Why

I think the callback was defined too deep into the `del_ins` operator. There is an custom Python wrapper operator, called `build_del_ins_operator` that calls the actual operators that delete and insert data in BigQuery. The callback was set in the delete/insert operators, but not the Python wrapper. Adding to the wrapper to see if errors are sent to Sentry.
 
### Known limitations

Needs testing in test to confirm that it works correctly. 