### PR TITLE
Add date_macro param to dbt tasks

### DIFF
--- a/airflow_variables_dev.json
+++ b/airflow_variables_dev.json
@@ -124,7 +124,7 @@
     "partnership_assets__account_holders_activity_fact": false,
     "partnership_assets__asset_activity_fact": false
   },
-  "dbt_image_name": "stellar/stellar-dbt:64e752dbd",
+  "dbt_image_name": "stellar/stellar-dbt:fe0161a9c",
   "dbt_internal_source_db": "test-hubble-319619",
   "dbt_internal_source_schema": "test_crypto_stellar_internal",
   "dbt_job_execution_timeout_seconds": 300,

--- a/airflow_variables_prod.json
+++ b/airflow_variables_prod.json
@@ -125,7 +125,7 @@
     "partnership_assets__asset_activity_fact": false,
     "trade_agg": false
   },
-  "dbt_image_name": "stellar/stellar-dbt:64e752dbd",
+  "dbt_image_name": "stellar/stellar-dbt:fe0161a9c",
   "dbt_internal_source_db": "hubble-261722",
   "dbt_internal_source_schema": "crypto_stellar_internal_2",
   "dbt_job_execution_timeout_seconds": 2400,

--- a/dags/dbt_stellar_marts_dag.py
+++ b/dags/dbt_stellar_marts_dag.py
@@ -59,7 +59,7 @@ network_stats_agg_task = dbt_task(
     dag, tag="network_stats", excluded="stellar_dbt_public"
 )
 partnership_assets_task = dbt_task(
-    dag, tag="partnership_assets", operator="+", excluded="stellar_dbt_public"
+    dag, tag="partnership_assets", operator="+", excluded="stellar_dbt_public", date_macro="ds"
 )
 history_assets = dbt_task(dag, tag="history_assets", operator="+")
 wallet_metrics_task = dbt_task(

--- a/dags/dbt_stellar_marts_dag.py
+++ b/dags/dbt_stellar_marts_dag.py
@@ -59,7 +59,11 @@ network_stats_agg_task = dbt_task(
     dag, tag="network_stats", excluded="stellar_dbt_public"
 )
 partnership_assets_task = dbt_task(
-    dag, tag="partnership_assets", operator="+", excluded="stellar_dbt_public", date_macro="ds"
+    dag,
+    tag="partnership_assets",
+    operator="+",
+    excluded="stellar_dbt_public",
+    date_macro="ds",
 )
 history_assets = dbt_task(dag, tag="history_assets", operator="+")
 wallet_metrics_task = dbt_task(

--- a/dags/stellar_etl_airflow/build_dbt_task.py
+++ b/dags/stellar_etl_airflow/build_dbt_task.py
@@ -12,8 +12,8 @@ from stellar_etl_airflow.utils import skip_retry_dbt_errors
 VALID_DATE_MACROS = {
     "ts": "{{ ts }}",
     "ds": "{{ ds }}",
-    "prev_ds": "{{ prev_ds }}",
-    "next_ds": "{{ next_ds }}"
+    "data_interval_start": "{{ data_interval_start }}",
+    "data_interval_end": "{{ data_interval_end }}"
 }
 
 def create_dbt_profile(project="prod"):

--- a/dags/stellar_etl_airflow/build_dbt_task.py
+++ b/dags/stellar_etl_airflow/build_dbt_task.py
@@ -13,8 +13,9 @@ VALID_DATE_MACROS = {
     "ts": "{{ ts }}",
     "ds": "{{ ds }}",
     "data_interval_start": "{{ data_interval_start }}",
-    "data_interval_end": "{{ data_interval_end }}"
+    "data_interval_end": "{{ data_interval_end }}",
 }
+
 
 def create_dbt_profile(project="prod"):
     dbt_target = "{{ var.value.dbt_target }}"
@@ -139,7 +140,9 @@ def dbt_task(
     try:
         execution_date = VALID_DATE_MACROS[date_macro]
     except KeyError:
-        raise ValueError(f"Invalid date_macro: {date_macro}. Must be one of: {', '.join(VALID_DATE_MACROS.keys())}")
+        raise ValueError(
+            f"Invalid date_macro: {date_macro}. Must be one of: {', '.join(VALID_DATE_MACROS.keys())}"
+        )
 
     if Variable.get("dbt_full_refresh_models", deserialize_json=True).get(task_name):
         args.append("--full-refresh")


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

- [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
- [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
      otherwise).
- [ ] This PR's title starts with the jira ticket associated with the PR.

### Thoroughness

- [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
- [ ] I've updated the README with the added features, breaking changes, new instructions on how to use the repository.

</details>

### What

Add a new parameter to `dbt_task`, `date_macro` which allows the user to specific which [airflow macro](https://airflow.apache.org/docs/apache-airflow/stable/templates-ref.html) to pass as the execution date. This gives developers the flexibility to date parameterize their dbt code by date, `YYYY-MM-DD` or timestamp.

### Why

The incremental strategy insert_overwrite partitions executes its dbt model in multiple steps. There is an end hook that is a merge statement that passes the execution date as the partition to replace. Because Airflow was passing a timestamp, this code could not replace date partitions. This keeps consistency in the code without having to change the date logic in dbt in multiple places

### Known limitations

[TODO or N/A]
