### PR TITLE
Remove piping stdout and stderr from build tasks

### DIFF
--- a/dags/stellar_etl_airflow/build_export_task.py
+++ b/dags/stellar_etl_airflow/build_export_task.py
@@ -211,10 +211,10 @@ def build_export_task(
     )
 
     if command == "export_ledger_entry_changes" or command == "export_all_history":
-        arguments = f"""{etl_cmd_string} 1>> stdout.out 2>> stderr.out && cat stdout.out && cat stderr.out && echo "{{\\"output\\": \\"{output_file}\\"}}" >> /airflow/xcom/return.json"""
+        arguments = f"""{etl_cmd_string} && echo "{{\\"output\\": \\"{output_file}\\"}}" >> /airflow/xcom/return.json"""
     else:
         arguments = f"""
-                    {etl_cmd_string} 1>> stdout.out 2>> stderr.out && cat stdout.out && cat stderr.out && echo "{{\\"output\\": \\"{output_file}\\",
+                    {etl_cmd_string} && echo "{{\\"output\\": \\"{output_file}\\",
                     \\"failed_transforms\\": `grep failed_transforms stderr.out | cut -d\\",\\" -f2 | cut -d\\":\\" -f2`}}" >> /airflow/xcom/return.json
                     """
     return KubernetesPodOperator(

--- a/dags/stellar_etl_airflow/build_internal_export_task.py
+++ b/dags/stellar_etl_airflow/build_internal_export_task.py
@@ -74,7 +74,7 @@ def build_export_task(
             f"'batch_id={batch_id},batch_run_date={batch_date},batch_insert_ts={batch_insert_ts}'",
         ]
     etl_cmd_string = " ".join(cmd_args)
-    arguments = f""" {command} {etl_cmd_string} 1>> stdout.out 2>> stderr.out && cat stdout.out && cat stderr.out && echo "{{\\"output\\": \\"{output_filepath}\\"}}" >> /airflow/xcom/return.json"""
+    arguments = f""" {command} {etl_cmd_string} && echo "{{\\"output\\": \\"{output_filepath}\\"}}" >> /airflow/xcom/return.json"""
     env_vars.update(
         {
             "EXECUTION_DATE": "{{ ds }}",


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

- [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
- [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
      otherwise).
- [ ] This PR's title starts with the jira ticket associated with the PR.

### Thoroughness

- [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
- [ ] I've updated the README with the added features, breaking changes, new instructions on how to use the repository.

</details>

### What

https://github.com/stellar/stellar-etl-airflow/issues/573

Remove stdout and stderr piping from build tasks

### Why

The piping and cat-ing of stdout and stderr block the application output from being written to airflow logs in realtime. They also aren't output in the case of errors within the application which makes debugging harder

### Known limitations

N/A
