### PR TITLE
Repartition tables to closed_at daily

### DIFF
--- a/airflow_variables_dev.json
+++ b/airflow_variables_dev.json
@@ -201,88 +201,88 @@
   "owner": "SDF",
   "partition_fields": {
     "account_signers": {
-      "field": "batch_run_date",
-      "type": "MONTH"
+      "field": "closed_at",
+      "type": "DAY"
     },
     "accounts": {
-      "field": "batch_run_date",
-      "type": "MONTH"
+      "field": "closed_at",
+      "type": "DAY"
     },
     "claimable_balances": {
-      "field": "batch_run_date",
-      "type": "MONTH"
+      "field": "closed_at",
+      "type": "DAY"
     },
     "config_settings": {
       "field": "closed_at",
-      "type": "MONTH"
+      "type": "DAY"
     },
     "contract_code": {
       "field": "closed_at",
-      "type": "MONTH"
+      "type": "DAY"
     },
     "contract_data": {
       "field": "closed_at",
-      "type": "MONTH"
+      "type": "DAY"
     },
     "enriched_history_operations": {
       "field": "closed_at",
-      "type": "MONTH"
+      "type": "DAY"
     },
     "enriched_meaningful_history_operations": {
       "field": "closed_at",
-      "type": "MONTH"
+      "type": "DAY"
     },
     "history_assets": {
-      "field": "batch_run_date",
-      "type": "MONTH"
+      "field": "closed_at",
+      "type": "DAY"
     },
     "history_contract_events": {
       "field": "closed_at",
-      "type": "MONTH"
+      "type": "DAY"
     },
     "history_effects": {
-      "field": "batch_run_date",
-      "type": "MONTH"
+      "field": "closed_at",
+      "type": "DAY"
     },
     "history_ledgers": {
       "field": "closed_at",
-      "type": "MONTH"
+      "type": "DAY"
     },
     "history_operations": {
-      "field": "batch_run_date",
-      "type": "MONTH"
+      "field": "closed_at",
+      "type": "DAY"
     },
     "history_trades": {
       "field": "ledger_closed_at",
-      "type": "MONTH"
+      "type": "DAY"
     },
     "history_transactions": {
-      "field": "batch_run_date",
-      "type": "MONTH"
+      "field": "closed_at",
+      "type": "DAY"
     },
     "liquidity_pools": {
-      "field": "batch_run_date",
-      "type": "MONTH"
+      "field": "closed_at",
+      "type": "DAY"
     },
     "mgi": {
       "field": "tran_evnt_date",
-      "type": "MONTH"
+      "type": "DAY"
     },
     "offers": {
-      "field": "batch_run_date",
-      "type": "MONTH"
+      "field": "closed_at",
+      "type": "DAY"
     },
     "token_transfers_raw": {
       "field": "closed_at",
       "type": "DAY"
     },
     "trust_lines": {
-      "field": "batch_run_date",
-      "type": "MONTH"
+      "field": "closed_at",
+      "type": "DAY"
     },
     "ttl": {
       "field": "closed_at",
-      "type": "MONTH"
+      "type": "DAY"
     }
   },
   "partners_bucket": "ext-partner-sftp",

--- a/airflow_variables_prod.json
+++ b/airflow_variables_prod.json
@@ -203,84 +203,84 @@
   "owner": "SDF",
   "partition_fields": {
     "account_signers": {
-      "field": "batch_run_date",
-      "type": "MONTH"
+      "field": "closed_at",
+      "type": "DAY"
     },
     "accounts": {
-      "field": "batch_run_date",
-      "type": "MONTH"
+      "field": "closed_at",
+      "type": "DAY"
     },
     "claimable_balances": {
-      "field": "batch_run_date",
-      "type": "MONTH"
+      "field": "closed_at",
+      "type": "DAY"
     },
     "config_settings": {
       "field": "closed_at",
-      "type": "MONTH"
+      "type": "DAY"
     },
     "contract_code": {
       "field": "closed_at",
-      "type": "MONTH"
+      "type": "DAY"
     },
     "contract_data": {
       "field": "closed_at",
-      "type": "MONTH"
+      "type": "DAY"
     },
     "enriched_history_operations": {
       "field": "closed_at",
-      "type": "MONTH"
+      "type": "DAY"
     },
     "enriched_meaningful_history_operations": {
       "field": "closed_at",
-      "type": "MONTH"
+      "type": "DAY"
     },
     "history_assets": {
-      "field": "batch_run_date",
-      "type": "MONTH"
+      "field": "closed_at",
+      "type": "DAY"
     },
     "history_contract_events": {
       "field": "closed_at",
-      "type": "MONTH"
+      "type": "DAY"
     },
     "history_effects": {
-      "field": "batch_run_date",
-      "type": "MONTH"
+      "field": "closed_at",
+      "type": "DAY"
     },
     "history_ledgers": {
       "field": "closed_at",
-      "type": "MONTH"
+      "type": "DAY"
     },
     "history_operations": {
-      "field": "batch_run_date",
-      "type": "MONTH"
+      "field": "closed_at",
+      "type": "DAY"
     },
     "history_trades": {
       "field": "ledger_closed_at",
-      "type": "MONTH"
+      "type": "DAY"
     },
     "history_transactions": {
-      "field": "batch_run_date",
-      "type": "MONTH"
+      "field": "closed_at",
+      "type": "DAY"
     },
     "liquidity_pools": {
-      "field": "batch_run_date",
-      "type": "MONTH"
+      "field": "closed_at",
+      "type": "DAY"
     },
     "offers": {
-      "field": "batch_run_date",
-      "type": "MONTH"
+      "field": "closed_at",
+      "type": "DAY"
     },
     "token_transfers_raw": {
       "field": "closed_at",
       "type": "DAY"
     },
     "trust_lines": {
-      "field": "batch_run_date",
-      "type": "MONTH"
+      "field": "closed_at",
+      "type": "DAY"
     },
     "ttl": {
       "field": "closed_at",
-      "type": "MONTH"
+      "type": "DAY"
     }
   },
   "partners_bucket": "ext-partner-sftp",


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

- [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
- [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
      otherwise).
- [ ] This PR's title starts with the jira ticket associated with the PR.

### Thoroughness

- [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
- [ ] I've updated the README with the added features, breaking changes, new instructions on how to use the repository.

</details>

### What

https://github.com/stellar/hubble/issues/407

Repartition tables to use `closed_at` at the daily grain

### Why

Remove dependency and weirdness with partitioning on batch_run_date. closed_at is a much more standard and relevant column

### Known limitations

* Update downstream dependencies (query filters on batch_run_date, dbt models, etc...)
