### PR TITLE
Only send alerts for models/tests that have last status as failed/error

### DIFF
--- a/dags/dbt_data_quality_alerts_dag.py
+++ b/dags/dbt_data_quality_alerts_dag.py
@@ -29,6 +29,8 @@ with DAG(
         "monitor",
         resource_cfg="dbt",
         cmd_args=[
+            "--filters",
+            "statuses:fail,error",
             "--profiles-dir",
             ".",
         ],


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

- [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
- [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
      otherwise).
- [ ] This PR's title starts with the jira ticket associated with the PR.

### Thoroughness

- [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
- [ ] I've updated the README with the added features, breaking changes, new instructions on how to use the repository.

</details>

### What

We want to be alerted for DBT failures only when all the airflow retries have failed.

However current behavior is that we get atleast 1 alert for a DBT failure regardless it has been successful in retry.
From https://docs.elementary-data.com/oss/guides/alerts/alerts-configuration#filter-alerts and https://github.com/elementary-data/elementary/issues/605#issuecomment-1408868014 we can filter alerts by their last status using following cmd arguments

```
--filters statuses:fail,error
```

> To clarify - we're currently doing (1), but (2) may be mitigated in retry scenarios by running:
edr monitor -s result:error
(so we'll only include tests that failed in the last run, and the dedup feature guarantees we'll only send them once)

### Why

To reduce alarm fatigue

### Known limitations

An actual alert might get off because airflow task from next batch has been successful. However, we run data quality alert dag so frequently(every 15 mins), there is less risk of that.

### Testing

Tested in dev airflow. Command works okay