### PR TITLE
Generate avro files from bq tables

### DIFF
--- a/.sqlfluff
+++ b/.sqlfluff
@@ -81,6 +81,7 @@ batch_id = batch_id
 batch_run_date = batch_run_date
 prev_batch_run_date = prev_batch_run_date
 next_batch_run_date = next_batch_run_date
+uri = uri
 
 # Some rules can be configured directly from the config common to other rules
 [sqlfluff:rules]

--- a/airflow_variables_dev.json
+++ b/airflow_variables_dev.json
@@ -334,13 +334,13 @@
   "task_sla": {
     "asset_stats": 720,
     "build_batch_stats": 840,
+    "build_bq_generate_avro_job": 600,
     "build_bq_insert_job": 1080,
     "build_del_ins_from_gcs_to_bq_task": 2000,
     "build_delete_data_task": 1020,
     "build_export_task": 840,
     "build_gcs_to_bq_task": 960,
     "build_time_task": 480,
-    "build_bq_generate_avro_job": 600,
     "cleanup_metadata": 60,
     "create_sandbox": 2400,
     "current_state": 720,
@@ -368,6 +368,7 @@
   },
   "task_timeout": {
     "build_batch_stats": 180,
+    "build_bq_generate_avro_job": 600,
     "build_bq_insert_job": 180,
     "build_copy_table": 180,
     "build_dbt_task": 960,
@@ -375,8 +376,7 @@
     "build_delete_data_task": 180,
     "build_export_task": 420,
     "build_gcs_to_bq_task": 300,
-    "build_time_task": 480,
-    "build_bq_generate_avro_job": 600
+    "build_time_task": 480
   },
   "txmeta_datastore_path": "sdf-ledger-close-meta/ledgers",
   "use_captive_core": "False",

--- a/airflow_variables_dev.json
+++ b/airflow_variables_dev.json
@@ -1,5 +1,6 @@
 {
   "api_key_path": "/home/airflow/gcs/data/apiKey.json",
+  "avro_gcs_bucket": "test_dune_bucket_sdf",
   "bq_dataset": "test_crypto_stellar_internal",
   "bq_dataset_audit_log": "audit_log",
   "bq_project": "test-hubble-319619",
@@ -339,6 +340,7 @@
     "build_export_task": 840,
     "build_gcs_to_bq_task": 960,
     "build_time_task": 480,
+    "build_bq_generate_avro_job": 600,
     "cleanup_metadata": 60,
     "create_sandbox": 2400,
     "current_state": 720,
@@ -373,7 +375,8 @@
     "build_delete_data_task": 180,
     "build_export_task": 420,
     "build_gcs_to_bq_task": 300,
-    "build_time_task": 480
+    "build_time_task": 480,
+    "build_bq_generate_avro_job": 600
   },
   "txmeta_datastore_path": "sdf-ledger-close-meta/ledgers",
   "use_captive_core": "False",

--- a/airflow_variables_prod.json
+++ b/airflow_variables_prod.json
@@ -1,5 +1,6 @@
 {
   "api_key_path": "/home/airflow/gcs/data/apiKey.json",
+  "avro_gcs_bucket": "dune_bucket_sdf",
   "bq_dataset": "crypto_stellar_internal_2",
   "bq_dataset_audit_log": "audit_log",
   "bq_project": "hubble-261722",
@@ -337,6 +338,7 @@
     "build_export_task": 600,
     "build_gcs_to_bq_task": 660,
     "build_time_task": 300,
+    "build_bq_generate_avro_job": 600,
     "cleanup_metadata": 60,
     "create_sandbox": 1020,
     "current_state": 1200,
@@ -371,7 +373,8 @@
     "build_delete_data_task": 180,
     "build_export_task": 300,
     "build_gcs_to_bq_task": 300,
-    "build_time_task": 360
+    "build_time_task": 360,
+    "build_bq_generate_avro_job": 600
   },
   "txmeta_datastore_path": "sdf-ledger-close-meta/ledgers",
   "use_captive_core": "False",

--- a/airflow_variables_prod.json
+++ b/airflow_variables_prod.json
@@ -332,13 +332,13 @@
   "task_sla": {
     "asset_stats": 420,
     "build_batch_stats": 600,
+    "build_bq_generate_avro_job": 600,
     "build_bq_insert_job": 840,
     "build_del_ins_from_gcs_to_bq_task": 2000,
     "build_delete_data_task": 780,
     "build_export_task": 600,
     "build_gcs_to_bq_task": 660,
     "build_time_task": 300,
-    "build_bq_generate_avro_job": 600,
     "cleanup_metadata": 60,
     "create_sandbox": 1020,
     "current_state": 1200,
@@ -366,6 +366,7 @@
   },
   "task_timeout": {
     "build_batch_stats": 180,
+    "build_bq_generate_avro_job": 600,
     "build_bq_insert_job": 180,
     "build_copy_table": 180,
     "build_dbt_task": 1800,
@@ -373,8 +374,7 @@
     "build_delete_data_task": 180,
     "build_export_task": 300,
     "build_gcs_to_bq_task": 300,
-    "build_time_task": 360,
-    "build_bq_generate_avro_job": 600
+    "build_time_task": 360
   },
   "txmeta_datastore_path": "sdf-ledger-close-meta/ledgers",
   "use_captive_core": "False",

--- a/dags/generate_avro_files_dag.py
+++ b/dags/generate_avro_files_dag.py
@@ -1,11 +1,12 @@
 from datetime import datetime
 
 from airflow import DAG
-from kubernetes.client import models as k8s
+from stellar_etl_airflow import macros
+from stellar_etl_airflow.build_cross_dependency_task import build_cross_deps
 from stellar_etl_airflow.build_bq_generate_avro_job_task import (
     build_bq_generate_avro_job,
 )
-from stellar_etl_airflow.build_cross_dependency_task import build_cross_deps
+from airflow.operators.dummy import DummyOperator
 from stellar_etl_airflow.default import (
     alert_sla_miss,
     get_default_dag_args,
@@ -15,16 +16,18 @@ from stellar_etl_airflow.default import (
 init_sentry()
 
 dag = DAG(
-    "generate_avro_files",
+    "generate_avro",
     default_args=get_default_dag_args(),
-    start_date=datetime(2024, 10, 1, 0, 0),
-    description="This DAG generates AVRO files from BQ tables",
-    schedule_interval="0 * * * *",  # Runs every hour
-    user_defined_filters={
-        "container_resources": lambda s: k8s.V1ResourceRequirements(requests=s),
-    },
-    max_active_runs=5,
+    start_date=datetime(2024, 10, 1, 1, 0),
     catchup=True,
+    description="This DAG generates AVRO files from BQ tables",
+    schedule_interval="0 * * * *",
+    render_template_as_native_obj=True,
+    user_defined_macros={
+        "subtract_data_interval": macros.subtract_data_interval,
+        "batch_run_date_as_datetime_string": macros.batch_run_date_as_datetime_string,
+        "batch_run_date_as_directory_string": macros.batch_run_date_as_directory_string,
+    },
     sla_miss_callback=alert_sla_miss,
 )
 
@@ -32,11 +35,14 @@ public_project = "{{ var.value.public_project }}"
 public_dataset = "{{ var.value.public_dataset }}"
 gcs_bucket = "{{ var.value.avro_gcs_bucket }}"
 
+
 # Wait on ingestion DAGs
 wait_on_history_table = build_cross_deps(
     dag, "wait_on_ledgers_txs", "history_table_export"
 )
 wait_on_state_table = build_cross_deps(dag, "wait_on_state_table", "state_table_export")
+
+dummy_task = DummyOperator(task_id='dummy_task', dag=dag)
 
 # Generate AVRO files
 avro_tables = [
@@ -55,7 +61,7 @@ avro_tables = [
 ]
 
 for table in avro_tables:
-    task = build_bq_generate_avro_job(
+    avro_task = build_bq_generate_avro_job(
         dag=dag,
         project=public_project,
         dataset=public_dataset,
@@ -63,5 +69,7 @@ for table in avro_tables:
         gcs_bucket=gcs_bucket,
     )
 
-    wait_on_history_table >> task
-    wait_on_state_table >> task
+    dummy_task >> avro_task
+    wait_on_history_table >> avro_task
+    wait_on_state_table >> avro_task
+

--- a/dags/generate_avro_files_dag.py
+++ b/dags/generate_avro_files_dag.py
@@ -2,10 +2,10 @@ from datetime import datetime
 
 from airflow import DAG
 from kubernetes.client import models as k8s
-from stellar_etl_airflow.build_cross_dependency_task import build_cross_deps
 from stellar_etl_airflow.build_bq_generate_avro_job_task import (
-    build_bq_generate_avro_job
+    build_bq_generate_avro_job,
 )
+from stellar_etl_airflow.build_cross_dependency_task import build_cross_deps
 from stellar_etl_airflow.default import (
     alert_sla_miss,
     get_default_dag_args,

--- a/dags/generate_avro_files_dag.py
+++ b/dags/generate_avro_files_dag.py
@@ -29,6 +29,10 @@ dag = DAG(
     sla_miss_callback=alert_sla_miss,
 )
 
+public_project = "{{ var.value.public_project }}"
+public_dataset = "{{ var.value.public_dataset }}"
+gcs_bucket = "{{ var.value.avro_gcs_bucket }}"
+
 # Wait on ingestion DAGs
 wait_on_history_table = build_cross_deps(
     dag, "wait_on_ledgers_txs", "history_table_export"

--- a/dags/generate_avro_files_dag.py
+++ b/dags/generate_avro_files_dag.py
@@ -1,12 +1,12 @@
 from datetime import datetime
 
 from airflow import DAG
+from airflow.operators.dummy import DummyOperator
 from stellar_etl_airflow import macros
-from stellar_etl_airflow.build_cross_dependency_task import build_cross_deps
 from stellar_etl_airflow.build_bq_generate_avro_job_task import (
     build_bq_generate_avro_job,
 )
-from airflow.operators.dummy import DummyOperator
+from stellar_etl_airflow.build_cross_dependency_task import build_cross_deps
 from stellar_etl_airflow.default import (
     alert_sla_miss,
     get_default_dag_args,
@@ -42,7 +42,7 @@ wait_on_history_table = build_cross_deps(
 )
 wait_on_state_table = build_cross_deps(dag, "wait_on_state_table", "state_table_export")
 
-dummy_task = DummyOperator(task_id='dummy_task', dag=dag)
+dummy_task = DummyOperator(task_id="dummy_task", dag=dag)
 
 # Generate AVRO files
 avro_tables = [

--- a/dags/generate_avro_files_dag.py
+++ b/dags/generate_avro_files_dag.py
@@ -42,6 +42,7 @@ wait_on_history_table = build_cross_deps(
 )
 wait_on_state_table = build_cross_deps(dag, "wait_on_state_table", "state_table_export")
 
+# Add dummy_task so DAG generates the avro_tables loop and dependency graph correctly
 dummy_task = DummyOperator(task_id="dummy_task", dag=dag)
 
 # Generate AVRO files

--- a/dags/generate_avro_files_dag.py
+++ b/dags/generate_avro_files_dag.py
@@ -1,0 +1,63 @@
+from datetime import datetime
+
+from airflow import DAG
+from kubernetes.client import models as k8s
+from stellar_etl_airflow.build_cross_dependency_task import build_cross_deps
+from stellar_etl_airflow.build_bq_generate_avro_job_task import build_bq_generate_avro_job
+from stellar_etl_airflow.default import (
+    alert_sla_miss,
+    get_default_dag_args,
+    init_sentry,
+)
+
+init_sentry()
+
+dag = DAG(
+    "generate_avro_files",
+    default_args=get_default_dag_args(),
+    start_date=datetime(2024, 10, 1, 0, 0),
+    description="This DAG generates AVRO files from BQ tables",
+    schedule_interval="0 * * * *",  # Runs every hour
+    user_defined_filters={
+        "container_resources": lambda s: k8s.V1ResourceRequirements(requests=s),
+    },
+    max_active_runs=5,
+    catchup=True,
+    tags=["dbt-enriched-base-tables"],
+    sla_miss_callback=alert_sla_miss,
+)
+
+# Wait on ingestion DAGs
+wait_on_history_table = build_cross_deps(
+    dag, "wait_on_ledgers_txs", "history_table_export"
+)
+wait_on_state_table = build_cross_deps(dag, "wait_on_state_table", "state_table_export")
+
+# Generate AVRO files
+avro_tables = [
+    "accounts",
+    "contract_data",
+    "history_contract_events",
+    "history_ledgers",
+    "history_trades",
+    "history_transactions",
+    "liquidity_pools",
+    "offers",
+    "trust_lines",
+    "ttl",
+    #"history_effects",
+    #"history_operations",
+]
+
+for table in avro_tables:
+    task = build_bq_generate_avro_job(
+        dag=dag,
+        project=public_project,
+        dataset=public_dataset,
+        table=table,
+        gcs_bucket=gcs_bucket,
+    )
+
+    wait_on_history_table >> task
+    wait_on_state_table >> task
+

--- a/dags/generate_avro_files_dag.py
+++ b/dags/generate_avro_files_dag.py
@@ -3,7 +3,9 @@ from datetime import datetime
 from airflow import DAG
 from kubernetes.client import models as k8s
 from stellar_etl_airflow.build_cross_dependency_task import build_cross_deps
-from stellar_etl_airflow.build_bq_generate_avro_job_task import build_bq_generate_avro_job
+from stellar_etl_airflow.build_bq_generate_avro_job_task import (
+    build_bq_generate_avro_job
+)
 from stellar_etl_airflow.default import (
     alert_sla_miss,
     get_default_dag_args,
@@ -45,8 +47,8 @@ avro_tables = [
     "offers",
     "trust_lines",
     "ttl",
-    #"history_effects",
-    #"history_operations",
+    # "history_effects",
+    # "history_operations",
 ]
 
 for table in avro_tables:
@@ -60,4 +62,3 @@ for table in avro_tables:
 
     wait_on_history_table >> task
     wait_on_state_table >> task
-

--- a/dags/generate_avro_files_dag.py
+++ b/dags/generate_avro_files_dag.py
@@ -72,4 +72,3 @@ for table in avro_tables:
     dummy_task >> avro_task
     wait_on_history_table >> avro_task
     wait_on_state_table >> avro_task
-

--- a/dags/generate_avro_files_dag.py
+++ b/dags/generate_avro_files_dag.py
@@ -25,7 +25,6 @@ dag = DAG(
     },
     max_active_runs=5,
     catchup=True,
-    tags=["dbt-enriched-base-tables"],
     sla_miss_callback=alert_sla_miss,
 )
 

--- a/dags/queries/generate_avro/accounts.sql
+++ b/dags/queries/generate_avro/accounts.sql
@@ -1,0 +1,17 @@
+export data
+  options (
+    uri = '{uri}',
+    format = 'avro',
+    overwrite=true
+    )
+as (
+  select
+    *
+    except(sequence_ledger, batch_id, batch_insert_ts, batch_run_date),
+    sequence_ledger as account_sequence_last_modified_ledger
+  from {project_id}.{dataset_id}.accounts
+  where true
+    and closed_at >= '{batch_run_date}'
+    and closed_at < '{next_batch_run_date}'
+  order by closed_at asc
+)

--- a/dags/queries/generate_avro/accounts.sql
+++ b/dags/queries/generate_avro/accounts.sql
@@ -11,6 +11,8 @@ as (
     sequence_ledger as account_sequence_last_modified_ledger
   from {project_id}.{dataset_id}.accounts
   where true
+    and batch_run_date >= '{batch_run_date}'
+    and batch_run_date < '{next_batch_run_date}'
     and closed_at >= '{batch_run_date}'
     and closed_at < '{next_batch_run_date}'
   order by closed_at asc

--- a/dags/queries/generate_avro/accounts.sql
+++ b/dags/queries/generate_avro/accounts.sql
@@ -7,10 +7,11 @@ options (
 as (
     select
         *
-        except(sequence_ledger, batch_id, batch_insert_ts, batch_run_date)
+        except (sequence_ledger, batch_id, batch_insert_ts, batch_run_date)
         , sequence_ledger as account_sequence_last_modified_ledger
     from {project_id}.{dataset_id}.accounts
-    where true
+    where
+        true
         and batch_run_date >= '{batch_run_date}'
         and batch_run_date < '{next_batch_run_date}'
         and closed_at >= '{batch_run_date}'

--- a/dags/queries/generate_avro/accounts.sql
+++ b/dags/queries/generate_avro/accounts.sql
@@ -1,19 +1,19 @@
 export data
-  options (
-    uri = '{uri}',
-    format = 'avro',
-    overwrite=true
-    )
+options (
+    uri = '{uri}'
+    , format = 'avro'
+    , overwrite = true
+)
 as (
-  select
-    *
-    except(sequence_ledger, batch_id, batch_insert_ts, batch_run_date),
-    sequence_ledger as account_sequence_last_modified_ledger
-  from {project_id}.{dataset_id}.accounts
-  where true
-    and batch_run_date >= '{batch_run_date}'
-    and batch_run_date < '{next_batch_run_date}'
-    and closed_at >= '{batch_run_date}'
-    and closed_at < '{next_batch_run_date}'
-  order by closed_at asc
+    select
+        *
+        except(sequence_ledger, batch_id, batch_insert_ts, batch_run_date)
+        , sequence_ledger as account_sequence_last_modified_ledger
+    from {project_id}.{dataset_id}.accounts
+    where true
+        and batch_run_date >= '{batch_run_date}'
+        and batch_run_date < '{next_batch_run_date}'
+        and closed_at >= '{batch_run_date}'
+        and closed_at < '{next_batch_run_date}'
+    order by closed_at asc
 )

--- a/dags/queries/generate_avro/contract_data.sql
+++ b/dags/queries/generate_avro/contract_data.sql
@@ -14,4 +14,3 @@ as (
     and closed_at < '{next_batch_run_date}'
   order by closed_at asc
 )
-

--- a/dags/queries/generate_avro/contract_data.sql
+++ b/dags/queries/generate_avro/contract_data.sql
@@ -1,0 +1,17 @@
+export data
+  options (
+    uri = '{uri}',
+    format = 'avro',
+    overwrite=true
+    )
+as (
+  select
+    *
+    except(batch_id, batch_insert_ts, batch_run_date)
+  from {project_id}.{dataset_id}.contract_data
+  where true
+    and closed_at >= '{batch_run_date}'
+    and closed_at < '{next_batch_run_date}'
+  order by closed_at asc
+)
+

--- a/dags/queries/generate_avro/contract_data.sql
+++ b/dags/queries/generate_avro/contract_data.sql
@@ -1,16 +1,15 @@
 export data
-  options (
-    uri = '{uri}',
-    format = 'avro',
-    overwrite=true
-    )
+options (
+    uri = '{uri}'
+    , format = 'avro'
+    , overwrite = true
+)
 as (
-  select
-    *
-    except(batch_id, batch_insert_ts, batch_run_date)
-  from {project_id}.{dataset_id}.contract_data
-  where true
-    and closed_at >= '{batch_run_date}'
-    and closed_at < '{next_batch_run_date}'
-  order by closed_at asc
+    select *
+        except(batch_id, batch_insert_ts, batch_run_date)
+    from {project_id}.{dataset_id}.contract_data
+    where true
+        and closed_at >= '{batch_run_date}'
+        and closed_at < '{next_batch_run_date}'
+    order by closed_at asc
 )

--- a/dags/queries/generate_avro/contract_data.sql
+++ b/dags/queries/generate_avro/contract_data.sql
@@ -5,10 +5,12 @@ options (
     , overwrite = true
 )
 as (
-    select *
-        except(batch_id, batch_insert_ts, batch_run_date)
+    select
+        *
+        except (batch_id, batch_insert_ts, batch_run_date)
     from {project_id}.{dataset_id}.contract_data
-    where true
+    where
+        true
         and closed_at >= '{batch_run_date}'
         and closed_at < '{next_batch_run_date}'
     order by closed_at asc

--- a/dags/queries/generate_avro/history_contract_events.sql
+++ b/dags/queries/generate_avro/history_contract_events.sql
@@ -14,4 +14,3 @@ as (
     and closed_at < '{next_batch_run_date}'
   order by closed_at asc
 )
-

--- a/dags/queries/generate_avro/history_contract_events.sql
+++ b/dags/queries/generate_avro/history_contract_events.sql
@@ -1,16 +1,15 @@
 export data
-  options (
-    uri = '{uri}',
-    format = 'avro',
-    overwrite=true
-    )
+options (
+    uri = '{uri}'
+    , format = 'avro'
+    , overwrite = true
+)
 as (
-  select
-    *
-    except(batch_id, batch_insert_ts, batch_run_date)
-  from {project_id}.{dataset_id}.history_contract_events
-  where true
-    and closed_at >= '{batch_run_date}'
-    and closed_at < '{next_batch_run_date}'
-  order by closed_at asc
+    select *
+        except(batch_id, batch_insert_ts, batch_run_date)
+    from {project_id}.{dataset_id}.history_contract_events
+    where true
+        and closed_at >= '{batch_run_date}'
+        and closed_at < '{next_batch_run_date}'
+    order by closed_at asc
 )

--- a/dags/queries/generate_avro/history_contract_events.sql
+++ b/dags/queries/generate_avro/history_contract_events.sql
@@ -5,10 +5,12 @@ options (
     , overwrite = true
 )
 as (
-    select *
-        except(batch_id, batch_insert_ts, batch_run_date)
+    select
+        *
+        except (batch_id, batch_insert_ts, batch_run_date)
     from {project_id}.{dataset_id}.history_contract_events
-    where true
+    where
+        true
         and closed_at >= '{batch_run_date}'
         and closed_at < '{next_batch_run_date}'
     order by closed_at asc

--- a/dags/queries/generate_avro/history_contract_events.sql
+++ b/dags/queries/generate_avro/history_contract_events.sql
@@ -1,0 +1,17 @@
+export data
+  options (
+    uri = '{uri}',
+    format = 'avro',
+    overwrite=true
+    )
+as (
+  select
+    *
+    except(batch_id, batch_insert_ts, batch_run_date)
+  from {project_id}.{dataset_id}.history_contract_events
+  where true
+    and closed_at >= '{batch_run_date}'
+    and closed_at < '{next_batch_run_date}'
+  order by closed_at asc
+)
+

--- a/dags/queries/generate_avro/history_effects.sql
+++ b/dags/queries/generate_avro/history_effects.sql
@@ -16,4 +16,3 @@ as (
     and closed_at < '{next_batch_run_date}'
   order by closed_at asc
 )
-

--- a/dags/queries/generate_avro/history_effects.sql
+++ b/dags/queries/generate_avro/history_effects.sql
@@ -12,6 +12,8 @@ as (
     except(predicate)
   from {project_id}.{dataset_id}.history_effects
   where true
+    and batch_run_date >= '{batch_run_date}'
+    and batch_run_date < '{next_batch_run_date}'
     and closed_at >= '{batch_run_date}'
     and closed_at < '{next_batch_run_date}'
   order by closed_at asc

--- a/dags/queries/generate_avro/history_effects.sql
+++ b/dags/queries/generate_avro/history_effects.sql
@@ -1,0 +1,19 @@
+export data
+  options (
+    uri = '{uri}',
+    format = 'avro',
+    overwrite=true
+    )
+as (
+  select
+    *
+    except(details, batch_id, batch_insert_ts, batch_run_date),
+    details.*
+    except(predicate)
+  from {project_id}.{dataset_id}.history_effects
+  where true
+    and closed_at >= '{batch_run_date}'
+    and closed_at < '{next_batch_run_date}'
+  order by closed_at asc
+)
+

--- a/dags/queries/generate_avro/history_effects.sql
+++ b/dags/queries/generate_avro/history_effects.sql
@@ -1,20 +1,20 @@
 export data
-  options (
-    uri = '{uri}',
-    format = 'avro',
-    overwrite=true
-    )
+options (
+    uri = '{uri}'
+    , format = 'avro'
+    , overwrite = true
+)
 as (
-  select
-    *
-    except(details, batch_id, batch_insert_ts, batch_run_date),
-    details.*
-    except(predicate)
-  from {project_id}.{dataset_id}.history_effects
-  where true
-    and batch_run_date >= '{batch_run_date}'
-    and batch_run_date < '{next_batch_run_date}'
-    and closed_at >= '{batch_run_date}'
-    and closed_at < '{next_batch_run_date}'
-  order by closed_at asc
+    select
+        *
+        except(details, batch_id, batch_insert_ts, batch_run_date)
+        , details.*
+        except(predicate)
+    from {project_id}.{dataset_id}.history_effects
+    where true
+        and batch_run_date >= '{batch_run_date}'
+        and batch_run_date < '{next_batch_run_date}'
+        and closed_at >= '{batch_run_date}'
+        and closed_at < '{next_batch_run_date}'
+    order by closed_at asc
 )

--- a/dags/queries/generate_avro/history_effects.sql
+++ b/dags/queries/generate_avro/history_effects.sql
@@ -7,11 +7,12 @@ options (
 as (
     select
         *
-        except(details, batch_id, batch_insert_ts, batch_run_date)
+        except (details, batch_id, batch_insert_ts, batch_run_date)
         , details.*
-        except(predicate)
+        except (predicate)
     from {project_id}.{dataset_id}.history_effects
-    where true
+    where
+        true
         and batch_run_date >= '{batch_run_date}'
         and batch_run_date < '{next_batch_run_date}'
         and closed_at >= '{batch_run_date}'

--- a/dags/queries/generate_avro/history_ledgers.sql
+++ b/dags/queries/generate_avro/history_ledgers.sql
@@ -14,4 +14,3 @@ as (
     and closed_at < '{next_batch_run_date}'
   order by closed_at asc
 )
-

--- a/dags/queries/generate_avro/history_ledgers.sql
+++ b/dags/queries/generate_avro/history_ledgers.sql
@@ -1,0 +1,17 @@
+export data
+  options (
+    uri = '{uri}',
+    format = 'avro',
+    overwrite=true
+    )
+as (
+  select
+    *
+    except(batch_id, batch_insert_ts, batch_run_date)
+  from {project_id}.{dataset_id}.history_ledgers
+  where true
+    and closed_at >= '{batch_run_date}'
+    and closed_at < '{next_batch_run_date}'
+  order by closed_at asc
+)
+

--- a/dags/queries/generate_avro/history_ledgers.sql
+++ b/dags/queries/generate_avro/history_ledgers.sql
@@ -5,10 +5,12 @@ options (
     , overwrite = true
 )
 as (
-    select *
-        except(batch_id, batch_insert_ts, batch_run_date)
+    select
+        *
+        except (batch_id, batch_insert_ts, batch_run_date)
     from {project_id}.{dataset_id}.history_ledgers
-    where true
+    where
+        true
         and closed_at >= '{batch_run_date}'
         and closed_at < '{next_batch_run_date}'
     order by closed_at asc

--- a/dags/queries/generate_avro/history_ledgers.sql
+++ b/dags/queries/generate_avro/history_ledgers.sql
@@ -1,16 +1,15 @@
 export data
-  options (
-    uri = '{uri}',
-    format = 'avro',
-    overwrite=true
-    )
+options (
+    uri = '{uri}'
+    , format = 'avro'
+    , overwrite = true
+)
 as (
-  select
-    *
-    except(batch_id, batch_insert_ts, batch_run_date)
-  from {project_id}.{dataset_id}.history_ledgers
-  where true
-    and closed_at >= '{batch_run_date}'
-    and closed_at < '{next_batch_run_date}'
-  order by closed_at asc
+    select *
+        except(batch_id, batch_insert_ts, batch_run_date)
+    from {project_id}.{dataset_id}.history_ledgers
+    where true
+        and closed_at >= '{batch_run_date}'
+        and closed_at < '{next_batch_run_date}'
+    order by closed_at asc
 )

--- a/dags/queries/generate_avro/history_operations.sql
+++ b/dags/queries/generate_avro/history_operations.sql
@@ -10,9 +10,11 @@ as (
     except(details, details_json, batch_id, batch_insert_ts, batch_run_date),
     details.*
     except(claimants, type),
-    details.type as details_type
+    details.type as soroban_operation_type
   from {project_id}.{dataset_id}.history_operations
   where true
+    and batch_run_date >= '{batch_run_date}'
+    and batch_run_date < '{next_batch_run_date}'
     and closed_at >= '{batch_run_date}'
     and closed_at < '{next_batch_run_date}'
   order by closed_at asc

--- a/dags/queries/generate_avro/history_operations.sql
+++ b/dags/queries/generate_avro/history_operations.sql
@@ -7,12 +7,13 @@ options (
 as (
     select
         *
-        except(details, details_json, batch_id, batch_insert_ts, batch_run_date)
+        except (details, details_json, batch_id, batch_insert_ts, batch_run_date)
         , details.*
-        except(claimants, type)
+        except (claimants, type)
         , details.type as soroban_operation_type
     from {project_id}.{dataset_id}.history_operations
-    where true
+    where
+        true
         and batch_run_date >= '{batch_run_date}'
         and batch_run_date < '{next_batch_run_date}'
         and closed_at >= '{batch_run_date}'

--- a/dags/queries/generate_avro/history_operations.sql
+++ b/dags/queries/generate_avro/history_operations.sql
@@ -17,4 +17,3 @@ as (
     and closed_at < '{next_batch_run_date}'
   order by closed_at asc
 )
-

--- a/dags/queries/generate_avro/history_operations.sql
+++ b/dags/queries/generate_avro/history_operations.sql
@@ -1,21 +1,21 @@
 export data
-  options (
-    uri = '{uri}',
-    format = 'avro',
-    overwrite=true
-    )
+options (
+    uri = '{uri}'
+    , format = 'avro'
+    , overwrite = true
+)
 as (
-  select
-    *
-    except(details, details_json, batch_id, batch_insert_ts, batch_run_date),
-    details.*
-    except(claimants, type),
-    details.type as soroban_operation_type
-  from {project_id}.{dataset_id}.history_operations
-  where true
-    and batch_run_date >= '{batch_run_date}'
-    and batch_run_date < '{next_batch_run_date}'
-    and closed_at >= '{batch_run_date}'
-    and closed_at < '{next_batch_run_date}'
-  order by closed_at asc
+    select
+        *
+        except(details, details_json, batch_id, batch_insert_ts, batch_run_date)
+        , details.*
+        except(claimants, type)
+        , details.type as soroban_operation_type
+    from {project_id}.{dataset_id}.history_operations
+    where true
+        and batch_run_date >= '{batch_run_date}'
+        and batch_run_date < '{next_batch_run_date}'
+        and closed_at >= '{batch_run_date}'
+        and closed_at < '{next_batch_run_date}'
+    order by closed_at asc
 )

--- a/dags/queries/generate_avro/history_operations.sql
+++ b/dags/queries/generate_avro/history_operations.sql
@@ -1,0 +1,20 @@
+export data
+  options (
+    uri = '{uri}',
+    format = 'avro',
+    overwrite=true
+    )
+as (
+  select
+    *
+    except(details, details_json, batch_id, batch_insert_ts, batch_run_date),
+    details.*
+    except(claimants, type),
+    details.type as details_type
+  from {project_id}.{dataset_id}.history_operations
+  where true
+    and closed_at >= '{batch_run_date}'
+    and closed_at < '{next_batch_run_date}'
+  order by closed_at asc
+)
+

--- a/dags/queries/generate_avro/history_trades.sql
+++ b/dags/queries/generate_avro/history_trades.sql
@@ -11,7 +11,7 @@ as (
     ledger_closed_at as closed_at
   from {project_id}.{dataset_id}.history_trades
   where true
-    and closed_at >= '{batch_run_date}'
-    and closed_at < '{next_batch_run_date}'
+    and ledger_closed_at >= '{batch_run_date}'
+    and ledger_closed_at < '{next_batch_run_date}'
   order by closed_at asc
 )

--- a/dags/queries/generate_avro/history_trades.sql
+++ b/dags/queries/generate_avro/history_trades.sql
@@ -1,0 +1,18 @@
+export data
+  options (
+    uri = '{uri}',
+    format = 'avro',
+    overwrite=true
+    )
+as (
+  select
+    *
+    except(ledger_closed_at, batch_id, batch_insert_ts, batch_run_date),
+    ledger_closed_at as closed_at
+  from {project_id}.{dataset_id}.history_trades
+  where true
+    and closed_at >= '{batch_run_date}'
+    and closed_at < '{next_batch_run_date}'
+  order by closed_at asc
+)
+

--- a/dags/queries/generate_avro/history_trades.sql
+++ b/dags/queries/generate_avro/history_trades.sql
@@ -15,4 +15,3 @@ as (
     and closed_at < '{next_batch_run_date}'
   order by closed_at asc
 )
-

--- a/dags/queries/generate_avro/history_trades.sql
+++ b/dags/queries/generate_avro/history_trades.sql
@@ -1,17 +1,17 @@
 export data
-  options (
-    uri = '{uri}',
-    format = 'avro',
-    overwrite=true
-    )
+options (
+    uri = '{uri}'
+    , format = 'avro'
+    , overwrite = true
+)
 as (
-  select
-    *
-    except(ledger_closed_at, batch_id, batch_insert_ts, batch_run_date),
-    ledger_closed_at as closed_at
-  from {project_id}.{dataset_id}.history_trades
-  where true
-    and ledger_closed_at >= '{batch_run_date}'
-    and ledger_closed_at < '{next_batch_run_date}'
-  order by closed_at asc
+    select
+        *
+        except(ledger_closed_at, batch_id, batch_insert_ts, batch_run_date)
+        , ledger_closed_at as closed_at
+    from {project_id}.{dataset_id}.history_trades
+    where true
+        and ledger_closed_at >= '{batch_run_date}'
+        and ledger_closed_at < '{next_batch_run_date}'
+    order by closed_at asc
 )

--- a/dags/queries/generate_avro/history_trades.sql
+++ b/dags/queries/generate_avro/history_trades.sql
@@ -7,10 +7,11 @@ options (
 as (
     select
         *
-        except(ledger_closed_at, batch_id, batch_insert_ts, batch_run_date)
+        except (ledger_closed_at, batch_id, batch_insert_ts, batch_run_date)
         , ledger_closed_at as closed_at
     from {project_id}.{dataset_id}.history_trades
-    where true
+    where
+        true
         and ledger_closed_at >= '{batch_run_date}'
         and ledger_closed_at < '{next_batch_run_date}'
     order by closed_at asc

--- a/dags/queries/generate_avro/history_transactions.sql
+++ b/dags/queries/generate_avro/history_transactions.sql
@@ -14,4 +14,3 @@ as (
     and closed_at < '{next_batch_run_date}'
   order by closed_at asc
 )
-

--- a/dags/queries/generate_avro/history_transactions.sql
+++ b/dags/queries/generate_avro/history_transactions.sql
@@ -1,0 +1,17 @@
+export data
+  options (
+    uri = '{uri}',
+    format = 'avro',
+    overwrite=true
+    )
+as (
+  select
+    *
+    except(batch_id, batch_insert_ts, batch_run_date)
+  from {project_id}.{dataset_id}.history_transactions
+  where true
+    and closed_at >= '{batch_run_date}'
+    and closed_at < '{next_batch_run_date}'
+  order by closed_at asc
+)
+

--- a/dags/queries/generate_avro/history_transactions.sql
+++ b/dags/queries/generate_avro/history_transactions.sql
@@ -5,10 +5,12 @@ options (
     , overwrite = true
 )
 as (
-    select *
-        except(batch_id, batch_insert_ts, batch_run_date)
+    select
+        *
+        except (batch_id, batch_insert_ts, batch_run_date)
     from {project_id}.{dataset_id}.history_transactions
-    where true
+    where
+        true
         and batch_run_date >= '{batch_run_date}'
         and batch_run_date < '{next_batch_run_date}'
         and closed_at >= '{batch_run_date}'

--- a/dags/queries/generate_avro/history_transactions.sql
+++ b/dags/queries/generate_avro/history_transactions.sql
@@ -10,6 +10,8 @@ as (
     except(batch_id, batch_insert_ts, batch_run_date)
   from {project_id}.{dataset_id}.history_transactions
   where true
+    and batch_run_date >= '{batch_run_date}'
+    and batch_run_date < '{next_batch_run_date}'
     and closed_at >= '{batch_run_date}'
     and closed_at < '{next_batch_run_date}'
   order by closed_at asc

--- a/dags/queries/generate_avro/history_transactions.sql
+++ b/dags/queries/generate_avro/history_transactions.sql
@@ -1,18 +1,17 @@
 export data
-  options (
-    uri = '{uri}',
-    format = 'avro',
-    overwrite=true
-    )
+options (
+    uri = '{uri}'
+    , format = 'avro'
+    , overwrite = true
+)
 as (
-  select
-    *
-    except(batch_id, batch_insert_ts, batch_run_date)
-  from {project_id}.{dataset_id}.history_transactions
-  where true
-    and batch_run_date >= '{batch_run_date}'
-    and batch_run_date < '{next_batch_run_date}'
-    and closed_at >= '{batch_run_date}'
-    and closed_at < '{next_batch_run_date}'
-  order by closed_at asc
+    select *
+        except(batch_id, batch_insert_ts, batch_run_date)
+    from {project_id}.{dataset_id}.history_transactions
+    where true
+        and batch_run_date >= '{batch_run_date}'
+        and batch_run_date < '{next_batch_run_date}'
+        and closed_at >= '{batch_run_date}'
+        and closed_at < '{next_batch_run_date}'
+    order by closed_at asc
 )

--- a/dags/queries/generate_avro/liquidity_pools.sql
+++ b/dags/queries/generate_avro/liquidity_pools.sql
@@ -14,4 +14,3 @@ as (
     and closed_at < '{next_batch_run_date}'
   order by closed_at asc
 )
-

--- a/dags/queries/generate_avro/liquidity_pools.sql
+++ b/dags/queries/generate_avro/liquidity_pools.sql
@@ -1,18 +1,17 @@
 export data
-  options (
-    uri = '{uri}',
-    format = 'avro',
-    overwrite=true
-    )
+options (
+    uri = '{uri}'
+    , format = 'avro'
+    , overwrite = true
+)
 as (
-  select
-    *
-    except(batch_id, batch_insert_ts, batch_run_date)
-  from {project_id}.{dataset_id}.liquidity_pools
-  where true
-    and batch_run_date >= '{batch_run_date}'
-    and batch_run_date < '{next_batch_run_date}'
-    and closed_at >= '{batch_run_date}'
-    and closed_at < '{next_batch_run_date}'
-  order by closed_at asc
+    select *
+        except(batch_id, batch_insert_ts, batch_run_date)
+    from {project_id}.{dataset_id}.liquidity_pools
+    where true
+        and batch_run_date >= '{batch_run_date}'
+        and batch_run_date < '{next_batch_run_date}'
+        and closed_at >= '{batch_run_date}'
+        and closed_at < '{next_batch_run_date}'
+    order by closed_at asc
 )

--- a/dags/queries/generate_avro/liquidity_pools.sql
+++ b/dags/queries/generate_avro/liquidity_pools.sql
@@ -10,6 +10,8 @@ as (
     except(batch_id, batch_insert_ts, batch_run_date)
   from {project_id}.{dataset_id}.liquidity_pools
   where true
+    and batch_run_date >= '{batch_run_date}'
+    and batch_run_date < '{next_batch_run_date}'
     and closed_at >= '{batch_run_date}'
     and closed_at < '{next_batch_run_date}'
   order by closed_at asc

--- a/dags/queries/generate_avro/liquidity_pools.sql
+++ b/dags/queries/generate_avro/liquidity_pools.sql
@@ -5,10 +5,12 @@ options (
     , overwrite = true
 )
 as (
-    select *
-        except(batch_id, batch_insert_ts, batch_run_date)
+    select
+        *
+        except (batch_id, batch_insert_ts, batch_run_date)
     from {project_id}.{dataset_id}.liquidity_pools
-    where true
+    where
+        true
         and batch_run_date >= '{batch_run_date}'
         and batch_run_date < '{next_batch_run_date}'
         and closed_at >= '{batch_run_date}'

--- a/dags/queries/generate_avro/liquidity_pools.sql
+++ b/dags/queries/generate_avro/liquidity_pools.sql
@@ -1,0 +1,17 @@
+export data
+  options (
+    uri = '{uri}',
+    format = 'avro',
+    overwrite=true
+    )
+as (
+  select
+    *
+    except(batch_id, batch_insert_ts, batch_run_date)
+  from {project_id}.{dataset_id}.liquidity_pools
+  where true
+    and closed_at >= '{batch_run_date}'
+    and closed_at < '{next_batch_run_date}'
+  order by closed_at asc
+)
+

--- a/dags/queries/generate_avro/offers.sql
+++ b/dags/queries/generate_avro/offers.sql
@@ -14,4 +14,3 @@ as (
     and closed_at < '{next_batch_run_date}'
   order by closed_at asc
 )
-

--- a/dags/queries/generate_avro/offers.sql
+++ b/dags/queries/generate_avro/offers.sql
@@ -5,10 +5,12 @@ options (
     , overwrite = true
 )
 as (
-    select *
-        except(batch_id, batch_insert_ts, batch_run_date)
+    select
+        *
+        except (batch_id, batch_insert_ts, batch_run_date)
     from {project_id}.{dataset_id}.offers
-    where true
+    where
+        true
         and batch_run_date >= '{batch_run_date}'
         and batch_run_date < '{next_batch_run_date}'
         and closed_at >= '{batch_run_date}'

--- a/dags/queries/generate_avro/offers.sql
+++ b/dags/queries/generate_avro/offers.sql
@@ -10,6 +10,8 @@ as (
     except(batch_id, batch_insert_ts, batch_run_date)
   from {project_id}.{dataset_id}.offers
   where true
+    and batch_run_date >= '{batch_run_date}'
+    and batch_run_date < '{next_batch_run_date}'
     and closed_at >= '{batch_run_date}'
     and closed_at < '{next_batch_run_date}'
   order by closed_at asc

--- a/dags/queries/generate_avro/offers.sql
+++ b/dags/queries/generate_avro/offers.sql
@@ -1,18 +1,17 @@
 export data
-  options (
-    uri = '{uri}',
-    format = 'avro',
-    overwrite=true
-    )
+options (
+    uri = '{uri}'
+    , format = 'avro'
+    , overwrite = true
+)
 as (
-  select
-    *
-    except(batch_id, batch_insert_ts, batch_run_date)
-  from {project_id}.{dataset_id}.offers
-  where true
-    and batch_run_date >= '{batch_run_date}'
-    and batch_run_date < '{next_batch_run_date}'
-    and closed_at >= '{batch_run_date}'
-    and closed_at < '{next_batch_run_date}'
-  order by closed_at asc
+    select *
+        except(batch_id, batch_insert_ts, batch_run_date)
+    from {project_id}.{dataset_id}.offers
+    where true
+        and batch_run_date >= '{batch_run_date}'
+        and batch_run_date < '{next_batch_run_date}'
+        and closed_at >= '{batch_run_date}'
+        and closed_at < '{next_batch_run_date}'
+    order by closed_at asc
 )

--- a/dags/queries/generate_avro/offers.sql
+++ b/dags/queries/generate_avro/offers.sql
@@ -1,0 +1,17 @@
+export data
+  options (
+    uri = '{uri}',
+    format = 'avro',
+    overwrite=true
+    )
+as (
+  select
+    *
+    except(batch_id, batch_insert_ts, batch_run_date)
+  from {project_id}.{dataset_id}.offers
+  where true
+    and closed_at >= '{batch_run_date}'
+    and closed_at < '{next_batch_run_date}'
+  order by closed_at asc
+)
+

--- a/dags/queries/generate_avro/trust_lines.sql
+++ b/dags/queries/generate_avro/trust_lines.sql
@@ -14,4 +14,3 @@ as (
     and closed_at < '{next_batch_run_date}'
   order by closed_at asc
 )
-

--- a/dags/queries/generate_avro/trust_lines.sql
+++ b/dags/queries/generate_avro/trust_lines.sql
@@ -1,18 +1,17 @@
 export data
-  options (
-    uri = '{uri}',
-    format = 'avro',
-    overwrite=true
-    )
+options (
+    uri = '{uri}'
+    , format = 'avro'
+    , overwrite = true
+)
 as (
-  select
-    *
-    except(batch_id, batch_insert_ts, batch_run_date)
-  from {project_id}.{dataset_id}.trust_lines
-  where true
-    and batch_run_date >= '{batch_run_date}'
-    and batch_run_date < '{next_batch_run_date}'
-    and closed_at >= '{batch_run_date}'
-    and closed_at < '{next_batch_run_date}'
-  order by closed_at asc
+    select *
+        except(batch_id, batch_insert_ts, batch_run_date)
+    from {project_id}.{dataset_id}.trust_lines
+    where true
+        and batch_run_date >= '{batch_run_date}'
+        and batch_run_date < '{next_batch_run_date}'
+        and closed_at >= '{batch_run_date}'
+        and closed_at < '{next_batch_run_date}'
+    order by closed_at asc
 )

--- a/dags/queries/generate_avro/trust_lines.sql
+++ b/dags/queries/generate_avro/trust_lines.sql
@@ -10,6 +10,8 @@ as (
     except(batch_id, batch_insert_ts, batch_run_date)
   from {project_id}.{dataset_id}.trust_lines
   where true
+    and batch_run_date >= '{batch_run_date}'
+    and batch_run_date < '{next_batch_run_date}'
     and closed_at >= '{batch_run_date}'
     and closed_at < '{next_batch_run_date}'
   order by closed_at asc

--- a/dags/queries/generate_avro/trust_lines.sql
+++ b/dags/queries/generate_avro/trust_lines.sql
@@ -5,10 +5,12 @@ options (
     , overwrite = true
 )
 as (
-    select *
-        except(batch_id, batch_insert_ts, batch_run_date)
+    select
+        *
+        except (batch_id, batch_insert_ts, batch_run_date)
     from {project_id}.{dataset_id}.trust_lines
-    where true
+    where
+        true
         and batch_run_date >= '{batch_run_date}'
         and batch_run_date < '{next_batch_run_date}'
         and closed_at >= '{batch_run_date}'

--- a/dags/queries/generate_avro/trust_lines.sql
+++ b/dags/queries/generate_avro/trust_lines.sql
@@ -1,0 +1,17 @@
+export data
+  options (
+    uri = '{uri}',
+    format = 'avro',
+    overwrite=true
+    )
+as (
+  select
+    *
+    except(batch_id, batch_insert_ts, batch_run_date)
+  from {project_id}.{dataset_id}.trust_lines
+  where true
+    and closed_at >= '{batch_run_date}'
+    and closed_at < '{next_batch_run_date}'
+  order by closed_at asc
+)
+

--- a/dags/queries/generate_avro/ttl.sql
+++ b/dags/queries/generate_avro/ttl.sql
@@ -14,4 +14,3 @@ as (
     and closed_at < '{next_batch_run_date}'
   order by closed_at asc
 )
-

--- a/dags/queries/generate_avro/ttl.sql
+++ b/dags/queries/generate_avro/ttl.sql
@@ -1,0 +1,17 @@
+export data
+  options (
+    uri = '{uri}',
+    format = 'avro',
+    overwrite=true
+    )
+as (
+  select
+    *
+    except(batch_id, batch_insert_ts, batch_run_date)
+  from {project_id}.{dataset_id}.ttl
+  where true
+    and closed_at >= '{batch_run_date}'
+    and closed_at < '{next_batch_run_date}'
+  order by closed_at asc
+)
+

--- a/dags/queries/generate_avro/ttl.sql
+++ b/dags/queries/generate_avro/ttl.sql
@@ -5,10 +5,12 @@ options (
     , overwrite = true
 )
 as (
-    select *
-        except(batch_id, batch_insert_ts, batch_run_date)
+    select
+        *
+        except (batch_id, batch_insert_ts, batch_run_date)
     from {project_id}.{dataset_id}.ttl
-    where true
+    where
+        true
         and closed_at >= '{batch_run_date}'
         and closed_at < '{next_batch_run_date}'
     order by closed_at asc

--- a/dags/queries/generate_avro/ttl.sql
+++ b/dags/queries/generate_avro/ttl.sql
@@ -1,16 +1,15 @@
 export data
-  options (
-    uri = '{uri}',
-    format = 'avro',
-    overwrite=true
-    )
+options (
+    uri = '{uri}'
+    , format = 'avro'
+    , overwrite = true
+)
 as (
-  select
-    *
-    except(batch_id, batch_insert_ts, batch_run_date)
-  from {project_id}.{dataset_id}.ttl
-  where true
-    and closed_at >= '{batch_run_date}'
-    and closed_at < '{next_batch_run_date}'
-  order by closed_at asc
+    select *
+        except(batch_id, batch_insert_ts, batch_run_date)
+    from {project_id}.{dataset_id}.ttl
+    where true
+        and closed_at >= '{batch_run_date}'
+        and closed_at < '{next_batch_run_date}'
+    order by closed_at asc
 )

--- a/dags/stellar_etl_airflow/build_bq_generate_avro_job_task.py
+++ b/dags/stellar_etl_airflow/build_bq_generate_avro_job_task.py
@@ -29,8 +29,10 @@ def build_bq_generate_avro_job(
     next_batch_run_date = (
         "{{ batch_run_date_as_datetime_string(dag, data_interval_end) }}"
     )
-    batch_run_time = f"{batch_run_date.hour}:{batch_run_date.minute}:{batch_run_date.second}":
-    uri = f"gs://{gcs_bucket}/avro/{table}/{batch_run_date.year}/{batch_run_date.month}/{batch_run_date.day}/{batch_run_time}/*.avro"
+    uri_datetime = (
+        "{{ batch_run_date_as_directory_string(dag, data_interval_start) }}"
+    )
+    uri = f"gs://{gcs_bucket}/avro/{table}/{uri_datetime}/*.avro"
     sql_params = {
         "project_id": project,
         "dataset_id": dataset,
@@ -51,14 +53,14 @@ def build_bq_generate_avro_job(
         task_id=f"generate_avro_{table}",
         execution_timeout=timedelta(
             seconds=Variable.get("task_timeout", deserialize_json=True)[
-                build_bq_insert_job.__name__
+                build_bq_generate_avro_job.__name__
             ]
         ),
         on_failure_callback=alert_after_max_retries,
         configuration=configuration,
         sla=timedelta(
             seconds=Variable.get("task_sla", deserialize_json=True)[
-                build_bq_insert_job.__name__
+                build_bq_generate_avro_job.__name__
             ]
         ),
     )

--- a/dags/stellar_etl_airflow/build_bq_generate_avro_job_task.py
+++ b/dags/stellar_etl_airflow/build_bq_generate_avro_job_task.py
@@ -1,0 +1,64 @@
+import os
+from datetime import timedelta
+
+from airflow.models import Variable
+from airflow.providers.google.cloud.operators.bigquery import BigQueryInsertJobOperator
+from stellar_etl_airflow import macros
+from stellar_etl_airflow.build_bq_insert_job_task import file_to_string
+from stellar_etl_airflow.default import alert_after_max_retries
+
+
+def get_query_filepath(query_name):
+    root = os.path.dirname(os.path.dirname(__file__))
+    return os.path.join(root, f"queries/generate_avro/{query_name}.sql")
+
+
+def build_bq_generate_avro_job(
+    dag,
+    project,
+    dataset,
+    table,
+    gcs_bucket,
+):
+    query_path = get_query_filepath(table)
+    query = file_to_string(query_path)
+    batch_run_date = "{{ batch_run_date_as_datetime_string(dag, data_interval_start) }}"
+    prev_batch_run_date = (
+        "{{ batch_run_date_as_datetime_string(dag, prev_data_interval_start_success) }}"
+    )
+    next_batch_run_date = (
+        "{{ batch_run_date_as_datetime_string(dag, data_interval_end) }}"
+    )
+    batch_run_time = f"{batch_run_date.hour}:{batch_run_date.minute}:{batch_run_date.second}":
+    uri = f"gs://{gcs_bucket}/avro/{table}/{batch_run_date.year}/{batch_run_date.month}/{batch_run_date.day}/{batch_run_time}/*.avro"
+    sql_params = {
+        "project_id": project,
+        "dataset_id": dataset,
+        "prev_batch_run_date": prev_batch_run_date,
+        "next_batch_run_date": next_batch_run_date,
+        "uri": uri,
+    }
+    query = query.format(**sql_params)
+    configuration = {
+        "query": {
+            "query": query,
+            "useLegacySql": False,
+        }
+    }
+
+    return BigQueryInsertJobOperator(
+        task_id=f"generate_avro_{table}",
+        execution_timeout=timedelta(
+            seconds=Variable.get("task_timeout", deserialize_json=True)[
+                build_bq_insert_job.__name__
+            ]
+        ),
+        on_failure_callback=alert_after_max_retries,
+        configuration=configuration,
+        sla=timedelta(
+            seconds=Variable.get("task_sla", deserialize_json=True)[
+                build_bq_insert_job.__name__
+            ]
+        ),
+    )
+

--- a/dags/stellar_etl_airflow/build_bq_generate_avro_job_task.py
+++ b/dags/stellar_etl_airflow/build_bq_generate_avro_job_task.py
@@ -62,4 +62,3 @@ def build_bq_generate_avro_job(
             ]
         ),
     )
-

--- a/dags/stellar_etl_airflow/build_bq_generate_avro_job_task.py
+++ b/dags/stellar_etl_airflow/build_bq_generate_avro_job_task.py
@@ -1,13 +1,12 @@
-import os
 from datetime import timedelta
 
 from airflow.models import Variable
 from airflow.providers.google.cloud.operators.bigquery import BigQueryInsertJobOperator
-from stellar_etl_airflow.build_bq_insert_job_task import (
-    get_query_filepath,
-    file_to_string,
-)
 from stellar_etl_airflow import macros
+from stellar_etl_airflow.build_bq_insert_job_task import (
+    file_to_string,
+    get_query_filepath,
+)
 from stellar_etl_airflow.default import alert_after_max_retries
 
 
@@ -24,9 +23,7 @@ def build_bq_generate_avro_job(
     next_batch_run_date = (
         "{{ batch_run_date_as_datetime_string(dag, data_interval_end) }}"
     )
-    uri_datetime = (
-        "{{ batch_run_date_as_directory_string(dag, data_interval_start) }}"
-    )
+    uri_datetime = ("{{ batch_run_date_as_directory_string(dag, data_interval_start) }}")
     uri = f"gs://{gcs_bucket}/avro/{table}/{uri_datetime}/*.avro"
     sql_params = {
         "project_id": project,

--- a/dags/stellar_etl_airflow/build_bq_generate_avro_job_task.py
+++ b/dags/stellar_etl_airflow/build_bq_generate_avro_job_task.py
@@ -34,6 +34,7 @@ def build_bq_generate_avro_job(
     sql_params = {
         "project_id": project,
         "dataset_id": dataset,
+        "batch_run_date": batch_run_date,
         "prev_batch_run_date": prev_batch_run_date,
         "next_batch_run_date": next_batch_run_date,
         "uri": uri,

--- a/dags/stellar_etl_airflow/build_bq_generate_avro_job_task.py
+++ b/dags/stellar_etl_airflow/build_bq_generate_avro_job_task.py
@@ -23,7 +23,7 @@ def build_bq_generate_avro_job(
     next_batch_run_date = (
         "{{ batch_run_date_as_datetime_string(dag, data_interval_end) }}"
     )
-    uri_datetime = ("{{ batch_run_date_as_directory_string(dag, data_interval_start) }}")
+    uri_datetime = "{{ batch_run_date_as_directory_string(dag, data_interval_start) }}"
     uri = f"gs://{gcs_bucket}/avro/{table}/{uri_datetime}/*.avro"
     sql_params = {
         "project_id": project,

--- a/dags/stellar_etl_airflow/macros.py
+++ b/dags/stellar_etl_airflow/macros.py
@@ -9,3 +9,7 @@ def batch_run_date_as_datetime_string(dag, start_time):
 
 def get_batch_id():
     return "{}-{}".format("{{ run_id }}", "{{ params.alias }}")
+
+def batch_run_date_as_directory_string(dag, start_time):
+    time = subtract_data_interval(dag, start_time)
+    return f"{time.year}/{time.month}/{time.day}/{time.hour}:{time.minute}:{time.second}"

--- a/dags/stellar_etl_airflow/macros.py
+++ b/dags/stellar_etl_airflow/macros.py
@@ -13,4 +13,6 @@ def get_batch_id():
 
 def batch_run_date_as_directory_string(dag, start_time):
     time = subtract_data_interval(dag, start_time)
-    return f"{time.year}/{time.month}/{time.day}/{time.hour}:{time.minute}:{time.second}"
+    return (
+        f"{time.year}/{time.month}/{time.day}/{time.hour}:{time.minute}:{time.second}"
+    )

--- a/dags/stellar_etl_airflow/macros.py
+++ b/dags/stellar_etl_airflow/macros.py
@@ -10,6 +10,7 @@ def batch_run_date_as_datetime_string(dag, start_time):
 def get_batch_id():
     return "{}-{}".format("{{ run_id }}", "{{ params.alias }}")
 
+
 def batch_run_date_as_directory_string(dag, start_time):
     time = subtract_data_interval(dag, start_time)
     return f"{time.year}/{time.month}/{time.day}/{time.hour}:{time.minute}:{time.second}"


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

- [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
- [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
      otherwise).
- [ ] This PR's title starts with the jira ticket associated with the PR.

### Thoroughness

- [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
- [ ] I've updated the README with the added features, breaking changes, new instructions on how to use the repository.

</details>

### What

Adding DAG to generate hourly AVRO files from BQ tables

### Why

Needed a way to generate frontfill AVRO files for external analytics partnerships

### Known limitations

* Opted for individual table.sql files instead of programmatically generated through airflow/python even though this duplicates SQL. Main reason being it is unknown what kind of query logic that will need to be propagated to the queries to generate the AVRO files. Example is history_effects needing to 1. exclude columns 2. flatten a column 3. exclude a column from the flattened columns. It seems easier to manage at the individual table SQL level than adding function parameters in airflow
* Did not include a monthly time window backfill DAG
* `history_effects` and `history_operations` currently not run until confirmation that the tables works for external partners
