### PR TITLE
Fix logging in airflow

### DIFF
--- a/airflow_variables_dev.json
+++ b/airflow_variables_dev.json
@@ -155,7 +155,7 @@
   },
   "gcs_exported_data_bucket_name": "us-central1-test-hubble-43c3e190-bucket",
   "gcs_exported_object_prefix": "dag-exported",
-  "image_name": "stellar/stellar-etl:283c830e0",
+  "image_name": "stellar/stellar-etl:5d714ddce",
   "image_output_path": "/etl/exported_data/",
   "image_pull_policy": "IfNotPresent",
   "k8s_namespace": "hubble-composer",

--- a/airflow_variables_dev.json
+++ b/airflow_variables_dev.json
@@ -155,7 +155,7 @@
   },
   "gcs_exported_data_bucket_name": "us-central1-test-hubble-43c3e190-bucket",
   "gcs_exported_object_prefix": "dag-exported",
-  "image_name": "stellar/stellar-etl:e72e36766",
+  "image_name": "stellar/stellar-etl:283c830e0",
   "image_output_path": "/etl/exported_data/",
   "image_pull_policy": "IfNotPresent",
   "k8s_namespace": "hubble-composer",

--- a/airflow_variables_prod.json
+++ b/airflow_variables_prod.json
@@ -156,7 +156,7 @@
   },
   "gcs_exported_data_bucket_name": "us-central1-hubble-14c4ca64-bucket",
   "gcs_exported_object_prefix": "dag-exported",
-  "image_name": "stellar/stellar-etl:283c830e0",
+  "image_name": "stellar/stellar-etl:5d714ddce",
   "image_output_path": "/etl/exported_data/",
   "image_pull_policy": "IfNotPresent",
   "k8s_namespace": "hubble-composer",

--- a/airflow_variables_prod.json
+++ b/airflow_variables_prod.json
@@ -156,7 +156,7 @@
   },
   "gcs_exported_data_bucket_name": "us-central1-hubble-14c4ca64-bucket",
   "gcs_exported_object_prefix": "dag-exported",
-  "image_name": "stellar/stellar-etl:e72e36766",
+  "image_name": "stellar/stellar-etl:283c830e0",
   "image_output_path": "/etl/exported_data/",
   "image_pull_policy": "IfNotPresent",
   "k8s_namespace": "hubble-composer",

--- a/dags/stellar_etl_airflow/build_export_task.py
+++ b/dags/stellar_etl_airflow/build_export_task.py
@@ -211,10 +211,10 @@ def build_export_task(
     )
 
     if command == "export_ledger_entry_changes" or command == "export_all_history":
-        arguments = f"""{etl_cmd_string} && echo "{{\\"output\\": \\"{output_file}\\"}}" >> /airflow/xcom/return.json"""
+        arguments = f"""{etl_cmd_string} 1>> stdout.out 2>> stderr.out && cat stdout.out && cat stderr.out && echo "{{\\"output\\": \\"{output_file}\\"}}" >> /airflow/xcom/return.json"""
     else:
         arguments = f"""
-                    {etl_cmd_string} 2>> stderr.out && echo "{{\\"output\\": \\"{output_file}\\",
+                    {etl_cmd_string} 1>> stdout.out 2>> stderr.out && cat stdout.out && cat stderr.out && echo "{{\\"output\\": \\"{output_file}\\",
                     \\"failed_transforms\\": `grep failed_transforms stderr.out | cut -d\\",\\" -f2 | cut -d\\":\\" -f2`}}" >> /airflow/xcom/return.json
                     """
     return KubernetesPodOperator(


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

- [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
- [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
      otherwise).
- [ ] This PR's title starts with the jira ticket associated with the PR.

### Thoroughness

- [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
- [ ] I've updated the README with the added features, breaking changes, new instructions on how to use the repository.

</details>

### What

Updating the build_export_task to redirect stdout and stderr and then `cat` to output the stellar-etl logs to the airflow task log file.

### Why

For some reason if you don't redirect the stdout and stderr to a file the output messages never get recorded by the airflow task log file.

### Known limitations

This is pretty hacky and not ideal but it will at least get us logs in the stellar-etl airflow tasks. The interesting thing is that stderr error was already being redirected by the history_* export tasks but was just never written back out to the airflow task log

More exploration into why this is happening can be done in the future such as play with different k8sPodOperator settings, airflow settings, airflow task settings, airflow version limitation, etc...
