### PR TITLE
Patch/update partition expiration sandbox

### DIFF
--- a/dags/queries/create_table.sql
+++ b/dags/queries/create_table.sql
@@ -1,9 +1,9 @@
 create or replace table `{target_project}.{target_dataset}.{table_id}`
 partition by date_trunc(batch_run_date, day)
-options (partition_expiration_days = 180) as (
+options (partition_expiration_days = 450) as (
     select *
     from `{project_id}.{dataset_id}.{table_id}`
     where
-        batch_run_date >= date_trunc(date_sub(current_date(), interval 6 month), day)
-        and batch_run_date < date_trunc(current_date(), day)
+        batch_run_date >= date_trunc(date_sub('{batch_run_date}', interval 15 month), day)
+        and batch_run_date < date_trunc('{batch_run_date}', day)
 )

--- a/dags/queries/create_table.sql
+++ b/dags/queries/create_table.sql
@@ -4,6 +4,6 @@ options (partition_expiration_days = 450) as (
     select *
     from `{project_id}.{dataset_id}.{table_id}`
     where
-        batch_run_date >= date_trunc(date_sub('{batch_run_date}', interval 15 month), day)
-        and batch_run_date < date_trunc('{batch_run_date}', day)
+        batch_run_date >= date_trunc(date_sub(date('{batch_run_date}'), interval 15 month), day)
+        and batch_run_date < date_trunc(date('{batch_run_date}'), day)
 )

--- a/dags/sandbox_create_dag.py
+++ b/dags/sandbox_create_dag.py
@@ -27,7 +27,7 @@ with DAG(
     "sandbox_create_dag",
     default_args=get_default_dag_args(),
     description="This DAG creates a sandbox",
-    schedule_interval=None,
+    schedule_interval="@once",
     params={"alias": "sandbox_dataset"},
     user_defined_filters={
         "fromjson": lambda s: loads(s),


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

- [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
- [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
      otherwise).
- [ ] This PR's title starts with the jira ticket associated with the PR.

### Thoroughness

- [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
- [ ] I've updated the README with the added features, breaking changes, new instructions on how to use the repository.

</details>

### What

Update the canvas sandbox retention period to 5 quarters (15 months). The original retention window was 6 months. 

### Why

6 month is not a big enough time window to perform adequate period over period metrics. The business has requested a larger retention window.

### Known limitations

Canvas defaults to loading a full table into the workspace when creating a report. The user has to add filters after the initial load. It is possible that this retention window is too big and will timeout for any new development. If the window is too big, we will adjust to 9-12 months.

To recreate the tables, we will need to trigger a manual DAG run for the Create table dag, then rerun today's update day dag after the tables have been recreated