### PR TITLE
Add 30 day filter to audit_log

### DIFF
--- a/dags/queries/audit_log.sql
+++ b/dags/queries/audit_log.sql
@@ -229,6 +229,8 @@ WITH jobChangeEvent AS (
     JSON_EXTRACT_SCALAR(protopayload_auditlog.metadataJson, '$.jobChange.after') AS jobChangeAfter,
     REGEXP_EXTRACT(protopayload_auditlog.metadataJson, r'BigQueryAuditMetadata","(.*?)":') AS eventName,
   FROM {project_id}.{dataset_id}.cloudaudit_googleapis_com_data_access
+  where true
+    and timestamp >= current_timestamp - interval 30 day
 ),
 /*
  * TableCreation: Table creation event.
@@ -272,6 +274,8 @@ tableCreationEvent AS (
     JSON_EXTRACT_SCALAR(protopayload_auditlog.metadataJson,
       '$.tableCreation.reason')  AS tableCreationReason,
   FROM {project_id}.{dataset_id}.cloudaudit_googleapis_com_activity
+  where true
+    and timestamp >= current_timestamp - interval 30 day
 ),
 /*
  * TableChange: Table metadata change event
@@ -317,6 +321,8 @@ tableChangeEvent AS (
     CAST(JSON_EXTRACT_SCALAR(protopayload_auditlog.metadataJson,
       '$.tableChange.truncated') AS BOOL) AS tableChangeTruncated
   FROM {project_id}.{dataset_id}.cloudaudit_googleapis_com_activity
+  where true
+    and timestamp >= current_timestamp - interval 30 day
 ),
 /*
  * TableDeletion: Table deletion event
@@ -337,6 +343,8 @@ tableDeletionEvent AS (
     JSON_EXTRACT_SCALAR(protopayload_auditlog.metadataJson,
       '$.tableDeletion.reason') AS tableDeletionReason,
   FROM {project_id}.{dataset_id}.cloudaudit_googleapis_com_activity
+  where true
+    and timestamp >= current_timestamp - interval 30 day
 ),
 /*
  * TableDataRead: Data from tableDataRead audit logs
@@ -382,6 +390,8 @@ tableDataReadEvent AS (
       JSON_EXTRACT(protopayload_auditlog.metadataJson, '$.tableDataRead.sessionName')
       IGNORE NULLS ORDER BY protopayload_auditlog.resourceName) AS tableDataReadSessionName,
   FROM {project_id}.{dataset_id}.cloudaudit_googleapis_com_data_access
+  where true
+    and timestamp >= current_timestamp - interval 30 day
   GROUP BY jobId
 ),
 /*
@@ -411,6 +421,8 @@ tableDataChangeEvent AS (
     JSON_EXTRACT_SCALAR(protopayload_auditlog.metadataJson,
       '$.tableDataChange.jobName') AS tableDataChangeJobName,
   FROM {project_id}.{dataset_id}.cloudaudit_googleapis_com_data_access
+  where true
+    and timestamp >= current_timestamp - interval 30 day
 )
  -- End of WITH clauses
 SELECT


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

- [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
- [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
      otherwise).
- [ ] This PR's title starts with the jira ticket associated with the PR.

### Thoroughness

- [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
- [ ] I've updated the README with the added features, breaking changes, new instructions on how to use the repository.

</details>

### What

Adding a 30 day filter to the `audit_log` query. Was originally failing because it is a full table truncate_write where full history  was causing the following error:

```
google.api_core.exceptions.BadRequest: 400 Resources exceeded during query execution: The query could not be executed in the allotted memory. Peak usage: 147% of limit.
Top memory consumer(s):
  aggregate functions and GROUP BY clauses: 99%
  other/unattributed: 1%
```

### Why

To fix running the audit_log_dag

### Known limitations

The audit_log table will no longer contain full history but instead only 30 days of information. The source tables that produce the audit_log however will continue to have full history. The query will need to be manually run with the correct timestamp window if information more than 30 days ago is needed
