### PR TITLE
Update the schedule for MGI Dag

### DIFF
--- a/dags/dbt_stellar_marts_mgi_dag.py
+++ b/dags/dbt_stellar_marts_mgi_dag.py
@@ -17,7 +17,7 @@ dag = DAG(
     default_args=get_default_dag_args(),
     start_date=datetime(2024, 10, 1, 0, 0),
     description="This DAG runs dbt models at a daily cadence",
-    schedule_interval="0 17 * * *",  # Runs at 05:00 PM UTC / 11:00 AM CST as MGI files are received around ~10:00 AM CST
+    schedule_interval="0 16 * * *",  # Runs at 04:00 PM UTC / 10:00 AM CST as MGI files are received around ~10:00 AM CST
     user_defined_filters={
         "container_resources": lambda s: k8s.V1ResourceRequirements(requests=s),
     },


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

- [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
- [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
      otherwise).
- [ ] This PR's title starts with the jira ticket associated with the PR.

### Thoroughness

- [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
- [ ] I've updated the README with the added features, breaking changes, new instructions on how to use the repository.

</details>

### What

This PR reverts the schedule for MGI Dag back to 4 pm utc

### Why

MGI dag looks for success of dagrun of partner pipeline dag and the cadence should match for both. So our options are:
- Run partner pipeline dag at 5 PM UTC
- Run MGI Dag at 4 PM UTC / which this PR does
- Update MGI dag to look for different run time of partner pipeline 

### Known limitations

[TODO or N/A]
