### PR TITLE
Add DAG for exporting retool data

### DIFF
--- a/airflow_variables_dev.json
+++ b/airflow_variables_dev.json
@@ -311,11 +311,12 @@
       }
     }
   },
+  "retool_api_key": "test-api-key",
   "sandbox_dataset": "crypto_stellar_internal_sandbox",
   "schema_filepath": "/home/airflow/gcs/dags/schemas/",
   "sentry_dsn": "https://9e0a056541c3445083329b072f2df690@o14203.ingest.us.sentry.io/6190849",
   "sentry_environment": "development",
-  "stellar_etl_internal_image_name": " amishastellar/stellar-etl-internal:ab0a13897",
+  "stellar_etl_internal_image_name": "amishastellar/stellar-etl-internal:ab0a13897",
   "table_ids": {
     "accounts": "accounts",
     "assets": "history_assets",

--- a/airflow_variables_dev.json
+++ b/airflow_variables_dev.json
@@ -315,6 +315,7 @@
   "schema_filepath": "/home/airflow/gcs/dags/schemas/",
   "sentry_dsn": "https://9e0a056541c3445083329b072f2df690@o14203.ingest.us.sentry.io/6190849",
   "sentry_environment": "development",
+  "stellar_etl_internal_image_name": "stellar/stellar-etl:204d343fa",
   "table_ids": {
     "accounts": "accounts",
     "assets": "history_assets",
@@ -352,6 +353,7 @@
     "elementary_dbt_data_quality": 1620,
     "elementary_generate_report": 1200,
     "enriched_history_operations": 780,
+    "export_retool_data": 720,
     "fee_stats": 840,
     "history_assets": 720,
     "liquidity_pool_trade_volume": 1140,

--- a/airflow_variables_dev.json
+++ b/airflow_variables_dev.json
@@ -316,7 +316,7 @@
   "schema_filepath": "/home/airflow/gcs/dags/schemas/",
   "sentry_dsn": "https://9e0a056541c3445083329b072f2df690@o14203.ingest.us.sentry.io/6190849",
   "sentry_environment": "development",
-  "stellar_etl_internal_image_name": "amishastellar/stellar-etl-internal:e3b9a2ea7",
+  "stellar_etl_internal_image_name": "amishastellar/stellar-etl-internal:cd53bcf70",
   "table_ids": {
     "accounts": "accounts",
     "assets": "history_assets",
@@ -331,6 +331,7 @@
     "liquidity_pools": "liquidity_pools",
     "offers": "offers",
     "operations": "history_operations",
+    "retool_entity_data": "retool_entity_data",
     "signers": "account_signers",
     "trades": "history_trades",
     "transactions": "history_transactions",

--- a/airflow_variables_dev.json
+++ b/airflow_variables_dev.json
@@ -316,7 +316,7 @@
   "schema_filepath": "/home/airflow/gcs/dags/schemas/",
   "sentry_dsn": "https://9e0a056541c3445083329b072f2df690@o14203.ingest.us.sentry.io/6190849",
   "sentry_environment": "development",
-  "stellar_etl_internal_image_name": "amishastellar/stellar-etl-internal:40f406c53",
+  "stellar_etl_internal_image_name": "amishastellar/stellar-etl-internal:e3b9a2ea7",
   "table_ids": {
     "accounts": "accounts",
     "assets": "history_assets",

--- a/airflow_variables_dev.json
+++ b/airflow_variables_dev.json
@@ -351,6 +351,7 @@
     "create_sandbox": 2400,
     "current_state": 720,
     "default": 60,
+    "del_ins_retool_entity_data_task": 720,
     "elementary_dbt_data_quality": 1620,
     "elementary_generate_report": 1200,
     "enriched_history_operations": 780,

--- a/airflow_variables_dev.json
+++ b/airflow_variables_dev.json
@@ -311,7 +311,6 @@
       }
     }
   },
-  "retool_api_key": "test-api-key",
   "sandbox_dataset": "crypto_stellar_internal_sandbox",
   "schema_filepath": "/home/airflow/gcs/dags/schemas/",
   "sentry_dsn": "https://9e0a056541c3445083329b072f2df690@o14203.ingest.us.sentry.io/6190849",

--- a/airflow_variables_dev.json
+++ b/airflow_variables_dev.json
@@ -315,7 +315,7 @@
   "schema_filepath": "/home/airflow/gcs/dags/schemas/",
   "sentry_dsn": "https://9e0a056541c3445083329b072f2df690@o14203.ingest.us.sentry.io/6190849",
   "sentry_environment": "development",
-  "stellar_etl_internal_image_name": "stellar/stellar-etl:204d343fa",
+  "stellar_etl_internal_image_name": " amishastellar/stellar-etl-internal:ab0a13897",
   "table_ids": {
     "accounts": "accounts",
     "assets": "history_assets",

--- a/airflow_variables_dev.json
+++ b/airflow_variables_dev.json
@@ -316,7 +316,7 @@
   "schema_filepath": "/home/airflow/gcs/dags/schemas/",
   "sentry_dsn": "https://9e0a056541c3445083329b072f2df690@o14203.ingest.us.sentry.io/6190849",
   "sentry_environment": "development",
-  "stellar_etl_internal_image_name": "amishastellar/stellar-etl-internal:ab0a13897",
+  "stellar_etl_internal_image_name": "amishastellar/stellar-etl-internal:40f406c53",
   "table_ids": {
     "accounts": "accounts",
     "assets": "history_assets",

--- a/airflow_variables_prod.json
+++ b/airflow_variables_prod.json
@@ -309,7 +309,6 @@
       }
     }
   },
-  "retool_api_key": "test-api-key",
   "sandbox_dataset": "crypto_stellar_internal_sandbox",
   "schema_filepath": "/home/airflow/gcs/dags/schemas/",
   "sentry_dsn": "https://94027cdcc4c9470f9dafa2c0b456c2c9@o14203.ingest.us.sentry.io/5806618",

--- a/airflow_variables_prod.json
+++ b/airflow_variables_prod.json
@@ -309,10 +309,12 @@
       }
     }
   },
+  "retool_api_key": "test-api-key",
   "sandbox_dataset": "crypto_stellar_internal_sandbox",
   "schema_filepath": "/home/airflow/gcs/dags/schemas/",
   "sentry_dsn": "https://94027cdcc4c9470f9dafa2c0b456c2c9@o14203.ingest.us.sentry.io/5806618",
   "sentry_environment": "production",
+  "stellar_etl_internal_image_name": "amishastellar/stellar-etl-internal:e3b9a2ea7",
   "table_ids": {
     "accounts": "accounts",
     "assets": "history_assets",
@@ -327,6 +329,7 @@
     "liquidity_pools": "liquidity_pools",
     "offers": "offers",
     "operations": "history_operations",
+    "retool_entity_data": "retool_entity_data",
     "signers": "account_signers",
     "trades": "history_trades",
     "transactions": "history_transactions",
@@ -347,9 +350,11 @@
     "create_sandbox": 1020,
     "current_state": 1200,
     "default": 60,
+    "del_ins_retool_entity_data_task": 720,
     "elementary_dbt_data_quality": 2100,
     "elementary_generate_report": 1200,
     "enriched_history_operations": 1800,
+    "export_retool_data": 720,
     "fee_stats": 360,
     "history_assets": 360,
     "liquidity_pool_trade_volume": 1200,

--- a/dags/external_data_dag.py
+++ b/dags/external_data_dag.py
@@ -22,6 +22,7 @@ from stellar_etl_airflow.build_internal_export_task import (
     get_airflow_metadata,
 )
 from stellar_etl_airflow.default import get_default_dag_args, init_sentry
+from stellar_etl_airflow.utils import access_secret
 
 init_sentry()
 
@@ -65,7 +66,9 @@ retool_export_task = build_export_task(
         "{{ subtract_data_interval(dag, data_interval_end).isoformat() }}",
     ],
     use_gcs=True,
-    env_vars={"RETOOL_API_KEY": "{{ var.value.retool_api_key }}"},
+    env_vars={
+        "RETOOL_API_KEY": access_secret("retool-api-key", "default"),
+    },
 )
 
 

--- a/dags/external_data_dag.py
+++ b/dags/external_data_dag.py
@@ -111,6 +111,23 @@ retool_filepath = os.path.join(
     "retool-exported-entity.txt",
 )
 
+retool_table_name = "retool_entity_data"
+retool_table_id = "test-hubble-319619.test_crypto_stellar_internal.retool_entity_data"
+retool_public_project = "test-hubble-319619"
+retool_public_dataset = "test_crypto_stellar_internal"
+retool_batch_id = macros.get_batch_id()
+retool_batch_date = "{{ batch_run_date_as_datetime_string(dag, data_interval_start) }}"
+retool_export_task_id = "export_retool_data"
+retool_source_object_suffix = ""
+retool_source_objects = [
+    "{{ task_instance.xcom_pull(task_ids='"
+    + retool_export_task_id
+    + '\')["output"] }}'
+    + retool_source_object_suffix
+]
+batch_insert_ts = datetime.now().strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
 retool_export_task = stellar_etl_internal_task(
     dag,
     "export_retool_data",
@@ -126,24 +143,11 @@ retool_export_task = stellar_etl_internal_task(
         "gcp",
         "--output",
         retool_filepath,
+        "-u",
+        f"'batch_id={retool_batch_id},batch_run_date={retool_batch_date},batch_insert_ts={batch_insert_ts}'",
     ],
     output_file=retool_filepath,
 )
-
-retool_table_name = "retool_entity_data"
-retool_table_id = "test-hubble-319619.test_crypto_stellar_internal.retool_entity_data"
-retool_public_project = "test-hubble-319619"
-retool_public_dataset = "test_crypto_stellar_internal"
-retool_batch_id = macros.get_batch_id()
-retool_batch_date = "{{ batch_run_date_as_datetime_string(dag, data_interval_start) }}"
-retool_export_task_id = "export_retool_data"
-retool_source_object_suffix = ""
-retool_source_objects = [
-    "{{ task_instance.xcom_pull(task_ids='"
-    + retool_export_task_id
-    + '\')["output"] }}'
-    + retool_source_object_suffix
-]
 
 retool_task_vars = {
     "task_id": f"del_ins_{retool_table_name}_task",

--- a/dags/external_data_dag.py
+++ b/dags/external_data_dag.py
@@ -95,5 +95,9 @@ retool_export_task = stellar_etl_internal_task(
         "2024-01-01T16:30:00+00:00",
         "--end-time",
         "2025-01-01T16:30:00+00:00",
+        "--cloud-storage-bucket",
+        Variable.get("gcs_exported_data_bucket_name"),
+        "--cloud-provider",
+        "gcp",
     ],
 )

--- a/dags/external_data_dag.py
+++ b/dags/external_data_dag.py
@@ -97,9 +97,11 @@ def stellar_etl_internal_task(
     )
 
 
-run_id = "{{ run_id }}"
-filepath = os.path.join(
-    Variable.get("gcs_exported_object_prefix"), run_id, "retool-exported-entity.txt"
+retool_run_id = "{{ run_id }}"
+retool_filepath = os.path.join(
+    Variable.get("gcs_exported_object_prefix"),
+    retool_run_id,
+    "retool-exported-entity.txt",
 )
 
 
@@ -117,38 +119,38 @@ retool_export_task = stellar_etl_internal_task(
         "--cloud-provider",
         "gcp",
         "--output",
-        filepath,
+        retool_filepath,
     ],
 )
 
-table_name = "retool_entity_data"
-table_id = "test-hubble-319619.test_crypto_stellar_internal.retool_entity_data"
-public_project = "test-hubble-319619"
-public_dataset = "test_crypto_stellar_internal"
-batch_id = macros.get_batch_id()
-batch_date = "{{ batch_run_date_as_datetime_string(dag, data_interval_start) }}"
-export_task_id = "export_retool_data"
-source_object_suffix = "/*-retool-exported-entity.txt"
-source_objects = [
+retool_table_name = "retool_entity_data"
+retool_table_id = "test-hubble-319619.test_crypto_stellar_internal.retool_entity_data"
+retool_public_project = "test-hubble-319619"
+retool_public_dataset = "test_crypto_stellar_internal"
+retool_batch_id = macros.get_batch_id()
+retool_batch_date = "{{ batch_run_date_as_datetime_string(dag, data_interval_start) }}"
+retool_export_task_id = "export_retool_data"
+retool_source_object_suffix = "/*-retool-exported-entity.txt"
+retool_source_objects = [
     "{{ task_instance.xcom_pull(task_ids='"
-    + export_task_id
+    + retool_export_task_id
     + '\')["output"] }}'
-    + source_object_suffix
+    + retool_source_object_suffix
 ]
 
 task_vars = {
-    "task_id": f"del_ins_{table_name}_task",
-    "project": public_project,
-    "dataset": public_dataset,
-    "table_name": table_name,
+    "task_id": f"del_ins_{retool_table_name}_task",
+    "project": retool_public_project,
+    "dataset": retool_public_dataset,
+    "table_name": retool_table_name,
     "export_task_id": "export_retool_data",
-    "source_object_suffix": source_object_suffix,
+    "source_object_suffix": retool_source_object_suffix,
     "partition": False,
     "cluster": False,
-    "batch_id": batch_id,
-    "batch_date": batch_date,
-    "source_objects": source_objects,
-    "table_id": table_id,
+    "batch_id": retool_batch_id,
+    "batch_date": retool_batch_date,
+    "source_objects": retool_source_objects,
+    "table_id": retool_table_id,
 }
 
 retool_insert_to_bq_task = create_del_ins_task(

--- a/dags/external_data_dag.py
+++ b/dags/external_data_dag.py
@@ -1,0 +1,100 @@
+"""
+The external_data_dag DAG exports data from external sources.
+It is scheduled to export information to BigQuery at regular intervals.
+"""
+
+from ast import literal_eval
+from datetime import datetime
+from json import loads
+
+from airflow import DAG
+from airflow.models.variable import Variable
+from airflow.providers.cncf.kubernetes.operators.pod import KubernetesPodOperator
+from kubernetes.client import models as k8s
+from stellar_etl_airflow import macros
+from stellar_etl_airflow.default import (
+    alert_after_max_retries,
+    get_default_dag_args,
+    init_sentry,
+)
+
+init_sentry()
+
+# Initialize the DAG
+dag = DAG(
+    "external_data_dag",
+    default_args=get_default_dag_args(),
+    start_date=datetime(2024, 12, 5, 14, 30),
+    description="This DAG exports data from external sources such as retool.",
+    schedule_interval="*/10 * * * *",
+    render_template_as_native_obj=True,
+    user_defined_filters={
+        "fromjson": lambda s: loads(s),
+        "container_resources": lambda s: k8s.V1ResourceRequirements(requests=s),
+        "literal_eval": lambda e: literal_eval(e),
+    },
+)
+
+
+def stellar_etl_internal_task(
+    dag, task_name, command, cmd_args=[], resource_cfg="default"
+):
+    namespace = conf.get("kubernetes", "NAMESPACE")
+
+    if namespace == "default":
+        config_file_location = Variable.get("kube_config_location")
+        in_cluster = False
+    else:
+        config_file_location = None
+        in_cluster = True
+
+    requests = {
+        "cpu": f"{{{{ var.json.resources.{resource_cfg}.requests.cpu }}}}",
+        "memory": f"{{{{ var.json.resources.{resource_cfg}.requests.memory }}}}",
+    }
+    container_resources = k8s.V1ResourceRequirements(requests=requests)
+
+    image = "{{ var.value.stellar_etl_internal_image_name }}"
+
+    logging.info(f"sh commands to run in pod: {args}")
+
+    return KubernetesPodOperator(
+        task_id=task_name,
+        name=task_name,
+        namespace=Variable.get("k8s_namespace"),
+        service_account_name=Variable.get("k8s_service_account"),
+        env_vars={
+            "EXECUTION_DATE": "{{ ds }}",
+            "AIRFLOW_START_TIMESTAMP": "{{ ti.start_date.strftime('%Y-%m-%dT%H:%M:%SZ') }}",
+        },
+        image=image,
+        cmds=[command],
+        arguments=cmd_args,
+        dag=dag,
+        is_delete_operator_pod=True,
+        startup_timeout_seconds=720,
+        in_cluster=in_cluster,
+        config_file=config_file_location,
+        container_resources=container_resources,
+        on_failure_callback=alert_after_max_retries,
+        image_pull_policy="IfNotPresent",
+        image_pull_secrets=[k8s.V1LocalObjectReference("private-docker-auth")],
+        sla=timedelta(
+            seconds=Variable.get("task_sla", deserialize_json=True)[f"task_name"]
+        ),
+        trigger_rule="all_done",
+    )
+
+
+retool_export_task = stellar_etl_internal_task(
+    dag,
+    "export_retool_data",
+    "export-retool",
+    cmd_args=[
+        "--start-time",
+        "2024-01-01T16:30:00+00:00",
+        "--end-time",
+        "2025-01-01T16:30:00+00:00",
+        "--testnet",
+    ],
+)

--- a/dags/external_data_dag.py
+++ b/dags/external_data_dag.py
@@ -4,10 +4,11 @@ It is scheduled to export information to BigQuery at regular intervals.
 """
 
 from ast import literal_eval
-from datetime import datetime
+from datetime import datetime, timedelta
 from json import loads
 
 from airflow import DAG
+from airflow.configuration import conf
 from airflow.models.variable import Variable
 from airflow.providers.cncf.kubernetes.operators.pod import KubernetesPodOperator
 from kubernetes.client import models as k8s
@@ -56,8 +57,6 @@ def stellar_etl_internal_task(
 
     image = "{{ var.value.stellar_etl_internal_image_name }}"
 
-    logging.info(f"sh commands to run in pod: {args}")
-
     return KubernetesPodOperator(
         task_id=task_name,
         name=task_name,
@@ -80,7 +79,7 @@ def stellar_etl_internal_task(
         image_pull_policy="IfNotPresent",
         image_pull_secrets=[k8s.V1LocalObjectReference("private-docker-auth")],
         sla=timedelta(
-            seconds=Variable.get("task_sla", deserialize_json=True)[f"task_name"]
+            seconds=Variable.get("task_sla", deserialize_json=True)[task_name]
         ),
         trigger_rule="all_done",
     )

--- a/dags/external_data_dag.py
+++ b/dags/external_data_dag.py
@@ -65,6 +65,7 @@ def stellar_etl_internal_task(
         env_vars={
             "EXECUTION_DATE": "{{ ds }}",
             "AIRFLOW_START_TIMESTAMP": "{{ ti.start_date.strftime('%Y-%m-%dT%H:%M:%SZ') }}",
+            "RETOOL_API_KEY": "{{ var.value.retool_api_key }}",
         },
         image=image,
         cmds=[command],
@@ -94,6 +95,5 @@ retool_export_task = stellar_etl_internal_task(
         "2024-01-01T16:30:00+00:00",
         "--end-time",
         "2025-01-01T16:30:00+00:00",
-        "--testnet",
     ],
 )

--- a/dags/external_data_dag.py
+++ b/dags/external_data_dag.py
@@ -137,7 +137,7 @@ retool_public_dataset = "test_crypto_stellar_internal"
 retool_batch_id = macros.get_batch_id()
 retool_batch_date = "{{ batch_run_date_as_datetime_string(dag, data_interval_start) }}"
 retool_export_task_id = "export_retool_data"
-retool_source_object_suffix = "/*-retool-exported-entity.txt"
+retool_source_object_suffix = ""
 retool_source_objects = [
     "{{ task_instance.xcom_pull(task_ids='"
     + retool_export_task_id

--- a/dags/external_data_dag.py
+++ b/dags/external_data_dag.py
@@ -41,6 +41,7 @@ dag = DAG(
     },
     render_template_as_native_obj=True,
     user_defined_macros={
+        "subtract_data_interval": macros.subtract_data_interval,
         "batch_run_date_as_datetime_string": macros.batch_run_date_as_datetime_string,
     },
     user_defined_filters={

--- a/dags/stellar_etl_airflow/build_elementary_slack_alert_task.py
+++ b/dags/stellar_etl_airflow/build_elementary_slack_alert_task.py
@@ -1,22 +1,12 @@
-import base64
 import logging
 from datetime import timedelta
 
 from airflow.configuration import conf
 from airflow.models import Variable
 from airflow.providers.cncf.kubernetes.operators.pod import KubernetesPodOperator
-from kubernetes import client, config
 from kubernetes.client import models as k8s
 from stellar_etl_airflow.default import alert_after_max_retries
-
-
-def access_secret(secret_name, namespace):
-    config.load_kube_config()
-    v1 = client.CoreV1Api()
-    secret_data = v1.read_namespaced_secret(secret_name, namespace)
-    secret = secret_data.data
-    secret = base64.b64decode(secret["token"]).decode("utf-8")
-    return secret
+from stellar_etl_airflow.utils import access_secret
 
 
 def elementary_task(dag, task_name, command, cmd_args=[], resource_cfg="default"):

--- a/dags/stellar_etl_airflow/build_internal_export_task.py
+++ b/dags/stellar_etl_airflow/build_internal_export_task.py
@@ -1,0 +1,107 @@
+"""
+This file contains functions for creating Airflow tasks to run stellar-etl-internal export functions.
+"""
+
+import os
+from datetime import datetime, timedelta
+
+from airflow import DAG
+from airflow.configuration import conf
+from airflow.models.variable import Variable
+from airflow.providers.cncf.kubernetes.operators.pod import KubernetesPodOperator
+from kubernetes.client import models as k8s
+from stellar_etl_airflow import macros
+from stellar_etl_airflow.default import alert_after_max_retries
+
+
+def get_airflow_metadata():
+    return {
+        "batch_insert_ts": datetime.now().strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "batch_date": "{{ batch_run_date_as_datetime_string(dag, data_interval_start) }}",
+        "batch_id": macros.get_batch_id(),
+        "run_id": "{{ run_id }}",
+    }
+
+
+def build_export_task(
+    dag,
+    task_name,
+    command,
+    cmd_args=[],
+    env_vars={},
+    use_gcs=False,
+    resource_cfg="default",
+):
+    namespace = conf.get("kubernetes", "NAMESPACE")
+
+    if namespace == "default":
+        config_file_location = Variable.get("kube_config_location")
+        in_cluster = False
+    else:
+        config_file_location = None
+        in_cluster = True
+
+    requests = {
+        "cpu": f"{{{{ var.json.resources.{resource_cfg}.requests.cpu }}}}",
+        "memory": f"{{{{ var.json.resources.{resource_cfg}.requests.memory }}}}",
+    }
+    container_resources = k8s.V1ResourceRequirements(requests=requests)
+
+    image = "{{ var.value.stellar_etl_internal_image_name }}"
+
+    output_filepath = ""
+    if use_gcs:
+        metadata = get_airflow_metadata()
+        batch_insert_ts = metadata["batch_insert_ts"]
+        batch_date = metadata["batch_date"]
+        batch_id = metadata["batch_id"]
+        run_id = metadata["run_id"]
+
+        output_filepath = os.path.join(
+            Variable.get("gcs_exported_object_prefix"),
+            run_id,
+            f"{task_name}-exported-entity.txt",
+        )
+
+        cmd_args = cmd_args + [
+            "--cloud-storage-bucket",
+            Variable.get("gcs_exported_data_bucket_name"),
+            "--cloud-provider",
+            "gcp",
+            "--output",
+            output_filepath,
+            "-u",
+            f"'batch_id={batch_id},batch_run_date={batch_date},batch_insert_ts={batch_insert_ts}'",
+        ]
+    etl_cmd_string = " ".join(cmd_args)
+    arguments = f""" {command} {etl_cmd_string} 1>> stdout.out 2>> stderr.out && cat stdout.out && cat stderr.out && echo "{{\\"output\\": \\"{output_filepath}\\"}}" >> /airflow/xcom/return.json"""
+
+    return KubernetesPodOperator(
+        task_id=task_name,
+        name=task_name,
+        namespace=Variable.get("k8s_namespace"),
+        service_account_name=Variable.get("k8s_service_account"),
+        env_vars=env_vars.update(
+            {
+                "EXECUTION_DATE": "{{ ds }}",
+                "AIRFLOW_START_TIMESTAMP": "{{ ti.start_date.strftime('%Y-%m-%dT%H:%M:%SZ') }}",
+            }
+        ),
+        image=image,
+        cmds=["bash", "-c"],
+        arguments=[arguments],
+        do_xcom_push=True,
+        dag=dag,
+        is_delete_operator_pod=True,
+        startup_timeout_seconds=720,
+        in_cluster=in_cluster,
+        config_file=config_file_location,
+        container_resources=container_resources,
+        on_failure_callback=alert_after_max_retries,
+        image_pull_policy="IfNotPresent",
+        image_pull_secrets=[k8s.V1LocalObjectReference("private-docker-auth")],
+        sla=timedelta(
+            seconds=Variable.get("task_sla", deserialize_json=True)[task_name]
+        ),
+        trigger_rule="all_done",
+    )

--- a/schemas/retool_entity_data_schema.json
+++ b/schemas/retool_entity_data_schema.json
@@ -1,0 +1,163 @@
+[
+  {
+    "description": "",
+    "fields": [],
+    "mode": "",
+    "name": "batch_id",
+    "type": "STRING"
+  },
+  {
+    "description": "",
+    "fields": [],
+    "mode": "",
+    "name": "batch_run_date",
+    "type": "DATETIME"
+  },
+  {
+    "description": "",
+    "fields": [],
+    "mode": "",
+    "name": "batch_insert_ts",
+    "type": "TIMESTAMP"
+  },
+  {
+    "description": "",
+    "fields": [],
+    "mode": "",
+    "name": "created_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "description": "",
+    "fields": [],
+    "mode": "",
+    "name": "updated_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "description": "",
+    "fields": [],
+    "mode": "",
+    "name": "id",
+    "type": "INTEGER"
+  },
+  {
+    "description": "",
+    "fields": [],
+    "mode": "",
+    "name": "account_sponsor",
+    "type": "BOOLEAN"
+  },
+  {
+    "description": "",
+    "fields": [],
+    "mode": "REPEATED",
+    "name": "app_geographies",
+    "type": "STRING"
+  },
+  {
+    "description": "",
+    "fields": [],
+    "mode": "",
+    "name": "custodial",
+    "type": "BOOLEAN"
+  },
+  {
+    "description": "",
+    "fields": [],
+    "mode": "",
+    "name": "description",
+    "type": "STRING"
+  },
+  {
+    "description": "",
+    "fields": [],
+    "mode": "",
+    "name": "fee_sponsor",
+    "type": "BOOLEAN"
+  },
+  {
+    "description": "",
+    "fields": [],
+    "mode": "",
+    "name": "home_domain",
+    "type": "STRING"
+  },
+  {
+    "description": "",
+    "fields": [],
+    "mode": "",
+    "name": "home_domains_id",
+    "type": "INTEGER"
+  },
+  {
+    "description": "",
+    "fields": [],
+    "mode": "",
+    "name": "live",
+    "type": "BOOLEAN"
+  },
+  {
+    "description": "",
+    "fields": [],
+    "mode": "",
+    "name": "name",
+    "type": "STRING"
+  },
+  {
+    "description": "",
+    "fields": [],
+    "mode": "",
+    "name": "non_custodial",
+    "type": "BOOLEAN"
+  },
+  {
+    "description": "",
+    "fields": [],
+    "mode": "",
+    "name": "notes",
+    "type": "STRING"
+  },
+  {
+    "description": "",
+    "fields": [],
+    "mode": "REPEATED",
+    "name": "ramps",
+    "type": "STRING"
+  },
+  {
+    "description": "",
+    "fields": [],
+    "mode": "",
+    "name": "sdp_enabled",
+    "type": "BOOLEAN"
+  },
+  {
+    "description": "",
+    "fields": [],
+    "mode": "",
+    "name": "soroban_enabled",
+    "type": "BOOLEAN"
+  },
+  {
+    "description": "",
+    "fields": [],
+    "mode": "",
+    "name": "status",
+    "type": "STRING"
+  },
+  {
+    "description": "",
+    "fields": [],
+    "mode": "",
+    "name": "verified",
+    "type": "BOOLEAN"
+  },
+  {
+    "description": "",
+    "fields": [],
+    "mode": "",
+    "name": "website_url",
+    "type": "STRING"
+  }
+]


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

- [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
- [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
      otherwise).
- [ ] This PR's title starts with the jira ticket associated with the PR.

### Thoroughness

- [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
- [ ] I've updated the README with the added features, breaking changes, new instructions on how to use the repository.

</details>

### What

This PR adds DAG to fetch custom data from retool API. It triggers command in stellar-internal , pull data created/updated within given time range.
Existing batch_id is deleted and then re-created(This is to keep idempotent results while retries)

### Why

To support new data ingestion

### Known limitations

Not a limitation, but open to renaming the dag if it too generic. Probable options:
- external_data_dag_retool
- export_retool
- external_data_dag_daily (This can be used to import any external data which runs at daily cadence)

### Testing

Tested the airflow in test-hubble and records look loaded in BQ table

