### PR TITLE
Remove null char from contract data asset_code in avro files

### DIFF
--- a/dags/queries/generate_avro/contract_data.sql
+++ b/dags/queries/generate_avro/contract_data.sql
@@ -7,7 +7,8 @@ options (
 as (
     select
         *
-        except (batch_id, batch_insert_ts, batch_run_date)
+        except (batch_id, batch_insert_ts, batch_run_date, asset_code)
+        , REPLACE(asset_code, '\u0000', '') as asset_code
     from {project_id}.{dataset_id}.contract_data
     where
         true

--- a/dags/queries/generate_avro/contract_data.sql
+++ b/dags/queries/generate_avro/contract_data.sql
@@ -8,7 +8,7 @@ as (
     select
         *
         except (batch_id, batch_insert_ts, batch_run_date, asset_code)
-        , REPLACE(asset_code, '\u0000', '') as asset_code
+        , replace(asset_code, '\u0000', '') as asset_code
     from {project_id}.{dataset_id}.contract_data
     where
         true


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

- [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
- [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
      otherwise).
- [ ] This PR's title starts with the jira ticket associated with the PR.

### Thoroughness

- [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
- [ ] I've updated the README with the added features, breaking changes, new instructions on how to use the repository.

</details>

### What

Strip out the null chars `\u0000` from the `asset_code` column in contract_data

### Why

Dune found that asset_code had null chars appended for some asset_codes which should be removed
https://stellarfoundation.slack.com/archives/C07N40J1789/p1728568351934499?thread_ts=1727985059.719139&cid=C07N40J1789

### Known limitations

* This is just a patch to get Dune unblocked for now

I believe this is caused because of the way `asset_code` in contracts are saved as ScVal and reconstructed to a string in stellar-etl. It seems like the null chars appear in asset_codes of type alpha12.

Next week we should:
* Update stellar-etl to strip the ScVal --> string asset_code from contract_data
  * https://github.com/stellar/stellar-etl/pull/285
* Strip the null chars from asset_code in contract_data in our BQ tables