### PR TITLE
Add task to run asset balance task

### DIFF
--- a/airflow_variables_dev.json
+++ b/airflow_variables_dev.json
@@ -390,7 +390,8 @@
     "trade_agg": 720,
     "tvl": 900,
     "update_sandbox": 60,
-    "wallet_metrics": 720
+    "wallet_metrics": 720,
+    "asset_balance_agg": 720
   },
   "task_timeout": {
     "build_batch_stats": 180,

--- a/airflow_variables_dev.json
+++ b/airflow_variables_dev.json
@@ -128,7 +128,7 @@
     "partnership_assets__account_holders_activity_fact": false,
     "partnership_assets__asset_activity_fact": false
   },
-  "dbt_image_name": "stellar/stellar-dbt:fd9a02c23",
+  "dbt_image_name": "stellar/stellar-dbt-dev:b4085af39",
   "dbt_internal_marts_dataset": "test_sdf_marts",
   "dbt_internal_source_db": "test-hubble-319619",
   "dbt_internal_source_schema": "test_crypto_stellar_internal",

--- a/airflow_variables_dev.json
+++ b/airflow_variables_dev.json
@@ -350,6 +350,7 @@
     "ttl": "ttl"
   },
   "task_sla": {
+    "asset_balance_agg": 720,
     "asset_stats": 720,
     "build_batch_stats": 840,
     "build_bq_generate_avro_job": 600,
@@ -390,8 +391,7 @@
     "trade_agg": 720,
     "tvl": 900,
     "update_sandbox": 60,
-    "wallet_metrics": 720,
-    "asset_balance_agg": 720
+    "wallet_metrics": 720
   },
   "task_timeout": {
     "build_batch_stats": 180,

--- a/airflow_variables_dev.json
+++ b/airflow_variables_dev.json
@@ -128,7 +128,7 @@
     "partnership_assets__account_holders_activity_fact": false,
     "partnership_assets__asset_activity_fact": false
   },
-  "dbt_image_name": "stellar/stellar-dbt-dev:b4085af39",
+  "dbt_image_name": "stellar/stellar-dbt:86f01e7f9",
   "dbt_internal_marts_dataset": "test_sdf_marts",
   "dbt_internal_source_db": "test-hubble-319619",
   "dbt_internal_source_schema": "test_crypto_stellar_internal",

--- a/airflow_variables_prod.json
+++ b/airflow_variables_prod.json
@@ -129,7 +129,7 @@
     "partnership_assets__asset_activity_fact": false,
     "trade_agg": false
   },
-  "dbt_image_name": "stellar/stellar-dbt:fd9a02c23",
+  "dbt_image_name": "stellar/stellar-dbt:86f01e7f9",
   "dbt_internal_marts_dataset": "sdf_marts",
   "dbt_internal_source_db": "hubble-261722",
   "dbt_internal_source_schema": "crypto_stellar_internal_2",

--- a/airflow_variables_prod.json
+++ b/airflow_variables_prod.json
@@ -348,6 +348,7 @@
     "ttl": "ttl"
   },
   "task_sla": {
+    "asset_balance_agg": 720,
     "asset_stats": 420,
     "build_batch_stats": 600,
     "build_bq_generate_avro_job": 600,
@@ -388,8 +389,7 @@
     "trade_agg": 1020,
     "tvl": 900,
     "update_sandbox": 5460,
-    "wallet_metrics": 720,
-    "asset_balance_agg": 720
+    "wallet_metrics": 720
   },
   "task_timeout": {
     "build_batch_stats": 180,

--- a/airflow_variables_prod.json
+++ b/airflow_variables_prod.json
@@ -388,7 +388,8 @@
     "trade_agg": 1020,
     "tvl": 900,
     "update_sandbox": 5460,
-    "wallet_metrics": 720
+    "wallet_metrics": 720,
+    "asset_balance_agg": 720
   },
   "task_timeout": {
     "build_batch_stats": 180,


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

- [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
- [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
      otherwise).
- [ ] This PR's title starts with the jira ticket associated with the PR.

### Thoroughness

- [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
- [ ] I've updated the README with the added features, breaking changes, new instructions on how to use the repository.

</details>

### What

This PR adds orchestration task for calculating asset agg balances.

### Why

To build curated data layer

### Known limitations

None

### Testing

Tested on dev airflow

1. ✅ wait_snapshot_task looks for success of snapshot dag for same date. Snapshot dag takes ~10-15 min to run and then asset balances task will run, picks up new data.

```
Run id: scheduled__2025-06-29T01:00:00+00:00
[2025-06-30 17:12:51.500142+00:00] {external_task.py:274} INFO - Poking for DAG 'dbt_snapshot' on 2025-06-29T01:00:00+00:00 ... 
```

2. ✅ dbt command is built correctly

```
['build', '--select', '+tag:asset_balance_agg', '--exclude', '+snapshots']
```
Following models will run when above command is executed
```
dbt list --exclude-resource-types test --select +tag:asset_balance_agg --exclude +snapshots
17:18:49  Running with dbt=1.8.7
.
.
stellar_dbt.marts.asset_balances.asset_balances__daily_agg
stellar_dbt.intermediate.account_balances.int_account_balances__liquidity_pools
stellar_dbt.intermediate.account_balances.int_account_balances__offers
stellar_dbt.intermediate.account_balances.int_account_balances__trustlines
```
